### PR TITLE
Introduce normalized institution configuration id

### DIFF
--- a/src/Surfnet/Stepup/Configuration/Value/InstitutionConfigurationId.php
+++ b/src/Surfnet/Stepup/Configuration/Value/InstitutionConfigurationId.php
@@ -29,12 +29,23 @@ final class InstitutionConfigurationId implements JsonSerializable
     private $institutionConfigurationId;
 
     /**
+     * @deprecated To be removed in next release; use normalizedFrom method to account for case-(in)sensitivity issues
+     *
      * @param Institution $institution
      * @return InstitutionConfigurationId
      */
     public static function from(Institution $institution)
     {
         return new self((string) Uuid::uuid5(self::UUID_NAMESPACE, $institution->getInstitution()));
+    }
+
+    /**
+     * @param Institution $institution
+     * @return InstitutionConfigurationId
+     */
+    public static function normalizedFrom(Institution $institution)
+    {
+        return new self((string) Uuid::uuid5(self::UUID_NAMESPACE, strtolower($institution->getInstitution())));
     }
 
     public function __construct($institutionConfigurationId)

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionConfigurationIdTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionConfigurationIdTest.php
@@ -87,10 +87,10 @@ class InstitutionConfigurationIdTest extends TestCase
         $mixedCaseInstitutionConfigurationId = InstitutionConfigurationId::normalizedFrom($mixedCaseInstitution);
         $lowerCaseInstitutionConfigurationId = InstitutionConfigurationId::normalizedFrom($lowerCaseInstitution);
 
-        $sameId = $mixedCaseInstitutionConfigurationId->equals($lowerCaseInstitutionConfigurationId);
+        $isSameId = $mixedCaseInstitutionConfigurationId->equals($lowerCaseInstitutionConfigurationId);
 
         $this->assertTrue(
-            $sameId,
+            $isSameId,
             'An InstitutionConfigurationId based on an institution with mixed casing'
             . 'should match an InstitutionConfigurationId based on the same institution in lower case'
         );
@@ -107,10 +107,10 @@ class InstitutionConfigurationIdTest extends TestCase
         $unnormalizedInstitutionConfigurationId = InstitutionConfigurationId::from($mixedCaseInstitution);
         $normalizedInstitutionConfigurationId   = InstitutionConfigurationId::normalizedFrom($mixedCaseInstitution);
 
-        $sameId = $unnormalizedInstitutionConfigurationId->equals($normalizedInstitutionConfigurationId);
+        $isSameId = $unnormalizedInstitutionConfigurationId->equals($normalizedInstitutionConfigurationId);
 
         $this->assertFalse(
-            $sameId,
+            $isSameId,
             'An normalized InstitutionConfigurationId based on an institution with mixed casing'
             . 'should not match an unnormalized InstitutionConfigurationId based on the same institution'
         );

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionConfigurationIdTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionConfigurationIdTest.php
@@ -76,6 +76,47 @@ class InstitutionConfigurationIdTest extends TestCase
     }
 
     /**
+     * @test
+     * @group domain
+     */
+    public function institution_configuration_ids_are_created_case_insensitively_from_institutions()
+    {
+        $mixedCaseInstitution = new Institution('An InStItUtIoN');
+        $lowerCaseInstitution = new Institution('an institution');
+
+        $mixedCaseInstitutionConfigurationId = InstitutionConfigurationId::normalizedFrom($mixedCaseInstitution);
+        $lowerCaseInstitutionConfigurationId = InstitutionConfigurationId::normalizedFrom($lowerCaseInstitution);
+
+        $sameId = $mixedCaseInstitutionConfigurationId->equals($lowerCaseInstitutionConfigurationId);
+
+        $this->assertTrue(
+            $sameId,
+            'An InstitutionConfigurationId based on an institution with mixed casing'
+            . 'should match an InstitutionConfigurationId based on the same institution in lower case'
+        );
+    }
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function normalized_institution_configuration_ids_and_unnormalized_institution_configuration_ids_are_not_the_same()
+    {
+        $mixedCaseInstitution = new Institution('An InStItUtIoN');
+
+        $unnormalizedInstitutionConfigurationId = InstitutionConfigurationId::from($mixedCaseInstitution);
+        $normalizedInstitutionConfigurationId   = InstitutionConfigurationId::normalizedFrom($mixedCaseInstitution);
+
+        $sameId = $unnormalizedInstitutionConfigurationId->equals($normalizedInstitutionConfigurationId);
+
+        $this->assertFalse(
+            $sameId,
+            'An normalized InstitutionConfigurationId based on an institution with mixed casing'
+            . 'should not match an unnormalized InstitutionConfigurationId based on the same institution'
+        );
+    }
+
+    /**
      * dataprovider
      */
     public function nonStringOrEmptyStringProvider()


### PR DESCRIPTION
Normalizing the institution configuration id fixes issues when basing institutions on schachome-organizations that are expected to work case-insensitively

The original construction of the (unnormalized) institution configuration id will be deprecated in favor of using normalized institution configuration ids