### PR TITLE
Multiple AllowedSecondFactors for the same institution can be saved

### DIFF
--- a/app/DoctrineMigrations/Version20170216085513.php
+++ b/app/DoctrineMigrations/Version20170216085513.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170216085513 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE allowed_second_factor DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE allowed_second_factor CHANGE institution institution VARCHAR(255) NOT NULL, CHANGE second_factor_type second_factor_type VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE allowed_second_factor ADD PRIMARY KEY (institution, second_factor_type)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE allowed_second_factor DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE allowed_second_factor CHANGE institution institution VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, CHANGE second_factor_type second_factor_type VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE allowed_second_factor ADD PRIMARY KEY (institution)');
+    }
+}

--- a/app/DoctrineMigrations/Version20170216085513.php
+++ b/app/DoctrineMigrations/Version20170216085513.php
@@ -19,7 +19,6 @@ class Version20170216085513 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE allowed_second_factor DROP PRIMARY KEY');
-        $this->addSql('ALTER TABLE allowed_second_factor CHANGE institution institution VARCHAR(255) NOT NULL, CHANGE second_factor_type second_factor_type VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE allowed_second_factor ADD PRIMARY KEY (institution, second_factor_type)');
     }
 
@@ -32,7 +31,6 @@ class Version20170216085513 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE allowed_second_factor DROP PRIMARY KEY');
-        $this->addSql('ALTER TABLE allowed_second_factor CHANGE institution institution VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, CHANGE second_factor_type second_factor_type VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
         $this->addSql('ALTER TABLE allowed_second_factor ADD PRIMARY KEY (institution)');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/AllowedSecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/AllowedSecondFactor.php
@@ -38,6 +38,7 @@ final class AllowedSecondFactor
     public $institution;
 
     /**
+     * @ORM\Id
      * @ORM\Column(type="stepup_second_factor_type")
      *
      * @var SecondFactorType


### PR DESCRIPTION
This corrects the primary key to be a compound key: the combination of
institution allowed second factor type is unique, but each institution
can have multiple second factor types. Since a PK also enforces a unique
constraint, having a PK on institution (a value object) limits the
allowed second factors to one per institution. By correcting the PK to
span both columns (Identity first for performance considerations), this
artificial limit is removed.