### PR TITLE
Stop using the isGssf method on SecondFactorType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "jms/di-extra-bundle": "~1.5",
         "jms/aop-bundle": "~1.0",
         "ramsey/uuid": "^2.9",
-        "surfnet/stepup-bundle": "^2.0"
+        "surfnet/stepup-bundle": "^3.0"
     },
     "require-dev": {
         "liip/rmt": "1.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2f4a4edb960d60c0d63e4a361e9cf7f",
+    "content-hash": "69de406d200a9761df50a4969882f1a0",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2373,16 +2373,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "0766c91a6b391739d9fe4693f684ef1332342df4"
+                "reference": "4564d2b468a9a9a0bcfa6356e055aacbd3c4e4f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/0766c91a6b391739d9fe4693f684ef1332342df4",
-                "reference": "0766c91a6b391739d9fe4693f684ef1332342df4",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/4564d2b468a9a9a0bcfa6356e055aacbd3c4e4f0",
+                "reference": "4564d2b468a9a9a0bcfa6356e055aacbd3c4e4f0",
                 "shasum": ""
             },
             "require": {
@@ -2426,7 +2426,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2017-06-14T13:03:51+00:00"
+            "time": "2017-11-30T07:47:43+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Surfnet/Stepup/Identity/Value/SecondFactorIdentifierFactory.php
+++ b/src/Surfnet/Stepup/Identity/Value/SecondFactorIdentifierFactory.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\Stepup\Identity\Value;
 
-use Surfnet\Stepup\Exception\LogicException;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 final class SecondFactorIdentifierFactory
@@ -38,15 +37,11 @@ final class SecondFactorIdentifierFactory
             return new YubikeyPublicId($secondFactorIdentifier);
         }
 
-        if ($type->isGssf()) {
-            return new GssfId($secondFactorIdentifier);
-        }
-
         if ($type->isU2f()) {
             return new U2fKeyHandle($secondFactorIdentifier);
         }
-
-        throw new LogicException(sprintf('Unknown second factor type "%s" encountered', $type->getSecondFactorType()));
+        // Assume the SecondFactorType is gssf if it isn't one of the specified types.
+        return new GssfId($secondFactorIdentifier);
     }
 
     /**
@@ -63,14 +58,10 @@ final class SecondFactorIdentifierFactory
             return YubikeyPublicId::unknown();
         }
 
-        if ($type->isGssf()) {
-            return GssfId::unknown();
-        }
-
         if ($type->isU2f()) {
             return U2fKeyHandle::unknown();
         }
-
-        throw new LogicException(sprintf('Unknown second factor type "%s" encountered', $type->getSecondFactorType()));
+        // Assume the SecondFactorType is gssf if it isn't one of the specified types.
+        return GssfId::unknown();
     }
 }


### PR DESCRIPTION
This PR adresses the problem described in this [pivotal bug](https://www.pivotaltracker.com/story/show/153250034) The 'proposed' solution of injecting the SFTypeService was dropped in favor of a more pragmatic solution. 

In this solution I assume the SF Type is GSSF if none of the other types are valid. This might pass along an invalid Gssf type but this will be checked later on in the code. 