### PR TITLE
Remember registration request date in verified SF projections

### DIFF
--- a/app/DoctrineMigrations/Version20171113123232.php
+++ b/app/DoctrineMigrations/Version20171113123232.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171113123232 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE verified_second_factor ADD registration_requested_at DATETIME NOT NULL');
+        $this->addSql('UPDATE verified_second_factor SET registration_requested_at = NOW()');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE verified_second_factor DROP registration_requested_at');
+    }
+}

--- a/src/Surfnet/Stepup/DateTime/DateTime.php
+++ b/src/Surfnet/Stepup/DateTime/DateTime.php
@@ -106,6 +106,17 @@ class DateTime
     }
 
     /**
+     * @return DateTime
+     */
+    public function endOfDay()
+    {
+        $dateTime = clone $this->dateTime;
+        $dateTime->setTime(23, 59, 59);
+
+        return new self($dateTime);
+    }
+
+    /**
      * @param DateTime $dateTime
      * @return boolean
      */

--- a/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
@@ -123,7 +123,11 @@ class VerifiedSecondFactor extends AbstractSecondFactor
      */
     public function canBeVettedNow()
     {
-        return !DateTime::now()->comesAfter($this->registrationRequestedAt->add(new \DateInterval('P14D')));
+        return !DateTime::now()->comesAfter(
+            $this->registrationRequestedAt
+                ->add(new \DateInterval('P14D'))
+                ->endOfDay()
+        );
     }
 
     public function vet(DocumentNumber $documentNumber)

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/VerifiedSecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/VerifiedSecondFactor.php
@@ -77,6 +77,13 @@ class VerifiedSecondFactor implements \JsonSerializable
      */
     public $registrationCode;
 
+    /**
+     * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
+     */
+    public $registrationRequestedAt;
+
     public function jsonSerialize()
     {
         return [
@@ -84,6 +91,7 @@ class VerifiedSecondFactor implements \JsonSerializable
             'type' => $this->type,
             'second_factor_identifier' => $this->secondFactorIdentifier,
             'registration_code' => $this->registrationCode,
+            'registration_requested_at' => $this->registrationRequestedAt->format('c'),
             'identity_id' => $this->identityId,
             'institution' => $this->institution,
             'common_name' => $this->commonName,

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/SecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/SecondFactorProjector.php
@@ -150,6 +150,7 @@ class SecondFactorProjector extends Projector
         $verified->type = $event->secondFactorType->getSecondFactorType();
         $verified->secondFactorIdentifier = $unverified->secondFactorIdentifier;
         $verified->registrationCode = $event->registrationCode;
+        $verified->registrationRequestedAt = $event->registrationRequestedAt;
 
         $this->verifiedRepository->save($verified);
         $this->unverifiedRepository->remove($unverified);


### PR DESCRIPTION
This change is required for RA to show expiration errors when looking
up verified registration codes.

See: https://www.pivotaltracker.com/story/show/133928873