### PR TITLE
Add missing trusted_proxies-setting

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,4 +1,8 @@
 parameters:
+    # IP addresses of any HTTP proxies that are sitting in from of the application
+    # See: http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html
+    trusted_proxies:   ~
+
     database_driver:   pdo_mysql
     database_host:     10.10.0.100
     database_port:     ~

--- a/app_dev.php.dist
+++ b/app_dev.php.dist
@@ -17,6 +17,9 @@ $request = Request::createFromGlobals();
 
 $kernel->boot();
 
+$trustedProxies = $kernel->getContainer()->getParameter('trusted_proxies');
+Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_ALL);
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/app_test.php.dist
+++ b/app_test.php.dist
@@ -17,6 +17,9 @@ $request = Request::createFromGlobals();
 
 $kernel->boot();
 
+$trustedProxies = $kernel->getContainer()->getParameter('trusted_proxies');
+Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_ALL);
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
Without it, a PHP fatal error is being raised during runtime:
Uncaught Symfony\\Component\\DependencyInjection\\Exception\\InvalidArgumentException: The parameter "trusted_proxies" must be defined.