### PR TITLE
Reintroduce the index on second_factors name_id

### DIFF
--- a/app/DoctrineMigrations/Version20180131150800.php
+++ b/app/DoctrineMigrations/Version20180131150800.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Update the Gateway `second_factor` table setting the primary key on the `id` and `identity_id` fields.
+ */
+class Version20180131150800 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $gatewaySchema = $this->getGatewaySchema();
+
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor DROP PRIMARY KEY', $gatewaySchema));
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD PRIMARY KEY (id, identity_id)', $gatewaySchema));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $gatewaySchema = $this->getGatewaySchema();
+
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor DROP PRIMARY KEY', $gatewaySchema));
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD PRIMARY KEY (id)', $gatewaySchema));
+    }
+
+    /**
+     * @return string
+     */
+    private function getGatewaySchema()
+    {
+        return $this->container->getParameter('database_gateway_name');
+    }
+}

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
@@ -22,6 +22,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Rhumsaa\Uuid\Uuid;
 
 /**
+ * WARNING: Any schema change made to this entity should also be applied to the Gateway SecondFactor entity!
+ * @see Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor (in OpenConext/Stepup-Gateway project)
+ *
  * @ORM\Entity(repositoryClass="Surfnet\StepupMiddleware\GatewayBundle\Repository\SecondFactorRepository")
  * @ORM\Table(
  *      indexes={
@@ -43,6 +46,7 @@ class SecondFactor
     /**
      * @var string
      *
+     * @ORM\Id
      * @ORM\Column(length=36)
      */
     private $identityId;


### PR DESCRIPTION
In a not so recent change the second factor entity diverged from its
Gateway counterpart. The Gateway and Middleware schema definition of
this entity should be identical.

Change was introduced in migration: Version20141210174213