### PR TITLE
Implement InstitutionConfiguration migration

### DIFF
--- a/app/config/config_dev_event_replay.yml
+++ b/app/config/config_dev_event_replay.yml
@@ -3,6 +3,3 @@ imports:
 
 swiftmailer:
     disable_delivery: true
-
-surfnet_stepup_middleware_command_handling:
-    warn_on_missing_email_template: false

--- a/app/config/config_prod_event_replay.yml
+++ b/app/config/config_prod_event_replay.yml
@@ -3,6 +3,3 @@ imports:
 
 swiftmailer:
     disable_delivery: true
-
-surfnet_stepup_middleware_command_handling:
-    warn_on_missing_email_template: false

--- a/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
+++ b/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
@@ -323,8 +323,8 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
      */
     protected function applyInstitutionConfigurationRemovedEvent(InstitutionConfigurationRemovedEvent $event)
     {
-        // reset all configuration to defaults. This way, should it be rebuild, it seems it is new again
-        $this->raLocations                     = [];
+        // reset all configuration to defaults. This way, should it be rebuild, it seems like it is new again
+        $this->raLocations                     = new RaLocationList([]);
         $this->useRaLocationsOption            = UseRaLocationsOption::getDefault();
         $this->showRaaContactInformationOption = ShowRaaContactInformationOption::getDefault();
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/RaLocationProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/RaLocationProjector.php
@@ -89,7 +89,7 @@ class RaLocationProjector extends Projector
         $this->repository->remove($raLocation);
     }
 
-    public function removeRaLocationsFor(InstitutionConfigurationRemovedEvent $event)
+    public function applyInstitutionConfigurationRemovedEvent(InstitutionConfigurationRemovedEvent $event)
     {
         $this->repository->removeRaLocationsFor($event->institution);
     }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/RemoveInstitutionConfigurationByUnnormalizedIdCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/RemoveInstitutionConfigurationByUnnormalizedIdCommand.php
@@ -19,7 +19,7 @@
 namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command;
 
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\AbstractCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\ManagementExecutable;
+use Symfony\Component\Validator\Constraints as Assert;
 
 final class RemoveInstitutionConfigurationByUnnormalizedIdCommand extends AbstractCommand implements
     ManagementExecutable

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/RemoveInstitutionConfigurationByUnnormalizedIdCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/RemoveInstitutionConfigurationByUnnormalizedIdCommand.php
@@ -21,8 +21,7 @@ namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\AbstractCommand;
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class RemoveInstitutionConfigurationByUnnormalizedIdCommand extends AbstractCommand implements
-    ManagementExecutable
+final class RemoveInstitutionConfigurationByUnnormalizedIdCommand extends AbstractCommand
 {
     /**
      * @Assert\NotBlank()

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Pipeline/AuthorizingStage.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Pipeline/AuthorizingStage.php
@@ -78,7 +78,7 @@ class AuthorizingStage implements Stage
                 implode(', ', $allowedRoles)
             ));
 
-            throw new ForbiddenException('Processing of Command "%s" is forbidden.');
+            throw new ForbiddenException(sprintf('Processing of Command "%s" is forbidden.', $command));
         }
 
         $this->logger->debug(sprintf('Client authorized to execute command "%s"', $command));

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
@@ -68,7 +68,7 @@ final class MigrateInstitutionConfigurationsCommand extends Command
         $connectionHelper = $container->get('surfnet_stepup_middleware_middleware.dbal_connection_helper');
         $provider         = $container->get('surfnet_stepup_middleware_middleware.institution_configuration_provider');
         $pipeline         = $container->get('pipeline');
-        $eventBus         = $container->get('surfnet_stepup_middleware_command_handling.event_bus.buffered');
+        $entityManager    = $container->get('doctrine.orm.middleware_entity_manager');
 
         // The InstitutionConfiguration commands require ROLE_MANAGEMENT
         // Note that the new events will not have any actor metadata associated with them
@@ -84,22 +84,26 @@ final class MigrateInstitutionConfigurationsCommand extends Command
             foreach ($state->inferRemovalCommands() as $removalCommand) {
                 $pipeline->process($removalCommand);
             }
-            $eventBus->flush();
+            $entityManager->flush();
+            $entityManager->clear();
 
             foreach ($state->inferCreateCommands() as $createCommand) {
                 $pipeline->process($createCommand);
             }
-            $eventBus->flush();
+            $entityManager->flush();
+            $entityManager->clear();
 
             foreach ($state->inferReconfigureCommands() as $reconfigureCommand) {
                 $pipeline->process($reconfigureCommand);
             }
-            $eventBus->flush();
+            $entityManager->flush();
+            $entityManager->clear();
 
             foreach ($state->inferAddRaLocationCommands() as $addRaLocationCommand) {
                 $pipeline->process($addRaLocationCommand);
             }
-            $eventBus->flush();
+            $entityManager->flush();
+            $entityManager->clear();
 
             $connectionHelper->commit();
             $output->writeln('<info>Successfully migrated institution configurations.</info>');

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
@@ -18,9 +18,14 @@
 
 namespace Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command;
 
+use Exception;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
 final class MigrateInstitutionConfigurationsCommand extends Command
 {
@@ -35,5 +40,74 @@ final class MigrateInstitutionConfigurationsCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+
+        $output->writeln([
+            '<error>WARNING: you are about to migrate institution configurations'
+            . ' to work with identifiers based on insitutions with normalized casing.</error>',
+            '<error>This command is intended to be run only once.</error>',
+            ''
+        ]);
+
+        $confirmationQuestion = new ConfirmationQuestion(
+            'Are you sure you want to run the institution configuration migrations? [y/N]',
+            false
+        );
+        $confirmed = $questionHelper->ask($input, $output, $confirmationQuestion);
+
+        if (!$confirmed) {
+            $output->writeln('<info>Exiting without running migrations.</info>');
+            return;
+        }
+
+        /** @var Container $container */
+        $container = $this->getApplication()->getKernel()->getContainer();
+
+        $tokenStorage     = $container->get('security.token_storage');
+        $connectionHelper = $container->get('surfnet_stepup_middleware_middleware.dbal_connection_helper');
+        $provider         = $container->get('surfnet_stepup_middleware_middleware.institution_configuration_provider');
+        $pipeline         = $container->get('pipeline');
+        $eventBus         = $container->get('surfnet_stepup_middleware_command_handling.event_bus.buffered');
+
+        // The InstitutionConfiguration commands require ROLE_MANAGEMENT
+        // Note that the new events will not have any actor metadata associated with them
+        $tokenStorage->setToken(new AnonymousToken('console', 'console', ['ROLE_MANAGEMENT']));
+
+        $connectionHelper->beginTransaction();
+
+        try {
+            $state = $provider->loadData();
+
+            foreach ($state->inferRemovalCommands() as $removalCommand) {
+                $pipeline->process($removalCommand);
+            }
+            $eventBus->flush();
+
+            foreach ($state->inferCreateCommands() as $createCommand) {
+                $pipeline->process($createCommand);
+            }
+            $eventBus->flush();
+
+            foreach ($state->inferReconfigureCommands() as $reconfigureCommand) {
+                $pipeline->process($reconfigureCommand);
+            }
+            $eventBus->flush();
+
+            foreach ($state->inferAddRaLocationCommands() as $addRaLocationCommand) {
+                $pipeline->process($addRaLocationCommand);
+            }
+            $eventBus->flush();
+
+            $connectionHelper->commit();
+            $output->writeln('<info>Successfully migrated institution configurations.</info>');
+        } catch (Exception $exception) {
+            $output->writeln(
+                sprintf('<error>Could not migrate institution configurations: %s</error>', $exception->getMessage())
+            );
+            $connectionHelper->rollBack();
+
+            throw $exception;
+        }
     }
 }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
@@ -70,10 +70,10 @@ final class MigrateInstitutionConfigurationsCommand extends Command
         $pipeline         = $container->get('pipeline');
         $entityManager    = $container->get('doctrine.orm.middleware_entity_manager');
 
-        // The InstitutionConfiguration commands require ROLE_MANAGEMENT
+        // The InstitutionConfiguration commands require ROLE_MANAGEMENT, AddRaLocation requires ROLE_RA
         // Note that the new events will not have any actor metadata associated with them
         $tokenStorage->setToken(
-            new AnonymousToken('cli.institution_configuration_migration', 'cli', ['ROLE_MANAGEMENT'])
+            new AnonymousToken('cli.institution_configuration_migration', 'cli', ['ROLE_MANAGEMENT', 'ROLE_RA'])
         );
 
         $connectionHelper->beginTransaction();

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
@@ -76,29 +76,35 @@ final class MigrateInstitutionConfigurationsCommand extends Command
             new AnonymousToken('cli.institution_configuration_migration', 'cli', ['ROLE_MANAGEMENT', 'ROLE_RA'])
         );
 
+        $output->writeln('<info>Starting institution configuration migrations</info>');
         $connectionHelper->beginTransaction();
 
         try {
+            $output->writeln('<info>Loading existing institution configuration data</info>');
             $state = $provider->loadData();
 
+            $output->writeln('<info>Removing existing institution configurations</info>');
             foreach ($state->inferRemovalCommands() as $removalCommand) {
                 $pipeline->process($removalCommand);
             }
             $entityManager->flush();
             $entityManager->clear();
 
+            $output->writeln('<info>Creating new institution configurations</info>');
             foreach ($state->inferCreateCommands() as $createCommand) {
                 $pipeline->process($createCommand);
             }
             $entityManager->flush();
             $entityManager->clear();
 
+            $output->writeln('<info>Reconfiguring institution configurations</info>');
             foreach ($state->inferReconfigureCommands() as $reconfigureCommand) {
                 $pipeline->process($reconfigureCommand);
             }
             $entityManager->flush();
             $entityManager->clear();
 
+            $output->writeln('<info>Adding RA locations</info>');
             foreach ($state->inferAddRaLocationCommands() as $addRaLocationCommand) {
                 $pipeline->process($addRaLocationCommand);
             }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/MigrateInstitutionConfigurationsCommand.php
@@ -72,7 +72,9 @@ final class MigrateInstitutionConfigurationsCommand extends Command
 
         // The InstitutionConfiguration commands require ROLE_MANAGEMENT
         // Note that the new events will not have any actor metadata associated with them
-        $tokenStorage->setToken(new AnonymousToken('console', 'console', ['ROLE_MANAGEMENT']));
+        $tokenStorage->setToken(
+            new AnonymousToken('cli.institution_configuration_migration', 'cli', ['ROLE_MANAGEMENT'])
+        );
 
         $connectionHelper->beginTransaction();
 

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Migrations/InstitutionConfiguration/InstitutionConfigurationState.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Migrations/InstitutionConfiguration/InstitutionConfigurationState.php
@@ -46,10 +46,11 @@ final class InstitutionConfigurationState
         }, $institutionConfigurationOptions);
         $mappedConfigurationOptions = array_combine($optionInstitutions, $institutionConfigurationOptions);
 
-        $raLocationInstitutions = array_map(function (RaLocation $raLocation) {
-            return $raLocation->institution->getInstitution();
-        }, $raLocations);
-        $mappedRaLocations = array_combine($raLocationInstitutions, $raLocations);
+        $mappedRaLocations = [];
+        foreach ($raLocations as $raLocation) {
+            $institution = $raLocation->institution->getInstitution();
+            $mappedRaLocations[$institution][] = $raLocation;
+        }
 
         $mappedInstitutionConfigurations = [];
         foreach ($configuredInstitutions as $institution) {

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Migrations/InstitutionConfiguration/MappedInstitutionConfiguration.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Migrations/InstitutionConfiguration/MappedInstitutionConfiguration.php
@@ -19,7 +19,7 @@
 namespace Surfnet\StepupMiddleware\MiddlewareBundle\Migrations\InstitutionConfiguration;
 
 use Rhumsaa\Uuid\Uuid;
-use Surfnet\Stepup\Configuration\Entity\RaLocation;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\RaLocation;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -46,7 +46,7 @@ final class MappedInstitutionConfiguration
     private $useRaLocationsOption;
 
     /**
-     * @var array|RaLocation[]
+     * @var RaLocation[]
      */
     private $raLocations;
 
@@ -118,10 +118,10 @@ final class MappedInstitutionConfiguration
             $command                     = new AddRaLocationCommand();
             $command->UUID               = (string) Uuid::uuid4();
             $command->institution        = $institution;
-            $command->raLocationId       = $raLocation->getId()->getRaLocationId();
-            $command->raLocationName     = $raLocation->getName()->getRaLocationName();
-            $command->contactInformation = $raLocation->getContactInformation()->getContactInformation();
-            $command->location           = $raLocation->getLocation()->getLocation();
+            $command->raLocationId       = $raLocation->id ;
+            $command->raLocationName     = $raLocation->name->getRaLocationName();
+            $command->contactInformation = $raLocation->contactInformation->getContactInformation();
+            $command->location           = $raLocation->location->getLocation();
 
             $commands[] = $command;
         }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
@@ -3,5 +3,5 @@ services:
         class: Surfnet\StepupMiddleware\MiddlewareBundle\Service\DBALConnectionHelper
         arguments:
             -
-                middleware: @doctrine.dbal.middleware_connection
-                gateway: @doctrine.dbal.gateway_connection
+                middleware: "@doctrine.dbal.middleware_connection"
+                gateway: "@doctrine.dbal.gateway_connection"

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
@@ -5,3 +5,10 @@ services:
             -
                 middleware: "@doctrine.dbal.middleware_connection"
                 gateway: "@doctrine.dbal.gateway_connection"
+
+    surfnet_stepup_middleware_middleware.institution_configuration_provider:
+        class: Surfnet\StepupMiddleware\MiddlewareBundle\Migrations\InstitutionConfiguration\InstitutionConfigurationProvider
+        arguments:
+            - "@surfnet_stepup_middleware_api.service.configured_institutions"
+            - "@surfnet_stepup_middleware_api.service.institution_configuration_options"
+            - "@surfnet_stepup_middleware_api.service.ra_location"

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/SurfnetStepupMiddlewareMiddlewareBundle.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/SurfnetStepupMiddlewareMiddlewareBundle.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupMiddleware\MiddlewareBundle;
 
 use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\BootstrapIdentityWithYubikeySecondFactorCommand;
+use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\MigrateInstitutionConfigurationsCommand;
 use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\MigrationsDiffDoctrineCommand;
 use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\MigrationsMigrateDoctrineCommand;
 use Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\ReplayEventsCommand;
@@ -33,5 +34,6 @@ class SurfnetStepupMiddlewareMiddlewareBundle extends Bundle
         $application->add(new MigrationsMigrateDoctrineCommand());
         $application->add(new BootstrapIdentityWithYubikeySecondFactorCommand());
         $application->add(new ReplayEventsCommand());
+        $application->add(new MigrateInstitutionConfigurationsCommand());
     }
 }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Tests/Migrations/InstitutionConfiguration/MappedInstitutionConfigurationTest.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Tests/Migrations/InstitutionConfiguration/MappedInstitutionConfigurationTest.php
@@ -20,7 +20,6 @@ namespace Surfnet\StepupMiddleware\MiddlewareBundle\Tests\Migrations\Institution
 
 use PHPUnit_Framework_TestCase as UnitTest;
 use Rhumsaa\Uuid\Uuid;
-use Surfnet\Stepup\Configuration\Entity\RaLocation;
 use Surfnet\Stepup\Configuration\Value\ContactInformation;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\Location;
@@ -28,6 +27,7 @@ use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\RaLocation;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\AddRaLocationCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\CreateInstitutionConfigurationCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\ReconfigureInstitutionConfigurationOptionsCommand;
@@ -143,7 +143,8 @@ class MappedInstitutionConfigurationTest extends UnitTest
         $useRaLocationsOption            = new UseRaLocationsOption(true);
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(false);
         $raLocation                      = RaLocation::create(
-            new RaLocationId((string) Uuid::uuid4()),
+            (string) Uuid::uuid4(),
+            $institution,
             new RaLocationName('Some Location'),
             new Location('Somewhere here or there'),
             new ContactInformation('Per phone.')
@@ -175,13 +176,15 @@ class MappedInstitutionConfigurationTest extends UnitTest
         $useRaLocationsOption            = new UseRaLocationsOption(true);
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(false);
         $firstRaLocation                 = RaLocation::create(
-            new RaLocationId((string) Uuid::uuid4()),
+            (string) Uuid::uuid4(),
+            $institution,
             new RaLocationName('Some Location'),
             new Location('Somewhere here or there'),
             new ContactInformation('Per phone.')
         );
         $secondRaLocation                = RaLocation::create(
-            new RaLocationId((string) Uuid::uuid4()),
+            (string) Uuid::uuid4(),
+            $institution,
             new RaLocationName('Somewhere else'),
             new Location('Utrecht, The Netherlands'),
             new ContactInformation('Shout really hard')
@@ -208,11 +211,11 @@ class MappedInstitutionConfigurationTest extends UnitTest
         RaLocation $raLocation
     ) {
         $this->assertEquals($institution->getInstitution(), $command->institution);
-        $this->assertEquals($raLocation->getId()->getRaLocationId(), $command->raLocationId);
-        $this->assertEquals($raLocation->getName()->getRaLocationName(), $command->raLocationName);
-        $this->assertEquals($raLocation->getLocation()->getLocation(), $command->location);
+        $this->assertEquals($raLocation->id, $command->raLocationId);
+        $this->assertEquals($raLocation->name->getRaLocationName(), $command->raLocationName);
+        $this->assertEquals($raLocation->location->getLocation(), $command->location);
         $this->assertEquals(
-            $raLocation->getContactInformation()->getContactInformation(),
+            $raLocation->contactInformation->getContactInformation(),
             $command->contactInformation
         );
     }


### PR DESCRIPTION
[135610963](https://www.pivotaltracker.com/story/show/135610963)

The InstitutionConfigurations are migrated in order to update existing InstitutionConfigurationIds to be handled case-insensitively.