### PR TITLE
Validate institution names case-insensitively

### DIFF
--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
@@ -134,6 +134,40 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
      * @test
      * @group validator
      */
+    public function validation_for_existing_institutions_is_done_case_insensitively()
+    {
+        $existingInstitutions = [ConfiguredInstitution::createFrom(new Institution('surfnet.nl'))];
+        $differentlyCasedButSameInstitution = 'Surfnet.nl';
+
+        $invalidRequest = [
+            $differentlyCasedButSameInstitution => [
+                'use_ra_locations'             => false,
+                'show_raa_contact_information' => true,
+                'allowed_second_factors'       => [],
+            ],
+        ];
+
+        $builder = Mockery::mock(ConstraintViolationBuilderInterface::class);
+        $builder->shouldNotReceive('addViolation');
+
+        $context = Mockery::mock(ExecutionContextInterface::class);
+        $context->shouldNotReceive('buildViolation');
+
+        $configuredInstitutionServiceMock = Mockery::mock(ConfiguredInstitutionService::class);
+        $configuredInstitutionServiceMock
+            ->shouldReceive('getAll')
+            ->andReturn($existingInstitutions);
+
+        $validator = new ReconfigureInstitutionRequestValidator($configuredInstitutionServiceMock);
+        $validator->initialize($context);
+
+        $validator->validate($invalidRequest, new ValidReconfigureInstitutionsRequest);
+    }
+
+    /**
+     * @test
+     * @group validator
+     */
     public function valid_reconfigure_institution_requests_do_not_cause_any_violations()
     {
         $institution = 'surfnet.nl';

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
@@ -83,9 +83,7 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
     {
         $configuredInstitutions = $this->getConfiguredInstitutions();
 
-        $nonExistentInstitutions = array_filter($institutions, function ($institution) use ($configuredInstitutions) {
-            return !in_array(strtolower($institution), $configuredInstitutions);
-        });
+        $nonExistentInstitutions = $this->determineNonExistentInstitutions($institutions, $configuredInstitutions);
 
         if (!empty($nonExistentInstitutions)) {
             throw new InvalidArgumentException(
@@ -155,11 +153,35 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
 
         $this->configuredInstitutions = array_map(
             function (ConfiguredInstitution $configuredInstitution) {
-                return strtolower($configuredInstitution->institution->getInstitution());
+                return $configuredInstitution->institution->getInstitution();
             },
             $this->configuredInstitutionsService->getAll()
         );
 
         return $this->configuredInstitutions;
+    }
+
+    /**
+     * @param string[] $institutions
+     * @param $configuredInstitutions
+     * @return string[]
+     */
+    public function determineNonExistentInstitutions(array $institutions, $configuredInstitutions)
+    {
+        $normalizedConfiguredInstitutions = array_map(
+            function ($institution) {
+                return strtolower($institution);
+            },
+            $configuredInstitutions
+        );
+
+        return array_filter(
+            $institutions,
+            function ($institution) use ($normalizedConfiguredInstitutions) {
+                $normalizedInstitution = strtolower($institution);
+
+                return !in_array($normalizedInstitution, $normalizedConfiguredInstitutions);
+            }
+        );
     }
 }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
@@ -84,7 +84,7 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
         $configuredInstitutions = $this->getConfiguredInstitutions();
 
         $nonExistentInstitutions = array_filter($institutions, function ($institution) use ($configuredInstitutions) {
-            return !in_array($institution, $configuredInstitutions);
+            return !in_array(strtolower($institution), $configuredInstitutions);
         });
 
         if (!empty($nonExistentInstitutions)) {
@@ -155,7 +155,7 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
 
         $this->configuredInstitutions = array_map(
             function (ConfiguredInstitution $configuredInstitution) {
-                return $configuredInstitution->institution->getInstitution();
+                return strtolower($configuredInstitution->institution->getInstitution());
             },
             $this->configuredInstitutionsService->getAll()
         );


### PR DESCRIPTION
The database is collated in a case-insensitive manner. As far as the database is concerned "Institution-a" == "institution-a".

This is why, when replacing an institution on the whitelist with the same institution name but with different casing,
the configured_institution is not changed: the InstitutionConfigurationProcessor detects no changes.
That is how you can have different casing as a configured_institution and as a whitelist_entry.

This goes wrong when trying to validate an institution configuration command as we check whether or not the
institution to configure is actually listed as a configured_institution.

This check was case-sensitive while its behavior should mirror the database, which works case-insensitive.