### PR TITLE
Set Symfony environment from cookie if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2.9.0
+**Bugfix**
+* Fix SRAA command for institution without config #228
+
+**Improvements**
+* Symfony 3.4.15 upgrade #230
+* Behat test support #229
+* Removed RMT from the project
+* Improved the documentation fixing links and formatting


### PR DESCRIPTION
When the 'testcookie' is set, Nginx and PHP-fpm will set the APP_DEV
environment variable to 'test'.

If the variable for some reason is not set, the system falls back on the
default 'dev' environment.

See https://www.pivotaltracker.com/story/show/156570267