### PR TITLE
Move monitor entry up in firewall config

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -3,13 +3,13 @@ security:
         dev:
             pattern: ^/_trans(/|$)
             security: false
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
         api:
             http_basic: ~
             entry_point: surfnet_stepup_middleware_api.security.json_basic_auth_entry_point
             stateless:  true
-        monitor:
-            pattern: ^/(info|health)$
-            security: false
 
     access_control:
         - { path: ^/management, roles: [ROLE_MANAGEMENT] } # can be expanded with hosts: or ip:


### PR DESCRIPTION
The firewall security config is changed slightly. The monitor entry was
moved one level up to prevent it from being affected by the api entry.

In effect this change ensures the api authentication mechanism is not
triggered on the health and info endpoint.