### PR TITLE
Always send registration confirmation email

### DIFF
--- a/src/Surfnet/Stepup/Identity/Event/EmailVerifiedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/EmailVerifiedEvent.php
@@ -32,7 +32,7 @@ use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class EmailVerifiedEvent extends IdentityEvent implements Forgettable
+class EmailVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified
 {
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId

--- a/src/Surfnet/Stepup/Identity/Event/GssfPossessionProvenAndVerifiedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/GssfPossessionProvenAndVerifiedEvent.php
@@ -25,13 +25,14 @@ use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\GssfId;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\StepupProvider;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable
+class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified
 {
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
@@ -59,6 +60,11 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
     public $email;
 
     /**
+     * @var \Surfnet\Stepup\Identity\Value\Locale Eg. "en_GB"
+     */
+    public $preferredLocale;
+
+    /**
      * @var \Surfnet\Stepup\DateTime\DateTime
      */
     public $registrationRequestedAt;
@@ -76,8 +82,11 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
      * @param GssfId                  $gssfId
      * @param CommonName              $commonName
      * @param Email                   $email
+     * @param Locale                  $locale
      * @param DateTime                $registrationRequestedAt
      * @param string                  $registrationCode
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         IdentityId $identityId,
@@ -87,6 +96,7 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
         GssfId $gssfId,
         CommonName $commonName,
         Email $email,
+        Locale $locale,
         DateTime $registrationRequestedAt,
         $registrationCode
     ) {
@@ -97,6 +107,7 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
         $this->gssfId                    = $gssfId;
         $this->commonName                = $commonName;
         $this->email                     = $email;
+        $this->preferredLocale           = $locale;
         $this->registrationRequestedAt   = $registrationRequestedAt;
         $this->registrationCode          = $registrationCode;
     }
@@ -115,6 +126,11 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
 
     public static function deserialize(array $data)
     {
+        // BC compatibility for event replay in test-environment only (2.8.0, fixed in 2.8.1)
+        if (!isset($data['preferred_locale'])) {
+            $data['preferred_locale'] = 'en_GB';
+        }
+
         return new self(
             new IdentityId($data['identity_id']),
             new Institution($data['identity_institution']),
@@ -123,6 +139,7 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
             GssfId::unknown(),
             CommonName::unknown(),
             Email::unknown(),
+            new Locale($data['preferred_locale']),
             DateTime::fromString($data['registration_requested_at']),
             (string) $data['registration_code']
         );
@@ -137,6 +154,7 @@ class GssfPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forg
             'stepup_provider'             => (string) $this->stepupProvider,
             'registration_requested_at'   => (string) $this->registrationRequestedAt,
             'registration_code'           => $this->registrationCode,
+            'preferred_locale'            => (string) $this->preferredLocale,
         ];
     }
 

--- a/src/Surfnet/Stepup/Identity/Event/PhonePossessionProvenAndVerifiedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/PhonePossessionProvenAndVerifiedEvent.php
@@ -24,13 +24,14 @@ use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\PhoneNumber;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable
+class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified
 {
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
@@ -53,6 +54,11 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
     public $email;
 
     /**
+     * @var \Surfnet\Stepup\Identity\Value\Locale Eg. "en_GB"
+     */
+    public $preferredLocale;
+
+    /**
      * @var \Surfnet\Stepup\DateTime\DateTime
      */
     public $registrationRequestedAt;
@@ -69,6 +75,7 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
      * @param PhoneNumber $phoneNumber
      * @param CommonName $commonName
      * @param Email $email
+     * @param Locale $locale
      * @param DateTime $registrationRequestedAt
      * @param string $registrationCode
      */
@@ -79,6 +86,7 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
         PhoneNumber $phoneNumber,
         CommonName $commonName,
         Email $email,
+        Locale $locale,
         DateTime $registrationRequestedAt,
         $registrationCode
     ) {
@@ -88,6 +96,7 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
         $this->phoneNumber = $phoneNumber;
         $this->commonName = $commonName;
         $this->email = $email;
+        $this->preferredLocale = $locale;
         $this->registrationRequestedAt = $registrationRequestedAt;
         $this->registrationCode = $registrationCode;
     }
@@ -106,6 +115,11 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
 
     public static function deserialize(array $data)
     {
+        // BC compatibility for event replay in test-environment only (2.8.0, fixed in 2.8.1)
+        if (!isset($data['preferred_locale'])) {
+            $data['preferred_locale'] = 'en_GB';
+        }
+
         return new self(
             new IdentityId($data['identity_id']),
             new Institution($data['identity_institution']),
@@ -113,6 +127,7 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
             PhoneNumber::unknown(),
             CommonName::unknown(),
             Email::unknown(),
+            new Locale($data['preferred_locale']),
             DateTime::fromString($data['registration_requested_at']),
             (string) $data['registration_code']
         );
@@ -126,6 +141,7 @@ class PhonePossessionProvenAndVerifiedEvent extends IdentityEvent implements For
             'second_factor_id'          => (string) $this->secondFactorId,
             'registration_requested_at'   => (string) $this->registrationRequestedAt,
             'registration_code'           => $this->registrationCode,
+            'preferred_locale'            => (string) $this->preferredLocale,
         ];
     }
 

--- a/src/Surfnet/Stepup/Identity/Event/PossessionProvenAndVerified.php
+++ b/src/Surfnet/Stepup/Identity/Event/PossessionProvenAndVerified.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Event;
+
+interface PossessionProvenAndVerified
+{
+}

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -250,6 +250,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
                     $yubikeyPublicId,
                     $this->commonName,
                     $this->email,
+                    $this->preferredLocale,
                     DateTime::now(),
                     OtpGenerator::generate(8)
                 )
@@ -292,6 +293,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
                     $phoneNumber,
                     $this->commonName,
                     $this->email,
+                    $this->preferredLocale,
                     DateTime::now(),
                     OtpGenerator::generate(8)
                 )
@@ -337,6 +339,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
                     $gssfId,
                     $this->commonName,
                     $this->email,
+                    $this->preferredLocale,
                     DateTime::now(),
                     OtpGenerator::generate(8)
                 )
@@ -379,6 +382,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
                     $keyHandle,
                     $this->commonName,
                     $this->email,
+                    $this->preferredLocale,
                     DateTime::now(),
                     OtpGenerator::generate(8)
                 )

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Processor/RegistrationEmailProcessor.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Processor/RegistrationEmailProcessor.php
@@ -23,12 +23,20 @@ use DateInterval;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Identity\Event\EmailVerifiedEvent;
+use Surfnet\Stepup\Identity\Event\GssfPossessionProvenAndVerifiedEvent;
+use Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent;
+use Surfnet\Stepup\Identity\Event\PossessionProvenAndVerified;
+use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenAndVerifiedEvent;
+use Surfnet\Stepup\Identity\Event\YubikeyPossessionProvenAndVerifiedEvent;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionConfigurationOptionsService;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\RaLocationService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCredentials;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\RegistrationMailService;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 final class RegistrationEmailProcessor extends Processor
 {
     /**
@@ -63,7 +71,32 @@ final class RegistrationEmailProcessor extends Processor
         $this->raLocationsService                     = $raLocationsService;
     }
 
+    public function handlePhonePossessionProvenAndVerifiedEvent(PhonePossessionProvenAndVerifiedEvent $event)
+    {
+        $this->handlePossessionProvenAndVerifiedEvent($event);
+    }
+
+    public function handleYubikeyPossessionProvenAndVerifiedEvent(YubikeyPossessionProvenAndVerifiedEvent $event)
+    {
+        $this->handlePossessionProvenAndVerifiedEvent($event);
+    }
+
+    public function handleU2fDevicePossessionProvenAndVerifiedEvent(U2fDevicePossessionProvenAndVerifiedEvent $event)
+    {
+        $this->handlePossessionProvenAndVerifiedEvent($event);
+    }
+
+    public function handleGssfPossessionProvenAndVerifiedEvent(GssfPossessionProvenAndVerifiedEvent $event)
+    {
+        $this->handlePossessionProvenAndVerifiedEvent($event);
+    }
+
     public function handleEmailVerifiedEvent(EmailVerifiedEvent $event)
+    {
+        $this->handlePossessionProvenAndVerifiedEvent($event);
+    }
+
+    private function handlePossessionProvenAndVerifiedEvent(PossessionProvenAndVerified $event)
     {
         $institution = new Institution($event->identityInstitution->getInstitution());
         $institutionConfigurationOptions = $this->institutionConfigurationOptionsService
@@ -94,7 +127,7 @@ final class RegistrationEmailProcessor extends Processor
      * @param EmailVerifiedEvent $event
      * @param Institution $institution
      */
-    private function sendRegistrationEmailWithRaLocations(EmailVerifiedEvent $event, Institution $institution)
+    private function sendRegistrationEmailWithRaLocations(PossessionProvenAndVerified $event, Institution $institution)
     {
         $this->registrationMailService->sendRegistrationEmailWithRaLocations(
             (string)$event->preferredLocale,
@@ -107,10 +140,10 @@ final class RegistrationEmailProcessor extends Processor
     }
 
     /**
-     * @param EmailVerifiedEvent $event
+     * @param PossessionProvenAndVerified $event
      * @param RegistrationAuthorityCredentials[] $ras
      */
-    private function sendRegistrationEmailWithRas(EmailVerifiedEvent $event, array $ras)
+    private function sendRegistrationEmailWithRas(PossessionProvenAndVerified $event, array $ras)
     {
         $this->registrationMailService->sendRegistrationEmailWithRas(
             (string)$event->preferredLocale,
@@ -126,7 +159,7 @@ final class RegistrationEmailProcessor extends Processor
      * @param EmailVerifiedEvent $event
      * @return DateTime
      */
-    private function getExpirationDateOfRegistration(EmailVerifiedEvent $event)
+    private function getExpirationDateOfRegistration(PossessionProvenAndVerified $event)
     {
         return $event->registrationRequestedAt->add(
             new DateInterval('P14D')


### PR DESCRIPTION
PR #221 broke the registration confirmation email for institutions
with email verification disabled. Stepup now always sends the
confirmation email regardless of the email verification setting.