### PR TITLE
Feature/gssp add through configuration

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -194,6 +194,7 @@ surfnet_stepup_middleware_command_handling:
 
 surfnet_stepup_middleware_middleware:
     email_verification_window: %email_verification_window%
+    enabled_generic_second_factors: %enabled_generic_second_factors%
 
 surfnet_stepup_middleware_management:
     email_required_locale: %default_locale%

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,3 +47,9 @@ parameters:
     stepup_loa_loa3: https://gateway.tld/authentication/loa3
 
     self_service_url: https://selfservice.tld
+
+    enabled_generic_second_factors:
+        biometric:
+            loa: 3
+        tiqr:
+            loa: 3

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "jms/di-extra-bundle": "~1.5",
         "jms/aop-bundle": "~1.0",
         "ramsey/uuid": "^2.9",
-        "surfnet/stepup-bundle": "^1.7"
+        "surfnet/stepup-bundle": "^2.0"
     },
     "require-dev": {
         "liip/rmt": "1.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "12395c47f78cda74d5d658b603a20f02",
+    "content-hash": "b2f4a4edb960d60c0d63e4a361e9cf7f",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2373,16 +2373,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "1.7.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "084b1e11781ca3f526e32a486f75a7e6a953e5fc"
+                "reference": "0ea9b1d5b661b28b8819fc2c9008ec8c71701183"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/084b1e11781ca3f526e32a486f75a7e6a953e5fc",
-                "reference": "084b1e11781ca3f526e32a486f75a7e6a953e5fc",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/0ea9b1d5b661b28b8819fc2c9008ec8c71701183",
+                "reference": "0ea9b1d5b661b28b8819fc2c9008ec8c71701183",
                 "shasum": ""
             },
             "require": {
@@ -2426,7 +2426,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2017-03-07T13:44:04+00:00"
+            "time": "2017-06-08T13:26:09+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -3197,12 +3197,12 @@
             "version": "0.9.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
+                "url": "https://github.com/mockery/mockery.git",
                 "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/4db079511a283e5aba1b3c2fb19037c645e70fc2",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/4db079511a283e5aba1b3c2fb19037c645e70fc2",
                 "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2",
                 "shasum": ""
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b349cfba2c1fe35e6374aaddf6ae887b",
+    "content-hash": "12395c47f78cda74d5d658b603a20f02",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1077,63 +1077,6 @@
                 "orm"
             ],
             "time": "2016-01-05T21:34:58+00:00"
-        },
-        {
-            "name": "egulias/email-validator",
-            "version": "2.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "bc31baa11ea2883e017f0a10d9722ef9d50eac1c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/bc31baa11ea2883e017f0a10d9722ef9d50eac1c",
-                "reference": "bc31baa11ea2883e017f0a10d9722ef9d50eac1c",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^1.0.1",
-                "php": ">= 5.5"
-            },
-            "require-dev": {
-                "dominicsayers/isemail": "dev-master",
-                "phpunit/phpunit": "^4.8.0",
-                "satooshi/php-coveralls": "dev-master"
-            },
-            "suggest": {
-                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Egulias\\EmailValidator\\": "EmailValidator"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Eduardo Gulias Davis"
-                }
-            ],
-            "description": "A library for validating emails against several RFCs",
-            "homepage": "https://github.com/egulias/EmailValidator",
-            "keywords": [
-                "email",
-                "emailvalidation",
-                "emailvalidator",
-                "validation",
-                "validator"
-            ],
-            "time": "2017-01-30T22:07:36+00:00"
         },
         {
             "name": "graylog2/gelf-php",
@@ -2487,30 +2430,28 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.0.1",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "008f088d535ed3333af5ad804dd4c0eaf97c2805"
+                "reference": "4cc92842069c2bbc1f28daaaf1d2576ec4dfe153"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/008f088d535ed3333af5ad804dd4c0eaf97c2805",
-                "reference": "008f088d535ed3333af5ad804dd4c0eaf97c2805",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/4cc92842069c2bbc1f28daaaf1d2576ec4dfe153",
+                "reference": "4cc92842069c2bbc1f28daaaf1d2576ec4dfe153",
                 "shasum": ""
             },
             "require": {
-                "egulias/email-validator": "~2.0",
-                "php": ">=7.0.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9.1",
-                "symfony/phpunit-bridge": "~3.3@dev"
+                "mockery/mockery": "~0.9.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "5.4-dev"
                 }
             },
             "autoload": {
@@ -2538,7 +2479,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2017-05-20T06:20:27+00:00"
+            "time": "2016-07-08T11:51:25+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -2714,30 +2655,28 @@
         },
         {
             "name": "symfony/swiftmailer-bundle",
-            "version": "v3.0.1",
+            "version": "v2.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/swiftmailer-bundle.git",
-                "reference": "5edfbd39eaefb176922a346c16b0ae3aaeec87e0"
+                "reference": "5e1a90f28213231ceee19c953bbebc5b5b95c690"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/5edfbd39eaefb176922a346c16b0ae3aaeec87e0",
-                "reference": "5edfbd39eaefb176922a346c16b0ae3aaeec87e0",
+                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/5e1a90f28213231ceee19c953bbebc5b5b95c690",
+                "reference": "5e1a90f28213231ceee19c953bbebc5b5b95c690",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2",
-                "swiftmailer/swiftmailer": "~6.0",
-                "symfony/config": "~2.7|~3.0",
-                "symfony/dependency-injection": "~2.7|~3.0",
-                "symfony/http-kernel": "~2.7|~3.0"
+                "swiftmailer/swiftmailer": ">=4.2.0,~5.0",
+                "symfony/config": "~2.3|~3.0",
+                "symfony/dependency-injection": "~2.3|~3.0",
+                "symfony/http-kernel": "~2.3|~3.0",
+                "symfony/yaml": "~2.3|~3.0"
             },
             "require-dev": {
-                "symfony/console": "~2.7|~3.0",
-                "symfony/framework-bundle": "~2.7|~3.0",
-                "symfony/phpunit-bridge": "~3.3@dev",
-                "symfony/yaml": "~2.7|~3.0"
+                "symfony/phpunit-bridge": "~2.7|~3.0"
             },
             "suggest": {
                 "psr/log": "Allows logging"
@@ -2745,7 +2684,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -2769,7 +2708,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2017-05-20T06:46:01+00:00"
+            "time": "2016-01-15T16:41:20+00:00"
         },
         {
             "name": "symfony/symfony",

--- a/composer.lock
+++ b/composer.lock
@@ -2373,16 +2373,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "0ea9b1d5b661b28b8819fc2c9008ec8c71701183"
+                "reference": "0766c91a6b391739d9fe4693f684ef1332342df4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/0ea9b1d5b661b28b8819fc2c9008ec8c71701183",
-                "reference": "0ea9b1d5b661b28b8819fc2c9008ec8c71701183",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/0766c91a6b391739d9fe4693f684ef1332342df4",
+                "reference": "0766c91a6b391739d9fe4693f684ef1332342df4",
                 "shasum": ""
             },
             "require": {
@@ -2426,7 +2426,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2017-06-08T13:26:09+00:00"
+            "time": "2017-06-14T13:03:51+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Surfnet/Stepup/Identity/Api/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Api/Identity.php
@@ -39,6 +39,7 @@ use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\StepupProvider;
 use Surfnet\Stepup\Identity\Value\U2fKeyHandle;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 interface Identity extends AggregateRoot
@@ -147,15 +148,15 @@ interface Identity extends AggregateRoot
     /**
      * Attempts to vet another identity's verified second factor.
      *
-     * @param Identity               $registrant
-     * @param SecondFactorId         $registrantsSecondFactorId
-     * @param SecondFactorType       $registrantsSecondFactorType
+     * @param Identity $registrant
+     * @param SecondFactorId $registrantsSecondFactorId
+     * @param SecondFactorType $registrantsSecondFactorType
      * @param SecondFactorIdentifier $registrantsSecondFactorIdentifier
-     * @param string                 $registrationCode
-     * @param DocumentNumber         $documentNumber
-     * @param bool                   $identityVerified
+     * @param string $registrationCode
+     * @param DocumentNumber $documentNumber
+     * @param bool $identityVerified
+     * @param SecondFactorTypeService $secondFactorTypeService
      * @return void
-     * @throws DomainException
      */
     public function vetSecondFactor(
         Identity $registrant,
@@ -164,7 +165,8 @@ interface Identity extends AggregateRoot
         SecondFactorIdentifier $registrantsSecondFactorIdentifier,
         $registrationCode,
         DocumentNumber $documentNumber,
-        $identityVerified
+        $identityVerified,
+        SecondFactorTypeService $secondFactorTypeService
     );
 
     /**

--- a/src/Surfnet/Stepup/Identity/Entity/AbstractSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/AbstractSecondFactor.php
@@ -33,9 +33,4 @@ abstract class AbstractSecondFactor extends EventSourcedEntity implements Second
     {
         return $service->hasEqualOrLowerLoaComparedTo($this->getType(), $type);
     }
-
-    /**
-     * @return SecondFactorType
-     */
-    abstract protected function getType();
 }

--- a/src/Surfnet/Stepup/Identity/Entity/AbstractSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/AbstractSecondFactor.php
@@ -19,18 +19,19 @@
 namespace Surfnet\Stepup\Identity\Entity;
 
 use Broadway\EventSourcing\EventSourcedEntity;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 abstract class AbstractSecondFactor extends EventSourcedEntity implements SecondFactor
 {
-    public function hasEqualOrHigherLoaComparedTo(SecondFactor $comparable)
+    public function hasEqualOrHigherLoaComparedTo(SecondFactor $comparable, SecondFactorTypeService $service)
     {
-        return $comparable->hasTypeWithEqualOrLowerLoaComparedTo($this->getType());
+        return $comparable->hasTypeWithEqualOrLowerLoaComparedTo($this->getType(), $service);
     }
 
-    public function hasTypeWithEqualOrLowerLoaComparedTo(SecondFactorType $type)
+    public function hasTypeWithEqualOrLowerLoaComparedTo(SecondFactorType $type, SecondFactorTypeService $service)
     {
-        return $this->getType()->hasEqualOrLowerLoaComparedTo($type);
+        return $service->hasEqualOrLowerLoaComparedTo($this->getType(), $type);
     }
 
     /**

--- a/src/Surfnet/Stepup/Identity/Entity/SecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/SecondFactor.php
@@ -36,4 +36,10 @@ interface SecondFactor
      * @return bool
      */
     public function hasTypeWithEqualOrLowerLoaComparedTo(SecondFactorType $type, SecondFactorTypeService $service);
+
+    /**
+     * @return SecondFactorType
+     */
+    public function getType();
+
 }

--- a/src/Surfnet/Stepup/Identity/Entity/SecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/SecondFactor.php
@@ -18,19 +18,22 @@
 
 namespace Surfnet\Stepup\Identity\Entity;
 
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 interface SecondFactor
 {
     /**
      * @param SecondFactor $comparable
+     * @param SecondFactorTypeService $service
      * @return bool
      */
-    public function hasEqualOrHigherLoaComparedTo(SecondFactor $comparable);
+    public function hasEqualOrHigherLoaComparedTo(SecondFactor $comparable, SecondFactorTypeService $service);
 
     /**
      * @param SecondFactorType $type
+     * @param SecondFactorTypeService $service
      * @return bool
      */
-    public function hasTypeWithEqualOrLowerLoaComparedTo(SecondFactorType $type);
+    public function hasTypeWithEqualOrLowerLoaComparedTo(SecondFactorType $type, SecondFactorTypeService $service);
 }

--- a/src/Surfnet/Stepup/Identity/Entity/SecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/SecondFactor.php
@@ -41,5 +41,4 @@ interface SecondFactor
      * @return SecondFactorType
      */
     public function getType();
-
 }

--- a/src/Surfnet/Stepup/Identity/Entity/SecondFactorCollection.php
+++ b/src/Surfnet/Stepup/Identity/Entity/SecondFactorCollection.php
@@ -19,18 +19,20 @@
 namespace Surfnet\Stepup\Identity\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 
 final class SecondFactorCollection extends ArrayCollection
 {
     /**
-     * @return SecondFactor|null
+     * @param SecondFactorTypeService $service
+     * @return null|SecondFactor
      */
-    public function getSecondFactorWithHighestLoa()
+    public function getSecondFactorWithHighestLoa(SecondFactorTypeService $service)
     {
         return array_reduce(
             $this->toArray(),
-            function (SecondFactor $carry, SecondFactor $item) {
-                return $carry->hasEqualOrHigherLoaComparedTo($item) ? $carry : $item;
+            function (SecondFactor $carry, SecondFactor $item) use ($service) {
+                return $service->hasEqualOrHigherLoaComparedTo($carry, $item->getType()) ? $carry : $item;
             },
             $this->first() ?: null
         );

--- a/src/Surfnet/Stepup/Identity/Entity/SecondFactorCollection.php
+++ b/src/Surfnet/Stepup/Identity/Entity/SecondFactorCollection.php
@@ -32,7 +32,7 @@ final class SecondFactorCollection extends ArrayCollection
         return array_reduce(
             $this->toArray(),
             function (SecondFactor $carry, SecondFactor $item) use ($service) {
-                return $service->hasEqualOrHigherLoaComparedTo($carry, $item->getType()) ? $carry : $item;
+                return $service->hasEqualOrHigherLoaComparedTo($carry->getType(), $item->getType()) ? $carry : $item;
             },
             $this->first() ?: null
         );

--- a/src/Surfnet/Stepup/Identity/Entity/UnverifiedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/UnverifiedSecondFactor.php
@@ -204,7 +204,7 @@ class UnverifiedSecondFactor extends AbstractSecondFactor
         $this->secondFactorIdentifier = $secondFactorIdentifierClass::unknown();
     }
 
-    protected function getType()
+    public function getType()
     {
         return $this->type;
     }

--- a/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
@@ -191,7 +191,7 @@ class VerifiedSecondFactor extends AbstractSecondFactor
         $this->secondFactorIdentifier = $secondFactorIdentifierClass::unknown();
     }
 
-    protected function getType()
+    public function getType()
     {
         return $this->type;
     }

--- a/src/Surfnet/Stepup/Identity/Entity/VettedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VettedSecondFactor.php
@@ -122,7 +122,7 @@ class VettedSecondFactor extends AbstractSecondFactor
         $this->secondFactorIdentifier = $secondFactorIdentifierClass::unknown();
     }
 
-    protected function getType()
+    public function getType()
     {
         return $this->type;
     }

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/AllowedSecondFactorListTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/AllowedSecondFactorListTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\Stepup\Tests\Configuration\Value;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 class AllowedSecondFactorListTest extends TestCase
@@ -222,10 +223,14 @@ class AllowedSecondFactorListTest extends TestCase
 
     public function availableSecondFactorTypeProvider()
     {
+        $service = new SecondFactorTypeService([
+            'biometric' => ['loa' => 3],
+            'tiqr' => ['loa' => 3],
+        ]);
         $secondFactorTypes = array_map(function ($availableSecondFactorType) {
             return [new SecondFactorType($availableSecondFactorType)];
-        }, SecondFactorType::getAvailableSecondFactorTypes());
+        }, $service->getAvailableSecondFactorTypes());
 
-        return array_combine(SecondFactorType::getAvailableSecondFactorTypes(), $secondFactorTypes);
+        return array_combine($service->getAvailableSecondFactorTypes(), $secondFactorTypes);
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
@@ -38,6 +38,7 @@ use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
 use Surfnet\Stepup\Identity\Value\StepupProvider;
 use Surfnet\Stepup\Identity\Value\U2fKeyHandle;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\AllowedSecondFactorListService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository;
@@ -84,22 +85,28 @@ class IdentityCommandHandler extends CommandHandler
      */
     private $allowedSecondFactorListService;
 
+    /** @var SecondFactorTypeService */
+    private $secondFactorTypeService;
+
     /**
      * @param RepositoryInterface            $eventSourcedRepository
      * @param IdentityRepository             $identityProjectionRepository
      * @param ConfigurableSettings           $configurableSettings
      * @param AllowedSecondFactorListService $allowedSecondFactorListService
+     * @param SecondFactorTypeService        $secondFactorTypeService
      */
     public function __construct(
         RepositoryInterface $eventSourcedRepository,
         IdentityRepository $identityProjectionRepository,
         ConfigurableSettings $configurableSettings,
-        AllowedSecondFactorListService $allowedSecondFactorListService
+        AllowedSecondFactorListService $allowedSecondFactorListService,
+        SecondFactorTypeService $secondFactorTypeService
     ) {
         $this->eventSourcedRepository = $eventSourcedRepository;
         $this->identityProjectionRepository = $identityProjectionRepository;
         $this->configurableSettings = $configurableSettings;
         $this->allowedSecondFactorListService = $allowedSecondFactorListService;
+        $this->secondFactorTypeService = $secondFactorTypeService;
     }
 
     public function handleCreateIdentityCommand(CreateIdentityCommand $command)
@@ -265,7 +272,8 @@ class IdentityCommandHandler extends CommandHandler
             $secondFactorIdentifier,
             $command->registrationCode,
             new DocumentNumber($command->documentNumber),
-            $command->identityVerified
+            $command->identityVerified,
+            $this->secondFactorTypeService
         );
 
         $this->eventSourcedRepository->save($authority);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
@@ -6,6 +6,7 @@ services:
             - @surfnet_stepup_middleware_api.repository.identity
             - @identity.entity.configurable_settings
             - @surfnet_stepup_middleware_api.service.allowed_second_factor_list
+            - @surfnet_stepup.service.second_factor_type
         tags: [{ name: command_bus.command_handler }]
 
     surfnet_stepup_middleware_command_handling.command_handler.registration_authority_command_handler:

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -53,6 +53,7 @@ use Surfnet\Stepup\Identity\Value\StepupProvider;
 use Surfnet\Stepup\Identity\Value\TimeFrame;
 use Surfnet\Stepup\Identity\Value\U2fKeyHandle;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\AllowedSecondFactorListService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as IdentityProjectionRepository;
@@ -89,6 +90,11 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      */
     private $identityProjectionRepository;
 
+    /**
+     * @var SecondFactorTypeService
+     */
+    private $secondFactorTypeService;
+
     public function setUp()
     {
         $this->allowedSecondFactorListServiceMock = m::mock(AllowedSecondFactorListService::class);
@@ -100,7 +106,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $aggregateFactory = new PublicConstructorAggregateFactory();
 
         $this->identityProjectionRepository = m::mock(IdentityProjectionRepository::class);
-
+        $this->secondFactorTypeService = m::mock(SecondFactorTypeService::class);
+        $this->secondFactorTypeService->shouldIgnoreMissing();
         return new IdentityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
@@ -109,7 +116,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
             ),
             $this->identityProjectionRepository,
             ConfigurableSettings::create(self::$window, ['nl_NL', 'en_GB']),
-            $this->allowedSecondFactorListServiceMock
+            $this->allowedSecondFactorListServiceMock,
+            $this->secondFactorTypeService
         );
     }
 
@@ -1124,6 +1132,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $registrantSecFacId          = new SecondFactorId('ISFID');
         $registrantSecFacIdentifier  = new YubikeyPublicId('00028278');
 
+        $this->secondFactorTypeService->shouldReceive('hasEqualOrLowerLoaComparedTo')->andReturn(true);
+
         $this->scenario
             ->withAggregateId($authorityId)
             ->given([
@@ -1233,6 +1243,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $registrantCommonName        = new CommonName('Reginald Waterloo');
         $registrantSecFacId          = new SecondFactorId('ISFID');
         $registrantPubId             = new YubikeyPublicId('00028278');
+
+        $this->secondFactorTypeService->shouldReceive('hasEqualOrLowerLoaComparedTo')->andReturn(false);
 
         $this->scenario
             ->withAggregateId($authorityId)

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -47,6 +47,7 @@ use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\TimeFrame;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\AllowedSecondFactorListService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as IdentityProjectionRepository;
@@ -65,7 +66,8 @@ class SecondFactorRevocationTest extends CommandHandlerTest
     protected function createCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus)
     {
         $aggregateFactory = new PublicConstructorAggregateFactory();
-
+        $service = m::mock(SecondFactorTypeService::class);
+        $service->shouldIgnoreMissing();
         return new IdentityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
@@ -74,7 +76,8 @@ class SecondFactorRevocationTest extends CommandHandlerTest
             ),
             m::mock(IdentityProjectionRepository::class),
             ConfigurableSettings::create(self::$window, []),
-            m::mock(AllowedSecondFactorListService::class)
+            m::mock(AllowedSecondFactorListService::class),
+            $service
         );
     }
 

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
@@ -32,6 +32,7 @@ services:
         class: Surfnet\StepupMiddleware\ManagementBundle\Validator\ReconfigureInstitutionRequestValidator
         arguments:
             - "@surfnet_stepup_middleware_api.service.configured_institutions"
+            - "@surfnet_stepup.service.second_factor_type"
         tags:
             - { name: validator.constraint_validator, alias: reconfigure_institution_configuration_structure_validator }
 

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ManagementBundle\Tests\Validator;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\ConfiguredInstitution;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\ConfiguredInstitutionService;
 use Surfnet\StepupMiddleware\ManagementBundle\Validator\Constraints\ValidReconfigureInstitutionsRequest;
@@ -77,8 +78,13 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
         $context = Mockery::mock('Symfony\Component\Validator\Context\ExecutionContextInterface');
         $context->shouldReceive('buildViolation')->with(self::spy($actualErrorMessage))->once()->andReturn($builder);
 
+        $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
+        $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
 
-        $validator = new ReconfigureInstitutionRequestValidator($configuredInstitutionServiceMock);
+        $validator = new ReconfigureInstitutionRequestValidator(
+            $configuredInstitutionServiceMock,
+            $secondFactorTypeServiceMock
+        );
         $validator->initialize($context);
         $validator->validate($reconfigureRequest, new ValidReconfigureInstitutionsRequest);
 
@@ -122,7 +128,13 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
             ->shouldReceive('getAll')
             ->andReturn($existingInstitutions);
 
-        $validator = new ReconfigureInstitutionRequestValidator($configuredInstitutionServiceMock);
+        $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
+        $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
+
+        $validator = new ReconfigureInstitutionRequestValidator(
+            $configuredInstitutionServiceMock,
+            $secondFactorTypeServiceMock
+        );
         $validator->initialize($context);
         
         $validator->validate($invalidRequest, new ValidReconfigureInstitutionsRequest);
@@ -157,8 +169,13 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
         $configuredInstitutionServiceMock
             ->shouldReceive('getAll')
             ->andReturn($existingInstitutions);
+        $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
+        $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
 
-        $validator = new ReconfigureInstitutionRequestValidator($configuredInstitutionServiceMock);
+        $validator = new ReconfigureInstitutionRequestValidator(
+            $configuredInstitutionServiceMock,
+            $secondFactorTypeServiceMock
+        );
         $validator->initialize($context);
 
         $validator->validate($invalidRequest, new ValidReconfigureInstitutionsRequest);
@@ -189,7 +206,13 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
         $context = Mockery::mock(ExecutionContextInterface::class);
         $context->shouldNotReceive('buildViolation');
 
-        $validator = new ReconfigureInstitutionRequestValidator($configuredInstitutionServiceMock);
+        $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
+        $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
+
+        $validator = new ReconfigureInstitutionRequestValidator(
+            $configuredInstitutionServiceMock,
+            $secondFactorTypeServiceMock
+        );
         $validator->initialize($context);
         $validator->validate($validRequest, new ValidReconfigureInstitutionsRequest);
     }

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ManagementBundle\Validator;
 use Assert\Assertion;
 use Assert\InvalidArgumentException as AssertionException;
 use InvalidArgumentException as CoreInvalidArgumentException;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\ConfiguredInstitution;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\ConfiguredInstitutionService;
@@ -41,9 +42,17 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
      */
     private $configuredInstitutions;
 
-    public function __construct(ConfiguredInstitutionService $configuredInstitutionsService)
-    {
+    /**
+     * @var SecondFactorTypeService
+     */
+    private $secondFactorTypeService;
+
+    public function __construct(
+        ConfiguredInstitutionService $configuredInstitutionsService,
+        SecondFactorTypeService $secondFactorTypeService
+    ) {
         $this->configuredInstitutionsService = $configuredInstitutionsService;
+        $this->secondFactorTypeService = $secondFactorTypeService;
     }
 
     public function validate($value, Constraint $constraint)
@@ -134,7 +143,7 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
         );
         Assertion::allInArray(
             $options['allowed_second_factors'],
-            SecondFactorType::getAvailableSecondFactorTypes(),
+            $this->secondFactorTypeService->getAvailableSecondFactorTypes(),
             'Option "allowed_second_factors" for "%s" must contain valid second factor types',
             $propertyPath
         );

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/DependencyInjection/Configuration.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/DependencyInjection/Configuration.php
@@ -42,6 +42,15 @@ class Configuration implements ConfigurationInterface
                             )
                         ->end()
                     ->end()
+                    ->arrayNode('enabled_generic_second_factors')
+                        ->isRequired()
+                        ->prototype('array')
+                        ->children()
+                            ->scalarNode('loa')
+                            ->isRequired()
+                            ->info('The lao level of the Gssf')
+                        ->end()
+                    ->end()
                 ->end();
 
         return $treeBuilder;

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/DependencyInjection/SurfnetStepupMiddlewareMiddlewareExtension.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/DependencyInjection/SurfnetStepupMiddlewareMiddlewareExtension.php
@@ -42,5 +42,10 @@ class SurfnetStepupMiddlewareMiddlewareExtension extends Extension
             ->setArguments([$config['email_verification_window'], $container->getParameter('locales')]);
 
         $container->setDefinition('identity.entity.configurable_settings', $definition);
+
+        $container->setParameter(
+            'middleware.enabled_generic_second_factors',
+            $config['enabled_generic_second_factors']
+        );
     }
 }


### PR DESCRIPTION
This pull request is the middleware portion of making the generic second factors configurable through YML configuration. To do so, a service was introduced that reads the gssf configuration and helps the application with LOA related queries on a SecondFactorType value object.

This pull request is related to this [story](https://www.pivotaltracker.com/story/show/144698955)