### PR TITLE
Require email verification by default

### DIFF
--- a/app/DoctrineMigrations/Version20180330094402.php
+++ b/app/DoctrineMigrations/Version20180330094402.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180330094402 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE institution_configuration_options CHANGE verify_email_option verify_email_option TINYINT(1) DEFAULT \'1\' NOT NULL');
+        $this->addSql('UPDATE institution_configuration_options SET verify_email_option = 1');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE institution_configuration_options CHANGE verify_email_option verify_email_option TINYINT(1) NOT NULL');
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
@@ -55,7 +55,7 @@ final class InstitutionConfigurationOptions
     public $showRaaContactInformationOption;
 
     /**
-     * @ORM\Column(type="stepup_verify_email_option")
+     * @ORM\Column(type="stepup_verify_email_option", options={"default" : 1})
      *
      * @var VerifyEmailOption
      */


### PR DESCRIPTION
While not intended, email verification was disabled for existing
institutions after upgrading to 2.7.0. Enabling email verification
for those institutions was tricky because the user first has to
'disable' it before it could be enabled again.

This commit fixes the problem by defaulting the column to true,
matching the expectation of underlying code.