### PR TITLE
Update default config parameter template

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -53,3 +53,6 @@ parameters:
             loa: 3
         tiqr:
             loa: 3
+
+    # The maximum number of tokens each identity (person) can register.
+    number_of_tokens_per_identity: 2


### PR DESCRIPTION
The 'number_of_tokens_per_identity' config parameter was not yet added
as a default config param. 2 is set as the default value.