### PR TITLE
Feature/specific replay/event selection

### DIFF
--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/ReplaySpecificEventsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/ReplaySpecificEventsCommand.php
@@ -18,9 +18,11 @@
 
 namespace Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class ReplaySpecificEventsCommand extends ContainerAwareCommand
 {
@@ -33,5 +35,19 @@ class ReplaySpecificEventsCommand extends ContainerAwareCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $container = $this->getContainer();
+        $eventCollection = $container->get('middleware.event_replay.event_collection');
+
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+
+        $selectEventsQuestion = new ChoiceQuestion(
+            'Which events would you like to replay? Please supply a comma-separated list of numbers.',
+            iterator_to_array($eventCollection)
+        );
+        $selectEventsQuestion->setMultiselect(true);
+
+        $chosenEvents   = $questionHelper->ask($input, $output, $selectEventsQuestion);
+        $eventCollection->select($chosenEvents);
     }
 }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/ReplaySpecificEventsCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/ReplaySpecificEventsCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReplaySpecificEventsCommand extends Command
+class ReplaySpecificEventsCommand extends ContainerAwareCommand
 {
     protected function configure()
     {

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/EventSourcing/EventCollection.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/EventSourcing/EventCollection.php
@@ -18,9 +18,11 @@
 
 namespace Surfnet\StepupMiddleware\MiddlewareBundle\EventSourcing;
 
+use ArrayIterator;
+use IteratorAggregate;
 use Surfnet\StepupMiddleware\MiddlewareBundle\Exception\InvalidArgumentException;
 
-final class EventCollection
+final class EventCollection implements IteratorAggregate
 {
     /**
      * @var string[]
@@ -43,5 +45,10 @@ final class EventCollection
 
             $this->eventNames[] = $eventName;
         }
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->eventNames);
     }
 }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/EventSourcing/EventCollection.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/EventSourcing/EventCollection.php
@@ -47,6 +47,26 @@ final class EventCollection implements IteratorAggregate
         }
     }
 
+    /**
+     * @param array $subset
+     * @return EventCollection
+     */
+    public function select(array $subset)
+    {
+        $nonAvailableEventNames = array_diff($subset, $this->eventNames);
+
+        if (!empty($nonAvailableEventNames)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Subset of event names contains event names not present in collection: %s',
+                    implode(', ', $nonAvailableEventNames)
+                )
+            );
+        }
+
+        return new self($subset);
+    }
+
     public function getIterator()
     {
         return new ArrayIterator($this->eventNames);

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/EventSourcing/EventCollection.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/EventSourcing/EventCollection.php
@@ -27,7 +27,7 @@ final class EventCollection
      */
     private $eventNames = [];
 
-    public function __construct($eventNames)
+    public function __construct(array $eventNames)
     {
         foreach ($eventNames as $eventName) {
             if (!is_string($eventName) || empty($eventName)) {

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/event_replaying.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/event_replaying.yml
@@ -1,4 +1,9 @@
 services:
+    middleware.event_replay.event_collection:
+        class: Surfnet\StepupMiddleware\MiddlewareBundle\EventSourcing\EventCollection
+        arguments:
+            - "%registered_events%"
+
     middleware.event_replay.projector_collection:
         class: Surfnet\StepupMiddleware\MiddlewareBundle\EventSourcing\ProjectorCollection
 

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Tests/EventSourcing/EventCollectionTest.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Tests/EventSourcing/EventCollectionTest.php
@@ -20,6 +20,8 @@ namespace Surfnet\StepupMiddleware\MiddlewareBundle\Tests\EventSourcing;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
+use Surfnet\Stepup\Configuration\Event\NewConfigurationCreatedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\StepupMiddleware\MiddlewareBundle\EventSourcing\EventCollection;
 use Surfnet\StepupMiddleware\MiddlewareBundle\Exception\InvalidArgumentException;
 
@@ -53,6 +55,35 @@ class EventCollectionTest extends TestCase
         $nonExistantClass = 'This\Class\Does\Not\Exist';
 
         new EventCollection([$nonExistantClass]);
+    }
+
+    /**
+     * @test
+     * @group event-replay
+     */
+    public function a_subset_of_events_can_be_selected_from_an_event_collection()
+    {
+        $eventCollection = new EventCollection([NewConfigurationCreatedEvent::class, SecondFactorVettedEvent::class]);
+
+        $expectedSubset = new EventCollection([NewConfigurationCreatedEvent::class]);
+        $subset = $eventCollection->select([NewConfigurationCreatedEvent::class]);
+
+        $this->assertEquals($expectedSubset, $subset);
+    }
+
+    /**
+     * @test
+     * @group event-replay
+     */
+    public function a_subset_containing_events_not_present_in_the_event_collection_cannot_be_selected()
+    {
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            'Subset of event names contains event names not present in collection'
+        );
+
+        $eventCollection = new EventCollection([NewConfigurationCreatedEvent::class]);
+        $eventCollection->select([SecondFactorVettedEvent::class]);
     }
 
     public function emptyOrNonStringProvider()


### PR DESCRIPTION
[133173121](https://www.pivotaltracker.com/story/show/133173121)

The selection can be a bit tedious, as Symfony Console requires you to select them by number.
It looks like this in the command line:
```
$ app/console stepup:event:replay
Which events would you like to replay? Please supply a comma-separated list of numbers.
  [0 ] Surfnet\Stepup\Configuration\Event\AllowedSecondFactorListUpdatedEvent
  [1 ] Surfnet\Stepup\Configuration\Event\ConfigurationUpdatedEvent
  [2 ] Surfnet\Stepup\Configuration\Event\EmailTemplatesUpdatedEvent
  [3 ] Surfnet\Stepup\Configuration\Event\IdentityProvidersUpdatedEvent
  [4 ] Surfnet\Stepup\Configuration\Event\InstitutionConfigurationRemovedEvent
  [5 ] Surfnet\Stepup\Configuration\Event\NewConfigurationCreatedEvent
  [6 ] Surfnet\Stepup\Configuration\Event\NewInstitutionConfigurationCreatedEvent
  [7 ] Surfnet\Stepup\Configuration\Event\RaLocationAddedEvent
  [8 ] Surfnet\Stepup\Configuration\Event\RaLocationContactInformationChangedEvent
  [9 ] Surfnet\Stepup\Configuration\Event\RaLocationRelocatedEvent
  [10] Surfnet\Stepup\Configuration\Event\RaLocationRemovedEvent
  [11] Surfnet\Stepup\Configuration\Event\RaLocationRenamedEvent
  [12] Surfnet\Stepup\Configuration\Event\ServiceProvidersUpdatedEvent
  [13] Surfnet\Stepup\Configuration\Event\ShowRaaContactInformationOptionChangedEvent
  [14] Surfnet\Stepup\Configuration\Event\SraaUpdatedEvent
  [15] Surfnet\Stepup\Configuration\Event\UseRaLocationsOptionChangedEvent
  [16] Surfnet\Stepup\Identity\Event\AppointedAsRaaEvent
  [17] Surfnet\Stepup\Identity\Event\AppointedAsRaEvent
  [18] Surfnet\Stepup\Identity\Event\CompliedWithUnverifiedSecondFactorRevocationEvent
  [19] Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaEvent
  [20] Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent
  [21] Surfnet\Stepup\Identity\Event\GssfPossessionProvenEvent
  [22] Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaEvent
  [23] Surfnet\Stepup\Identity\Event\IdentityCreatedEvent
  [24] Surfnet\Stepup\Identity\Event\EmailVerifiedEvent
  [25] Surfnet\Stepup\Identity\Event\CompliedWithVettedSecondFactorRevocationEvent
  [26] Surfnet\Stepup\Identity\Event\CompliedWithVerifiedSecondFactorRevocationEvent
  [27] Surfnet\Stepup\Identity\Event\IdentityForgottenEvent
  [28] Surfnet\Stepup\Identity\Event\IdentityRenamedEvent
  [29] Surfnet\Stepup\Identity\Event\LocalePreferenceExpressedEvent
  [30] Surfnet\Stepup\Identity\Event\InstitutionsAddedToWhitelistEvent
  [31] Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent
  [32] Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent
  [33] Surfnet\Stepup\Identity\Event\RegistrationAuthorityInformationAmendedEvent
  [34] Surfnet\Stepup\Identity\Event\InstitutionsRemovedFromWhitelistEvent
  [35] Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent
  [36] Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent
  [37] Surfnet\Stepup\Identity\Event\VerifiedSecondFactorRevokedEvent
  [38] Surfnet\Stepup\Identity\Event\WhitelistCreatedEvent
  [39] Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent
  [40] Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent
  [41] Surfnet\Stepup\Identity\Event\WhitelistReplacedEvent
  [42] Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent
  [43] Surfnet\Stepup\Identity\Event\YubikeyPossessionProvenEvent
 > 40, 41, 42
```