### PR TITLE
Update translation bundle to new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 !app/logs/.gitkeep
 /build/
 /vendor/
-/bin
 /composer.phar
 /cache.properties
 /app/SymfonyRequirements.php

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-15T16:48:43Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-01-22T13:49:52Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,33 +9,33 @@
       <trans-unit id="39fa7a2a290c8ead04a3f657443b7bc99549008f" resname="mw.mail.second_factor_revoked.subject">
         <source>mw.mail.second_factor_revoked.subject</source>
         <target>Your %tokenType% token was revoked</target>
-        <jms:reference-file line="118">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
-        <jms:reference-file line="174">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
+        <jms:reference-file line="118">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
+        <jms:reference-file line="174">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4ecaec491b38e8084eeaa53a7e5479a7714feb2" resname="ss.mail.email_verification_email.subject">
         <source>ss.mail.email_verification_email.subject</source>
         <target>Token registration: confirm your e-mail address</target>
-        <jms:reference-file line="101">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php</jms:reference-file>
-        <jms:reference-file line="1">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="101">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php</jms:reference-file>
+        <jms:reference-file line="1">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ddb12f14d7aee72840d8a71af5a6547ab9864da" resname="ss.mail.registration_email.subject">
         <source>ss.mail.registration_email.subject</source>
         <target>Token activation: activate your token</target>
-        <jms:reference-file line="180">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
-        <jms:reference-file line="228">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
-        <jms:reference-file line="103">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
-        <jms:reference-file line="157">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
-        <jms:reference-file line="2">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="106">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
+        <jms:reference-file line="163">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
+        <jms:reference-file line="2">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="180">/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
+        <jms:reference-file line="228">/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc0cc8035d5d7f5a4dc2d97d93db8b8ec9afacdc" resname="ss.mail.registration_reminder_email.subject">
         <source>ss.mail.registration_reminder_email.subject</source>
         <target>Token activation reminder: activate your token</target>
-        <jms:reference-file line="3">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="3">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1bfca8c7eb070f6654283560765b55c8ffa07200" resname="ss.mail.vetted_email.subject">
         <source>ss.mail.vetted_email.subject</source>
         <target>Token ready to use - authentication in two steps</target>
-        <jms:reference-file line="103">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php</jms:reference-file>
+        <jms:reference-file line="103">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-15T16:48:39Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-01-22T13:49:45Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -8,35 +8,35 @@
     <body>
       <trans-unit id="39fa7a2a290c8ead04a3f657443b7bc99549008f" resname="mw.mail.second_factor_revoked.subject">
         <source>mw.mail.second_factor_revoked.subject</source>
-        <target>Je %tokenType% token is ingetrokken
+        <target xml:space="preserve">Je %tokenType% token is ingetrokken
         </target>
-        <jms:reference-file line="118">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
-        <jms:reference-file line="174">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
+        <jms:reference-file line="118">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
+        <jms:reference-file line="174">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4ecaec491b38e8084eeaa53a7e5479a7714feb2" resname="ss.mail.email_verification_email.subject">
         <source>ss.mail.email_verification_email.subject</source>
         <target>Token registratie: bevestig je e-mailadres</target>
-        <jms:reference-file line="101">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php</jms:reference-file>
-        <jms:reference-file line="1">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="101">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php</jms:reference-file>
+        <jms:reference-file line="1">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ddb12f14d7aee72840d8a71af5a6547ab9864da" resname="ss.mail.registration_email.subject">
         <source>ss.mail.registration_email.subject</source>
         <target>Token activatie: activeer je token</target>
-        <jms:reference-file line="180">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
-        <jms:reference-file line="228">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
-        <jms:reference-file line="103">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
-        <jms:reference-file line="157">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
-        <jms:reference-file line="2">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="106">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
+        <jms:reference-file line="163">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php</jms:reference-file>
+        <jms:reference-file line="2">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="180">/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
+        <jms:reference-file line="228">/../src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc0cc8035d5d7f5a4dc2d97d93db8b8ec9afacdc" resname="ss.mail.registration_reminder_email.subject">
         <source>ss.mail.registration_reminder_email.subject</source>
         <target>Token activatie herinnering: activeer je token</target>
-        <jms:reference-file line="3">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="3">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1bfca8c7eb070f6654283560765b55c8ffa07200" resname="ss.mail.vetted_email.subject">
         <source>ss.mail.vetted_email.subject</source>
         <target>Token klaar voor gebruik - inloggen in twee stappen</target>
-        <jms:reference-file line="103">/var/www/mw-dev.stepup.coin.surf.net/app/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php</jms:reference-file>
+        <jms:reference-file line="103">/../src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/bin/extract-translations.sh
+++ b/bin/extract-translations.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+app/console translation:extract --config=default --env=dev

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "broadway/broadway": "~0.5.0",
         "pagerfanta/pagerfanta": "~1.0",
         "sensio/generator-bundle": "~2.3",
-        "jms/translation-bundle": "~1.1",
+        "jms/translation-bundle": "~1.3",
         "jms/di-extra-bundle": "~1.5",
         "jms/aop-bundle": "~1.0",
         "ramsey/uuid": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "69de406d200a9761df50a4969882f1a0",
+    "content-hash": "523efd52dcbd38bcf88c2853584449f9",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1630,41 +1630,40 @@
         },
         {
             "name": "jms/translation-bundle",
-            "version": "1.2.3",
+            "version": "1.3.2",
             "target-dir": "JMS/TranslationBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/JMSTranslationBundle.git",
-                "reference": "d0d6c7f002e4210217b5f7271a438309d305540a"
+                "reference": "08b8db92aa376b8e50ce4e779e849916abffd805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSTranslationBundle/zipball/d0d6c7f002e4210217b5f7271a438309d305540a",
-                "reference": "d0d6c7f002e4210217b5f7271a438309d305540a",
+                "url": "https://api.github.com/repos/schmittjoh/JMSTranslationBundle/zipball/08b8db92aa376b8e50ce4e779e849916abffd805",
+                "reference": "08b8db92aa376b8e50ce4e779e849916abffd805",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^1.4|^2.0",
-                "php": "^5.3.3|^7.0",
-                "symfony/console": "^2.3|^3.0",
-                "symfony/framework-bundle": "^2.3|^3.0"
-            },
-            "conflict": {
-                "twig/twig": "<1.12"
+                "nikic/php-parser": "^1.4 || ^2.0 || ^3.0",
+                "php": "^5.3.3 || ^7.0",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/framework-bundle": "^2.3 || ^3.0",
+                "twig/twig": "^1.27 || ^2.0"
             },
             "require-dev": {
                 "jms/di-extra-bundle": "^1.1",
                 "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+                "nyholm/nsa": "^1.0.1",
+                "phpunit/phpunit": "4.8.27",
                 "psr/log": "^1.0",
-                "sensio/framework-extra-bundle": "^2.3|^3.0",
-                "symfony/expression-language": "~2.6|~3.0",
-                "symfony/symfony": "^2.3|^3.0",
-                "twig/twig": "^1.12"
+                "sensio/framework-extra-bundle": "^2.3 || ^3.0",
+                "symfony/expression-language": "^2.6 || ^3.0",
+                "symfony/symfony": "^2.3 || ^3.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1694,7 +1693,7 @@
                 "ui",
                 "webinterface"
             ],
-            "time": "2016-05-08T03:48:49+00:00"
+            "time": "2017-04-20T19:44:02+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1828,24 +1827,24 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v2.1.0",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3"
+                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
-                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/579f4ce846734a1cf55d6a531d00ca07a43e3cda",
+                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.4"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.0|~5.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -1853,7 +1852,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1875,7 +1874,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-04-19T13:41:41+00:00"
+            "time": "2017-12-26T14:43:21+00:00"
         },
         {
             "name": "openconext/monitor-bundle",


### PR DESCRIPTION
The previous version of the JMS translation bundle (1.1) did not
support PHP 5.6 which we now require because of the recent changes in
the stepup SAML bundle. This commit updates the translation bundle to
version 1.3, fixing the broken translation:extract command.

The XLIFF files are regenerated because the data in these files are
slightly changed in version 1.3.