### PR TITLE
Stop assuming Tiqr is the only GSSP

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/ProveGssfPossessionCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/ProveGssfPossessionCommand.php
@@ -45,7 +45,9 @@ class ProveGssfPossessionCommand extends AbstractCommand implements SelfServiceE
     public $secondFactorId;
 
     /**
-     * The phone number
+     * The SecondFactorType identifier. 
+     * 
+     * For example in the case of a Tiqr GSSP it would be 'tiqr'.
      *
      * @Assert\NotBlank()
      * @Assert\Type(type="string")
@@ -55,7 +57,7 @@ class ProveGssfPossessionCommand extends AbstractCommand implements SelfServiceE
     public $stepupProvider;
 
     /**
-     * The phone number
+     * The identifier of the generic Stepup second factor type
      *
      * @Assert\NotBlank()
      * @Assert\Type(type="string")

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
@@ -235,14 +235,16 @@ class IdentityCommandHandler extends CommandHandler
         /** @var IdentityApi $identity */
         $identity = $this->eventSourcedRepository->load(new IdentityId($command->identityId));
 
-        // Assume tiqr is being used as it is the only GSSF currently supported
-        $this->assertSecondFactorIsAllowedFor(new SecondFactorType('tiqr'), $identity->getInstitution());
+        $secondFactorType = $command->stepupProvider;
+
+        // Validate that the chosen second factor type (stepupProvider) is allowed for the users instituti
+        $this->assertSecondFactorIsAllowedFor(new SecondFactorType($secondFactorType), $identity->getInstitution());
 
         $identity->setMaxNumberOfTokens($this->numberOfTokensPerIdentity);
 
         $identity->provePossessionOfGssf(
             new SecondFactorId($command->secondFactorId),
-            new StepupProvider($command->stepupProvider),
+            new StepupProvider($secondFactorType),
             new GssfId($command->gssfId),
             $this->emailVerificationIsRequired($identity),
             $this->configurableSettings->createNewEmailVerificationWindow()

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -511,7 +511,15 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
 
         $this->allowedSecondFactorListServiceMock
             ->shouldReceive('getAllowedSecondFactorListFor')
-            ->andReturn(AllowedSecondFactorList::blank());
+            ->andReturn(
+                AllowedSecondFactorList::ofTypes(
+                    [
+                        new SecondFactorType('biometric'),
+                        new SecondFactorType('tiqr'),
+                        new SecondFactorType('anotherGssp'),
+                    ]
+                )
+            );
 
         $command                 = new ProveGssfPossessionCommand();
         $command->identityId     = (string) $identityId;


### PR DESCRIPTION
Now that GSSP tokens can be configured by config, any assumption in the
 code that Tiqr is the only GSSP must be revised. This commit does just
 that for the IdentityCommandHandler.

In addition the ProveGssfPossessionCommand has been updated with a
 correction on the Phpdoc of the $stepupProvider field.