### PR TITLE
Fix SRAA command for institution without config

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Service/InstitutionConfigurationOptionsService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Service/InstitutionConfigurationOptionsService.php
@@ -56,7 +56,7 @@ class InstitutionConfigurationOptionsService
 
     /**
      * @param Institution $institution
-     * @return InstitutionConfigurationOptions
+     * @return InstitutionConfigurationOptions|null
      */
     public function findInstitutionConfigurationOptionsFor(Institution $institution)
     {
@@ -76,7 +76,7 @@ class InstitutionConfigurationOptionsService
     {
         $configuration = $this->findInstitutionConfigurationOptionsFor($institution);
 
-        if ($configuration->numberOfTokensPerIdentityOption->isEnabled()) {
+        if ($configuration !== null && $configuration->numberOfTokensPerIdentityOption->isEnabled()) {
             return $configuration->numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         }
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Service/InstitutionConfigurationOptionsServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Configuration/Service/InstitutionConfigurationOptionsServiceTest.php
@@ -43,7 +43,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
      * is configured in the parameters.yml under the moniker of 'number_of_tokens_per_identity'
      * @var int
      */
-    private $numberOfTokensPerIdentityDefault = 1;
+    private $numberOfTokensPerIdentityDefault = 13;
 
     public function setUp()
     {
@@ -72,8 +72,8 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
     }
 
     /**
-     * Simulates the use case where an institution does not have specific institution config, but defaults are used
-     * instead.
+     * Simulates the use case where an institution does have a specific institution config, but the token setting is
+     * disabled.
      */
     public function test_get_max_number_of_tokens_for_with_default_institution_configuration_settings()
     {
@@ -88,7 +88,27 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
         $numberOfTokens = $this->service->getMaxNumberOfTokensFor($institution);
 
         // One is configured as the globally set application default
-        $expectedNumberOfTokens = 1;
+        $expectedNumberOfTokens = 13;
+        $this->assertEquals($expectedNumberOfTokens, $numberOfTokens);
+    }
+
+
+    /**
+     * Simulates the use case where an institution does not have specific institution config, but defaults are used
+     * instead.
+     */
+    public function test_nullable_tokens_per_identity_options_in_institution_configuration_settings()
+    {
+        $institution = new Institution('surfnet.nl');
+
+        $this->repository
+            ->shouldReceive('findConfigurationOptionsFor')
+            ->andReturn(null);
+
+        $numberOfTokens = $this->service->getMaxNumberOfTokensFor($institution);
+
+        // One is configured as the globally set application default
+        $expectedNumberOfTokens = 13;
         $this->assertEquals($expectedNumberOfTokens, $numberOfTokens);
     }
 


### PR DESCRIPTION
Fix an error when the institution configuration is
null. So now the code could handle institutions
without institution configuration options.

https://www.pivotaltracker.com/n/projects/1163646/stories/159491443