### PR TITLE
Allow RA's to register multiple second factor tokens

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -68,7 +68,7 @@ class RaCandidateProjector extends Projector
             $event->email
         );
 
-        $this->raCandidateRepository->save($candidate);
+        $this->raCandidateRepository->merge($candidate);
     }
 
     /**
@@ -85,7 +85,7 @@ class RaCandidateProjector extends Projector
             $event->email
         );
 
-        $this->raCandidateRepository->save($candidate);
+        $this->raCandidateRepository->merge($candidate);
     }
 
     /**
@@ -150,7 +150,7 @@ class RaCandidateProjector extends Projector
             $event->email
         );
 
-        $this->raCandidateRepository->save($candidate);
+        $this->raCandidateRepository->merge($candidate);
     }
 
     protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -31,9 +31,9 @@ class RaCandidateRepository extends EntityRepository
      * @param RaCandidate $raCandidate
      * @return void
      */
-    public function save(RaCandidate $raCandidate)
+    public function merge(RaCandidate $raCandidate)
     {
-        $this->getEntityManager()->persist($raCandidate);
+        $this->getEntityManager()->merge($raCandidate);
         $this->getEntityManager()->flush();
     }
 


### PR DESCRIPTION
Vetting a second second factor token triggered an error because the
'ra_candidate' projection assumed a RA can never have more than one
token. Instead of inserting the ra_candidate, we merge it with a
potential existing ra_candidate entry.