### PR TITLE
Do not validate SecondFactorTypes in Command

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/ReconfigureInstitutionConfigurationOptionsCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/ReconfigureInstitutionConfigurationOptionsCommand.php
@@ -48,12 +48,6 @@ final class ReconfigureInstitutionConfigurationOptionsCommand extends AbstractCo
 
     /**
      * @Assert\NotNull()
-     * @Assert\All({
-     *     @Assert\Choice(
-     *         callback={"Surfnet\StepupBundle\Value\SecondFactorType", "getAvailableSecondFactorTypes"},
-     *         message="may only contain supported second factor types"
-     *     )
-     * })
      */
     public $allowedSecondFactors;
 }


### PR DESCRIPTION
**More information**
See commit message for detailed information about the bugfix

**Test instructions**
This can be tested by running the `/management/institution-configuration` api call (can be called from postman). 

I've tested with the following body:

```
{
    "dev.organisation.example": {
        "use_ra_locations": true, 
        "show_raa_contact_information": true,
        "allowed_second_factors": ["yubikey", "tiqr", "non-existing-token"]
    }
}
```

This no longer returns the Symfony 500 error but shows a nicer application error message:

```
{
    "errors": [
        "Institution(dev.organisation.example): Option \"allowed_second_factors\" for \"non-existing-token\" must contain valid second factor types"
    ]
}
```