### PR TITLE
Make selfServiceUrl available in mail templates

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/DependencyInjection/SurfnetStepupMiddlewareCommandHandlingExtension.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/DependencyInjection/SurfnetStepupMiddlewareCommandHandlingExtension.php
@@ -48,11 +48,13 @@ class SurfnetStepupMiddlewareCommandHandlingExtension extends Extension
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.email_verification_mail')
             ->replaceArgument(4, $config['self_service_email_verification_url_template'])
-            ->replaceArgument(6, $config['email_fallback_locale']);
+            ->replaceArgument(6, $config['email_fallback_locale'])
+            ->replaceArgument(7, $config['self_service_url']);
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.registration_mail')
-            ->replaceArgument(5, $config['email_fallback_locale']);
+            ->replaceArgument(5, $config['email_fallback_locale'])
+            ->replaceArgument(6, $config['self_service_url']);
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.second_factor_revocation_mail')
@@ -60,7 +62,8 @@ class SurfnetStepupMiddlewareCommandHandlingExtension extends Extension
             ->replaceArgument(6, $config['self_service_url']);
 
         $container
-            ->getDefinition('surfnet_stepup_middleware_command_handling.service.registration_mail')
-            ->replaceArgument(5, $config['email_fallback_locale']);
+            ->getDefinition('surfnet_stepup_middleware_command_handling.service.second_factor_vetted_mail')
+            ->replaceArgument(5, $config['email_fallback_locale'])
+            ->replaceArgument(6, $config['self_service_url']);
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php
@@ -63,6 +63,23 @@ final class EmailVerificationMailService
      */
     private $templateEngine;
 
+    /**
+     * @var string
+     */
+    private $selfServiceUrl;
+
+    /**
+     * @param Mailer $mailer
+     * @param Sender $sender
+     * @param TranslatorInterface $translator
+     * @param EngineInterface $templateEngine
+     * @param string $emailVerificationUrlTemplate
+     * @param EmailTemplateService $emailTemplateService
+     * @param string $fallbackLocale
+     * @param string $selfServiceUrl
+     *
+     * @throws \Assert\AssertionFailedException
+     */
     public function __construct(
         Mailer $mailer,
         Sender $sender,
@@ -70,7 +87,8 @@ final class EmailVerificationMailService
         EngineInterface $templateEngine,
         $emailVerificationUrlTemplate,
         EmailTemplateService $emailTemplateService,
-        $fallbackLocale
+        $fallbackLocale,
+        $selfServiceUrl
     ) {
         Assertion::string(
             $emailVerificationUrlTemplate,
@@ -84,6 +102,7 @@ final class EmailVerificationMailService
         $this->emailVerificationUrlTemplate = $emailVerificationUrlTemplate;
         $this->emailTemplateService = $emailTemplateService;
         $this->fallbackLocale = $fallbackLocale;
+        $this->selfServiceUrl = $selfServiceUrl;
     }
 
     /**
@@ -117,7 +136,8 @@ final class EmailVerificationMailService
             'locale'           => $locale,
             'commonName'       => $commonName,
             'email'            => $email,
-            'verificationUrl'  => $verificationUrl
+            'verificationUrl'  => $verificationUrl,
+            'selfServiceUrl'   => $this->selfServiceUrl,
         ];
 
         // Rendering file template instead of string

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
@@ -62,12 +62,20 @@ final class RegistrationMailService
     private $fallbackLocale;
 
     /**
+     * @var string
+     */
+    private $selfServiceUrl;
+
+    /**
      * @param Mailer $mailer
      * @param Sender $sender
      * @param TranslatorInterface $translator
      * @param EngineInterface $templateEngine
      * @param EmailTemplateService $emailTemplateService
      * @param string $fallbackLocale
+     * @param $selfServiceUrl
+     *
+     * @throws \Assert\AssertionFailedException
      */
     public function __construct(
         Mailer $mailer,
@@ -75,7 +83,8 @@ final class RegistrationMailService
         TranslatorInterface $translator,
         EngineInterface $templateEngine,
         EmailTemplateService $emailTemplateService,
-        $fallbackLocale
+        $fallbackLocale,
+        $selfServiceUrl
     ) {
         Assertion::string($fallbackLocale, 'Fallback locale "%s" expected to be string, type %s given');
 
@@ -85,6 +94,7 @@ final class RegistrationMailService
         $this->templateEngine = $templateEngine;
         $this->emailTemplateService = $emailTemplateService;
         $this->fallbackLocale = $fallbackLocale;
+        $this->selfServiceUrl = $selfServiceUrl;
     }
 
     /**
@@ -124,6 +134,7 @@ final class RegistrationMailService
             'registrationCode' => $registrationCode,
             'expirationDate'   => $expirationDate,
             'ras'              => $ras,
+            'selfServiceUrl'   => $this->selfServiceUrl,
         ];
 
         // Rendering file template instead of string
@@ -181,6 +192,7 @@ final class RegistrationMailService
             'registrationCode' => $registrationCode,
             'expirationDate'   => $expirationDate,
             'raLocations'      => $raLocations,
+            'selfServiceUrl'   => $this->selfServiceUrl,
         ];
 
         // Rendering file template instead of string

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php
@@ -79,6 +79,8 @@ final class SecondFactorRevocationMailService
      * @param EmailTemplateService $emailTemplateService
      * @param string $fallbackLocale
      * @param string $selfServiceUrl
+     *
+     * @throws \Assert\AssertionFailedException
      */
     public function __construct(
         Mailer $mailer,

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php
@@ -61,6 +61,10 @@ final class SecondFactorVettedMailService
      */
     private $fallbackLocale;
 
+    /**
+     * @var string
+     */
+    private $selfServiceUrl;
 
     /**
      * @param Mailer $mailer
@@ -69,6 +73,8 @@ final class SecondFactorVettedMailService
      * @param EngineInterface $templateEngine
      * @param EmailTemplateService $emailTemplateService
      * @param string $fallbackLocale
+     * @param string $selfServiceUrl
+     * @throws \Assert\AssertionFailedException
      */
     public function __construct(
         Mailer $mailer,
@@ -76,7 +82,8 @@ final class SecondFactorVettedMailService
         TranslatorInterface $translator,
         EngineInterface $templateEngine,
         EmailTemplateService $emailTemplateService,
-        $fallbackLocale
+        $fallbackLocale,
+        $selfServiceUrl
     ) {
         Assertion::string($fallbackLocale, 'Fallback locale "%s" expected to be string, type %s given');
 
@@ -86,9 +93,8 @@ final class SecondFactorVettedMailService
         $this->templateEngine = $templateEngine;
         $this->emailTemplateService = $emailTemplateService;
         $this->fallbackLocale = $fallbackLocale;
+        $this->selfServiceUrl = $selfServiceUrl;
     }
-
-
 
     /**
      * @param Locale     $locale
@@ -112,6 +118,7 @@ final class SecondFactorVettedMailService
             'templateString'   => $emailTemplate->htmlContent,
             'locale'           => $locale->getLocale(),
             'commonName'       => $commonName->getCommonName(),
+            'selfServiceUrl'   => $this->selfServiceUrl,
             'email'            => $email->getEmail(),
         ];
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
@@ -38,6 +38,7 @@ services:
             - "" # Verification URL set in bundle extension
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
+            - "" # Self service url is set in bundle extension
 
     surfnet_stepup_middleware_command_handling.service.registration_mail:
         public: false
@@ -49,6 +50,7 @@ services:
             - "@templating"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
+            - "" # Self service url is set in bundle extension
 
     surfnet_stepup_middleware_command_handling.service.second_factor_revocation_mail:
         public: false
@@ -72,6 +74,7 @@ services:
             - "@templating"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
+            - "" # Self service url is set in bundle extension
 
     surfnet_stepup_middleware_command_handling.email_sender:
         public: false


### PR DESCRIPTION
**Change description**
The `selfServiceUrl` has been made available in the following templates:

 * vetted (SecondFactorVettedMailService)
 * registration_code_with_ras (RegistrationMailService)
 * registration_code_with_ra_locations (RegistrationMailService)
 * confirm_email (EmailVerificationMailService)

**Test instructions**
Post updated `management/configuration` to the middleware API. The mail templates can now all hold the `{{ selfServiceUrl }}` translation parameter.

- The `confirm_email` mail template is sent when the user is presented with the mail confirmation challenge.
- `registration_code_with_ras` / `registration_code_with_ra_locations` is sent at the end of the registration process in SelfService.
- The `vetted` template will be sent after successfull registration at RA. (I was not able to test this situation as Middleware was not cooperative in the vetting process) @jorissteyn can you focus on this specific template? 

**More information**
https://www.pivotaltracker.com/story/show/155428664