### PR TITLE
Allow registration of multiple tokens

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -53,3 +53,5 @@ parameters:
             loa: 3
         tiqr:
             loa: 3
+    # Sets the number of tokens allowed for each identity
+    number_of_tokens_per_identity: 3

--- a/src/Surfnet/Stepup/Identity/Api/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Api/Identity.php
@@ -285,4 +285,9 @@ interface Identity extends AggregateRoot
      *     require the IdentityId VO in our SensitiveDataEventStoreDecorator.
      */
     public function getAggregateRootId();
+
+    /**
+     * @param int $numberOfTokens
+     */
+    public function setMaxNumberOfTokens($numberOfTokens);
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
@@ -7,6 +7,7 @@ services:
             - @identity.entity.configurable_settings
             - @surfnet_stepup_middleware_api.service.allowed_second_factor_list
             - @surfnet_stepup.service.second_factor_type
+            - %number_of_tokens_per_identity%
         tags: [{ name: command_bus.command_handler }]
 
     surfnet_stepup_middleware_command_handling.command_handler.registration_authority_command_handler:

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -117,7 +117,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
             $this->identityProjectionRepository,
             ConfigurableSettings::create(self::$window, ['nl_NL', 'en_GB']),
             $this->allowedSecondFactorListServiceMock,
-            $this->secondFactorTypeService
+            $this->secondFactorTypeService,
+            1
         );
     }
 
@@ -311,7 +312,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      */
     public function yubikey_possession_cannot_be_proven_twice()
     {
-        $this->setExpectedException('Surfnet\Stepup\Exception\DomainException', 'more than one token');
+        $this->setExpectedException('Surfnet\Stepup\Exception\DomainException', 'more than 1 token(s)');
 
         $id                = new IdentityId(self::uuid());
         $institution       = new Institution('A Corp.');
@@ -703,7 +704,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      */
     public function phone_possession_cannot_be_proven_twice()
     {
-        $this->setExpectedException('Surfnet\Stepup\Exception\DomainException', 'more than one token');
+        $this->setExpectedException('Surfnet\Stepup\Exception\DomainException', 'more than 1 token(s)');
 
         $id                = new IdentityId(self::uuid());
         $institution       = new Institution('A Corp.');
@@ -758,7 +759,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
      */
     public function cannot_prove_possession_of_arbitrary_second_factor_type_twice()
     {
-        $this->setExpectedException('Surfnet\Stepup\Exception\DomainException', 'more than one token');
+        $this->setExpectedException('Surfnet\Stepup\Exception\DomainException', 'more than 1 token(s)');
 
         $id                = new IdentityId(self::uuid());
         $institution       = new Institution('A Corp.');

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -77,7 +77,8 @@ class SecondFactorRevocationTest extends CommandHandlerTest
             m::mock(IdentityProjectionRepository::class),
             ConfigurableSettings::create(self::$window, []),
             m::mock(AllowedSecondFactorListService::class),
-            $service
+            $service,
+            1
         );
     }
 


### PR DESCRIPTION
**Review notes**
A config parameter can be set to indicate the maximum number of tokens
allowed for each identity. The IdentityCommandHandler sets this value
on the identity instance. This in turn allows the identity instance to
validate whether or not the requested additional token is allowed or
not.

A sensible default was set in the parameters.yml.dist file.

**Tasks**
 - [x] Travis build is passing
 - [x] Updated documentation
 - [x] Updated pivotal tracker
 - [x] Wrote appropriate tests

This PR is part of a series of changes in [SS](https://github.com/OpenConext/Stepup-SelfService/pull/127), [MW](https://github.com/OpenConext/Stepup-Middleware/pull/199) and [GW](https://github.com/OpenConext/Stepup-Gateway/pull/123).

For more information about the changes see [Pivotal](https://www.pivotaltracker.com/story/show/144697285) and the updated [docs](https://github.com/OpenConext/Stepup-Deploy/wiki/API-Design).