### PR TITLE
Add validation on institution SHO

### DIFF
--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_loa_uppercase_institution_sho.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_configuration/invalid_sp_loa_uppercase_institution_sho.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+return [
+    'expectedPropertyPath' => 'gateway.service_providers[0].loa',
+    'configuration'        => [
+        'gateway'         => [
+            'identity_providers' => [],
+            'service_providers'  => [
+                [
+                    "entity_id"                          => "https://entity.tld/id",
+                    "public_key"                         => "MIIE...",
+                    "acs"                                => ["https://entity.tld/consume-assertion"],
+                    "loa"                                => [
+                        "__default__" => 'https://entity.tld/authentication/loa2',
+                        "InstItuTioN" => 'https://entity.tld/authentication/loa3'
+                    ],
+                    "second_factor_only"                 => false,
+                    "second_factor_only_nameid_patterns" => [],
+                    "assertion_encryption_enabled"       => false,
+                    "blacklisted_encryption_algorithms"  => [],
+                ],
+            ],
+        ],
+        'sraa'            => ['20394-4320423-439248324'],
+        'email_templates' => [
+            'confirm_email'                       => ['en_GB' => 'Verify {{ commonName }}'],
+            'registration_code_with_ras'          => ['en_GB' => 'Code {{ commonName }}'],
+            'registration_code_with_ra_locations' => ['en_GB' => 'Code {{ commonName }}'],
+            'vetted'                              => ['en_GB' => 'Vetted {{ commonName }}'],
+            'second_factor_revoked'               => ['en_GB' => 'Revoked token for {{ commonName }}'],
+            'second_factor_verification_reminder_with_ras' => ['en_GB' => 'Code {{ commonName }}'],
+            'second_factor_verification_reminder_with_ra_locations' => ['en_GB' => 'Code {{ commonName }}'],
+        ],
+    ],
+];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ServiceProviderConfigurationValidator.php
@@ -137,6 +137,13 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
         Assertion::isArray($value, 'must be an object', $path);
         Assertion::keyExists($value, '__default__', "must have the default loa set on the '__default__' property", $path);
         Assertion::allString($value, 'all properties must contain strings as values', $path);
+
+        // Test if all SP specific LoA configuration entries are lower case.
+        $this->assertValidInstitutionIdentifiers(
+            $value,
+            'The shacHomeOrganisation names in SP LoA configuration must all be lower case',
+            $path
+        );
     }
 
     /**
@@ -151,5 +158,30 @@ class ServiceProviderConfigurationValidator implements ConfigurationValidatorInt
 
         Assertion::isArray($value, 'must contain an array', $propertyPath);
         Assertion::allString($value, 'must be an array of strings', $propertyPath);
+    }
+
+    /**
+     * All institution names (SHO values) should be lowercase.
+     *
+     * For example:
+     *  [
+     *     '__default__'      => 'loa1', // valid
+     *     'institution-1.nl' => 'loa1', // valid
+     *     'My.Institution'   => 'loa2', // invalid
+     *  ]
+     *
+     * @param array $spLoaConfiguration
+     * @param string $message
+     * @param $propertyPath
+     */
+    private function assertValidInstitutionIdentifiers(array $spLoaConfiguration, $message, $propertyPath)
+    {
+        $assertLowerCase = function ($sho) {
+            return ($sho === strtolower($sho));
+        };
+
+        // The array keys match the institution name / SHO.
+        $lowerCaseTestResults = array_map($assertLowerCase, array_keys($spLoaConfiguration));
+        Assertion::allTrue($lowerCaseTestResults, $message, $propertyPath);
     }
 }


### PR DESCRIPTION
The institution identifier (matching the SHO for authenticating users)
must be set as lower case values. This is validated in the assertion
method that was added to the ServiceProviderConfigurationValidator.