### PR TITLE
Update the institution configuration aggregate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ branches:
   only:
     - master
     - develop
+    - feature/update-projections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Develop
+**New features**
+* New institution configuration options can be configured (useRa, useRaa and selectRaa) #232 #233
 * The previously hardcoded "server_version" config option (Doctrine DBAL) is now configurable
 
 ## 2.9.1

--- a/app/DoctrineMigrations/Version20180918120046.php
+++ b/app/DoctrineMigrations/Version20180918120046.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180918120046 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('
+            ALTER TABLE institution_configuration_options 
+              ADD use_ra_option LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:stepup_select_ra_option)\', 
+              ADD use_raa_option LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:stepup_select_raa_option)\', 
+              ADD select_raa_option LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:stepup_select_raa_option)\'
+        ');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('
+            ALTER TABLE institution_configuration_options 
+              DROP use_ra_option, 
+              DROP use_raa_option, 
+              DROP select_raa_option
+        ');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -113,6 +113,9 @@ doctrine:
             stepup_second_factor_type: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\SecondFactorTypeType
             stepup_verify_email_option: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\VerifyEmailOptionType
             stepup_number_of_tokens_per_identity_option: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\NumberOfTokensPerIdentityType
+            stepup_use_ra_option: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\UseRaOptionType
+            stepup_use_raa_option: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\UseRaaOptionType
+            stepup_select_raa_option: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\SelectRaaOptionType
     orm:
         default_entity_manager: middleware
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/docs/MiddlewareConfiguration.md
+++ b/docs/MiddlewareConfiguration.md
@@ -386,6 +386,16 @@ The options must have the following keys:
 * `number_of_tokens_per_identity` (integer) The number of tokens an identity is allowed to vet. If the option is not set, the default value of `1` is set.
 * `allowed_second_factors`: (string[]) a list of second factor types that are allowed to be registered by users of this institution. This option only affects the registration of new second factors, it does not affect second factors that have been registered or vetted. If the list is empty all supported second factors are allowed. The supported second factors are found in the [Stepup-bundle](https://github.com/OpenConext/Stepup-bundle/blob/develop/src/Value/SecondFactorType.php#L31-L37). Default: empty list (all available second factors are allowed).
 
+And optionally the configuration can have these authorization related options:
+
+See this [RFC](https://github.com/OpenConext/Stepup-Deploy/wiki/rfc-fine-grained-authorization) for more details.
+
+* `use_ra`: (string[]) a list of SHOs of the institutions from which the RAs are also RAs in the institution. 
+* `use_raa`: (string[]) a list of SHOs of the institutions from which the RAAs are also RAAs in the institution.
+* `select_raa`: (string[]) a list of SHOs of the institutions from which the users may become RA(A)s in the institution.
+
+Note that the FGA options should consist of whitelisted institutions. 
+
 The structure of an institution configuration is therefore:
 ```
 {
@@ -394,14 +404,17 @@ The structure of an institution configuration is therefore:
         "show_raa_contact_information": true,
         "verify_email": true,
         "number_of_tokens_per_identity": 3,
-        "allowed_second_factors": ["yubikey", "sms"]
+        "allowed_second_factors": ["yubikey", "sms"]        
     },
     "another-organisation.example": {
         "use_ra_locations": true,
         "show_raa_contact_information": false,
         "verify_email": true,
         "number_of_tokens_per_identity": 1,
-        "allowed_second_factors": []
+        "allowed_second_factors": [],
+        "use_ra": ["organisation.example"],
+        "use_raa": [],
+        "select_raa": ["organisation.example", "another-organisation.example"]
     }
 }
 ```

--- a/docs/postman/2.json
+++ b/docs/postman/2.json
@@ -9,6 +9,9 @@
 		{
 			"name": "/management/configuration",
 			"request": {
+				"auth": {
+					"type": "noauth"
+				},
 				"method": "POST",
 				"header": [
 					{
@@ -282,6 +285,21 @@
 		{
 			"name": "/management/institution-configuration",
 			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "secret",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "management",
+							"type": "string"
+						}
+					]
+				},
 				"method": "GET",
 				"header": [
 					{
@@ -322,6 +340,21 @@
 		{
 			"name": "/management/institution-configuration",
 			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "secret",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "management",
+							"type": "string"
+						}
+					]
+				},
 				"method": "POST",
 				"header": [
 					{
@@ -339,10 +372,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"stepup.example.com\": {\n        \"use_ra_locations\": false,\n        \"show_raa_contact_information\": true,\n        \"verify_email\": true,\n        \"number_of_tokens_per_identity\": 3,\n        \"allowed_second_factors\": []\n    },\n    \"dev.organisation.example\": {\n        \"use_ra_locations\": true, \n        \"show_raa_contact_information\": false,\n        \"verify_email\": true,\n        \"number_of_tokens_per_identity\": 3,\n        \"allowed_second_factors\": []\n    },\n    \"institution-a.nl\": {\n        \"use_ra_locations\": true,\n        \"show_raa_contact_information\": true,\n        \"verify_email\": true,\n        \"number_of_tokens_per_identity\": 0,\n        \"allowed_second_factors\": []\n    },\n    \"institution-b.nl\": {\n        \"use_ra_locations\": true,\n        \"show_raa_contact_information\": true,\n        \"verify_email\": false,\n        \"number_of_tokens_per_identity\": 2,\n        \"allowed_second_factors\": []\n    },\n    \"institution-d.nl\": {\n        \"use_ra_locations\": true,\n        \"show_raa_contact_information\": false,\n        \"verify_email\":false,\n        \"number_of_tokens_per_identity\": 3,\n        \"allowed_second_factors\": [ \"yubikey\", \"tiqr\" ]\n    }\n}"
+					"raw": "{\n  \"institution-a.example.com\": {\n    \"use_ra_locations\": true,\n    \"show_raa_contact_information\": true,\n    \"verify_email\": true,\n    \"allowed_second_factors\": [],\n    \"number_of_tokens_per_identity\": 2,\n    \"authorization_settings\": []\n  },\n  \"institution-b.example.com\": {\n    \"use_ra_locations\": false,\n    \"show_raa_contact_information\": false,\n    \"verify_email\": false,\n    \"allowed_second_factors\": [],\n    \"number_of_tokens_per_identity\": 1\n  },\n  \"institution-d.example.com\": {\n    \"use_ra_locations\": true,\n    \"show_raa_contact_information\": true,\n    \"verify_email\": true,\n    \"allowed_second_factors\": [\"yubikey\", \"tiqr\"],\n    \"number_of_tokens_per_identity\": 1\n  }\n}"
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/management/institution-configuration",
+					"raw": "http://middleware.stepup.example.com/management/institution-configuration?XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -353,6 +386,12 @@
 					"path": [
 						"management",
 						"institution-configuration"
+					],
+					"query": [
+						{
+							"key": "XDEBUG_SESSION_START",
+							"value": "PHPSTORM"
+						}
 					]
 				},
 				"description": "POST the institution configuration options to reconfigure\n"

--- a/src/Surfnet/Stepup/Configuration/Event/NewInstitutionConfigurationCreatedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/NewInstitutionConfigurationCreatedEvent.php
@@ -108,13 +108,13 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
 
         // Support FGA options on PRE FGA events
         if (!isset($data['use_ra_option'])) {
-            $data['use_ra_option'] = UseRaOption::getDefault()->getUseRaOption();
+            $data['use_ra_option'] = UseRaOption::getDefault()->getInstitutions();
         }
         if (!isset($data['use_raa_option'])) {
-            $data['use_raa_option'] = UseRaaOption::getDefault()->getUseRaaOption();
+            $data['use_raa_option'] = UseRaaOption::getDefault()->getInstitutions();
         }
         if (!isset($data['select_raa_option'])) {
-            $data['select_raa_option'] = SelectRaaOption::getDefault()->getSelectRaaOption();
+            $data['select_raa_option'] = SelectRaaOption::getDefault()->getInstitutions();
         }
 
         return new self(
@@ -139,9 +139,9 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
             'show_raa_contact_information_option' => $this->showRaaContactInformationOption->isEnabled(),
             'verify_email_option'                 => $this->verifyEmailOption->isEnabled(),
             'number_of_tokens_per_identity_option' => $this->numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity(),
-            'use_ra_option' => $this->useRaOption->getUseRaOption(),
-            'use_raa_option' => $this->useRaaOption->getUseRaaOption(),
-            'select_raa_option' => $this->selectRaaOption->getSelectRaaOption(),
+            'use_ra_option' => $this->useRaOption->getInstitutions(),
+            'use_raa_option' => $this->useRaaOption->getInstitutions(),
+            'select_raa_option' => $this->selectRaaOption->getInstitutions(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/NewInstitutionConfigurationCreatedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/NewInstitutionConfigurationCreatedEvent.php
@@ -22,8 +22,11 @@ use Broadway\Serializer\SerializableInterface;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 
 class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
@@ -57,13 +60,31 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
      */
     public $numberOfTokensPerIdentityOption;
 
+    /**
+     * @var UseRaOption
+     */
+    public $useRaOption;
+
+    /**
+     * @var UseRaaOption
+     */
+    public $useRaaOption;
+
+    /**
+     * @var SelectRaaOption
+     */
+    public $selectRaaOption;
+
     public function __construct(
         InstitutionConfigurationId $institutionConfigurationId,
         Institution $institution,
         UseRaLocationsOption $useRaLocationsOption,
         ShowRaaContactInformationOption $showRaaContactInformationOption,
         VerifyEmailOption $verifyEmailOption,
-        NumberOfTokensPerIdentityOption $numberOfTokensPerIdentityOption
+        NumberOfTokensPerIdentityOption $numberOfTokensPerIdentityOption,
+        UseRaOption $useRaOption,
+        UseRaaOption $useRaaOption,
+        SelectRaaOption $selectRaaOption
     ) {
         $this->institutionConfigurationId      = $institutionConfigurationId;
         $this->institution                     = $institution;
@@ -71,6 +92,9 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
         $this->showRaaContactInformationOption = $showRaaContactInformationOption;
         $this->verifyEmailOption               = $verifyEmailOption;
         $this->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption;
+        $this->useRaOption = $useRaOption;
+        $this->useRaaOption = $useRaaOption;
+        $this->selectRaaOption = $selectRaaOption;
     }
 
     public static function deserialize(array $data)
@@ -82,13 +106,27 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
             $data['number_of_tokens_per_identity_option'] = NumberOfTokensPerIdentityOption::DISABLED;
         }
 
+        // Support FGA options on PRE FGA events
+        if (!isset($data['use_ra_option'])) {
+            $data['use_ra_option'] = UseRaOption::getDefault()->getUseRaOption();
+        }
+        if (!isset($data['use_raa_option'])) {
+            $data['use_raa_option'] = UseRaaOption::getDefault()->getUseRaaOption();
+        }
+        if (!isset($data['select_raa_option'])) {
+            $data['select_raa_option'] = SelectRaaOption::getDefault()->getSelectRaaOption();
+        }
+
         return new self(
             new InstitutionConfigurationId($data['institution_configuration_id']),
             new Institution($data['institution']),
             new UseRaLocationsOption($data['use_ra_locations_option']),
             new ShowRaaContactInformationOption($data['show_raa_contact_information_option']),
             new VerifyEmailOption($data['verify_email_option']),
-            new NumberOfTokensPerIdentityOption($data['number_of_tokens_per_identity_option'])
+            new NumberOfTokensPerIdentityOption($data['number_of_tokens_per_identity_option']),
+            new UseRaOption($data['use_ra_option']),
+            new UseRaaOption($data['use_raa_option']),
+            new SelectRaaOption($data['select_raa_option'])
         );
     }
 
@@ -101,6 +139,9 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
             'show_raa_contact_information_option' => $this->showRaaContactInformationOption->isEnabled(),
             'verify_email_option'                 => $this->verifyEmailOption->isEnabled(),
             'number_of_tokens_per_identity_option' => $this->numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity(),
+            'use_ra_option' => $this->useRaOption->getUseRaOption(),
+            'use_raa_option' => $this->useRaaOption->getUseRaaOption(),
+            'select_raa_option' => $this->selectRaaOption->getSelectRaaOption(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
@@ -64,7 +64,7 @@ final class SelectRaaOptionChangedEvent implements SerializableInterface
         return [
             'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
             'institution' => $this->institution->getInstitution(),
-            'select_raa_option' => $this->selectRaaOption->getSelectRaaOptions(),
+            'select_raa_option' => $this->selectRaaOption->getSelectRaaOption(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Event;
+
+use Broadway\Serializer\SerializableInterface;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
+
+final class SelectRaaOptionChangedEvent implements SerializableInterface
+{
+    /**
+     * @var InstitutionConfigurationId
+     */
+    public $institutionConfigurationId;
+
+    /**
+     * @var Institution
+     */
+    public $institution;
+
+    /**
+     * @var SelectRaaOption
+     */
+    public $selectRaaOption;
+
+    public function __construct(
+        InstitutionConfigurationId $institutionConfigurationId,
+        Institution $institution,
+        SelectRaaOption $selectRaaOption
+    ) {
+        $this->institutionConfigurationId = $institutionConfigurationId;
+        $this->institution = $institution;
+        $this->selectRaaOption = $selectRaaOption;
+    }
+
+    public static function deserialize(array $data)
+    {
+        return new self(
+            new InstitutionConfigurationId($data['institution_configuration_id']),
+            new Institution($data['institution']),
+            new SelectRaaOption($data['select_raa_option'])
+        );
+    }
+
+    public function serialize()
+    {
+        return [
+            'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
+            'institution' => $this->institution->getInstitution(),
+            'select_raa_option' => $this->selectRaaOption->getSelectRaaOptions(),
+        ];
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
@@ -64,7 +64,7 @@ final class SelectRaaOptionChangedEvent implements SerializableInterface
         return [
             'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
             'institution' => $this->institution->getInstitution(),
-            'select_raa_option' => $this->selectRaaOption->getSelectRaaOption(),
+            'select_raa_option' => $this->selectRaaOption->getInstitutions(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/UseRaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/UseRaOptionChangedEvent.php
@@ -64,7 +64,7 @@ final class UseRaOptionChangedEvent implements SerializableInterface
         return [
             'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
             'institution' => $this->institution->getInstitution(),
-            'use_ra_option' => $this->useRaOption->getUseRaOption(),
+            'use_ra_option' => $this->useRaOption->getInstitutions(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/UseRaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/UseRaOptionChangedEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Event;
+
+use Broadway\Serializer\SerializableInterface;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
+
+final class UseRaOptionChangedEvent implements SerializableInterface
+{
+    /**
+     * @var InstitutionConfigurationId
+     */
+    public $institutionConfigurationId;
+
+    /**
+     * @var Institution
+     */
+    public $institution;
+
+    /**
+     * @var UseRaOption
+     */
+    public $useRaOption;
+
+    public function __construct(
+        InstitutionConfigurationId $institutionConfigurationId,
+        Institution $institution,
+        UseRaOption $useRaOption
+    ) {
+        $this->institutionConfigurationId = $institutionConfigurationId;
+        $this->institution = $institution;
+        $this->useRaOption = $useRaOption;
+    }
+
+    public static function deserialize(array $data)
+    {
+        return new self(
+            new InstitutionConfigurationId($data['institution_configuration_id']),
+            new Institution($data['institution']),
+            new UseRaOption($data['use_ra_option'])
+        );
+    }
+
+    public function serialize()
+    {
+        return [
+            'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
+            'institution' => $this->institution->getInstitution(),
+            'use_raa_option' => $this->useRaOption->getUseRaOption(),
+        ];
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Event/UseRaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/UseRaOptionChangedEvent.php
@@ -64,7 +64,7 @@ final class UseRaOptionChangedEvent implements SerializableInterface
         return [
             'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
             'institution' => $this->institution->getInstitution(),
-            'use_raa_option' => $this->useRaOption->getUseRaOption(),
+            'use_ra_option' => $this->useRaOption->getUseRaOption(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/UseRaaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/UseRaaOptionChangedEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Event;
+
+use Broadway\Serializer\SerializableInterface;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
+
+final class UseRaaOptionChangedEvent implements SerializableInterface
+{
+    /**
+     * @var InstitutionConfigurationId
+     */
+    public $institutionConfigurationId;
+
+    /**
+     * @var Institution
+     */
+    public $institution;
+
+    /**
+     * @var UseRaaOption
+     */
+    public $useRaaOption;
+
+    public function __construct(
+        InstitutionConfigurationId $institutionConfigurationId,
+        Institution $institution,
+        UseRaaOption $useRaaOption
+    ) {
+        $this->institutionConfigurationId = $institutionConfigurationId;
+        $this->institution = $institution;
+        $this->useRaaOption = $useRaaOption;
+    }
+
+    public static function deserialize(array $data)
+    {
+        return new self(
+            new InstitutionConfigurationId($data['institution_configuration_id']),
+            new Institution($data['institution']),
+            new UseRaaOption($data['use_raa_option'])
+        );
+    }
+
+    public function serialize()
+    {
+        return [
+            'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
+            'institution' => $this->institution->getInstitution(),
+            'use_raa_option' => $this->useRaaOption->getUseRaaOption(),
+        ];
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Event/UseRaaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/UseRaaOptionChangedEvent.php
@@ -64,7 +64,7 @@ final class UseRaaOptionChangedEvent implements SerializableInterface
         return [
             'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
             'institution' => $this->institution->getInstitution(),
-            'use_raa_option' => $this->useRaaOption->getUseRaaOption(),
+            'use_raa_option' => $this->useRaaOption->getInstitutions(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
+++ b/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
@@ -30,8 +30,11 @@ use Surfnet\Stepup\Configuration\Event\RaLocationContactInformationChangedEvent;
 use Surfnet\Stepup\Configuration\Event\RaLocationRelocatedEvent;
 use Surfnet\Stepup\Configuration\Event\RaLocationRemovedEvent;
 use Surfnet\Stepup\Configuration\Event\RaLocationRenamedEvent;
+use Surfnet\Stepup\Configuration\Event\SelectRaaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\ShowRaaContactInformationOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\UseRaaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\UseRaLocationsOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\UseRaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\VerifyEmailOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
 use Surfnet\Stepup\Configuration\Value\ContactInformation;
@@ -42,8 +45,11 @@ use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationList;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 use Surfnet\Stepup\Exception\DomainException;
 
@@ -215,6 +221,39 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
                 $this->institutionConfigurationId,
                 $this->institution,
                 $numberOfTokensPerIdentityOption
+            )
+        );
+    }
+
+    public function configureUseRaOption(UseRaOption $useRaOption)
+    {
+        $this->apply(
+            new UseRaOptionChangedEvent(
+                $this->institutionConfigurationId,
+                $this->institution,
+                $useRaOption
+            )
+        );
+    }
+
+    public function configureUseRaaOption(UseRaaOption $useRaaOption)
+    {
+        $this->apply(
+            new UseRaaOptionChangedEvent(
+                $this->institutionConfigurationId,
+                $this->institution,
+                $useRaaOption
+            )
+        );
+    }
+
+    public function configureSelectRaaOption(SelectRaaOption $selectRaaOption)
+    {
+        $this->apply(
+            new SelectRaaOptionChangedEvent(
+                $this->institutionConfigurationId,
+                $this->institution,
+                $selectRaaOption
             )
         );
     }

--- a/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
+++ b/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
@@ -55,6 +55,7 @@ use Surfnet\Stepup\Exception\DomainException;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Events and value objects
+ * @SuppressWarnings(PHPMD.TooManyMethods) AggregateRoot
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) AggregateRoot
  */
 class InstitutionConfiguration extends EventSourcedAggregateRoot implements InstitutionConfigurationInterface
@@ -95,6 +96,22 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
     private $numberOfTokensPerIdentityOption;
 
     /**
+     * @var UseRaOption
+     */
+    private $useRaOption;
+
+    /**
+     * @var UseRaaOption
+     */
+
+    private $useRaaOption;
+
+    /**
+     * @var SelectRaaOption
+     */
+    private $selectRaaOption;
+
+    /**
      * @var AllowedSecondFactorList
      */
     private $allowedSecondFactorList;
@@ -119,7 +136,10 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
                 UseRaLocationsOption::getDefault(),
                 ShowRaaContactInformationOption::getDefault(),
                 VerifyEmailOption::getDefault(),
-                NumberOfTokensPerIdentityOption::getDefault()
+                NumberOfTokensPerIdentityOption::getDefault(),
+                UseRaOption::getDefault(),
+                UseRaaOption::getDefault(),
+                SelectRaaOption::getDefault()
             )
         );
         $institutionConfiguration->apply(new AllowedSecondFactorListUpdatedEvent(
@@ -148,7 +168,10 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
                 UseRaLocationsOption::getDefault(),
                 ShowRaaContactInformationOption::getDefault(),
                 VerifyEmailOption::getDefault(),
-                NumberOfTokensPerIdentityOption::getDefault()
+                NumberOfTokensPerIdentityOption::getDefault(),
+                UseRaOption::getDefault(),
+                UseRaaOption::getDefault(),
+                SelectRaaOption::getDefault()
             )
         );
         $this->apply(new AllowedSecondFactorListUpdatedEvent(
@@ -227,6 +250,10 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
 
     public function configureUseRaOption(UseRaOption $useRaOption)
     {
+        if ($this->useRaOption->equals($useRaOption)) {
+            return;
+        }
+
         $this->apply(
             new UseRaOptionChangedEvent(
                 $this->institutionConfigurationId,
@@ -238,6 +265,10 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
 
     public function configureUseRaaOption(UseRaaOption $useRaaOption)
     {
+        if ($this->useRaaOption->equals($useRaaOption)) {
+            return;
+        }
+
         $this->apply(
             new UseRaaOptionChangedEvent(
                 $this->institutionConfigurationId,
@@ -249,6 +280,10 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
 
     public function configureSelectRaaOption(SelectRaaOption $selectRaaOption)
     {
+        if ($this->selectRaaOption->equals($selectRaaOption)) {
+            return;
+        }
+
         $this->apply(
             new SelectRaaOptionChangedEvent(
                 $this->institutionConfigurationId,
@@ -389,6 +424,12 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
         $this->showRaaContactInformationOption = $event->showRaaContactInformationOption;
         $this->verifyEmailOption               = $event->verifyEmailOption;
         $this->numberOfTokensPerIdentityOption = $event->numberOfTokensPerIdentityOption;
+
+        // Apply the FGA options
+        $this->useRaOption = $event->useRaOption;
+        $this->useRaaOption = $event->useRaaOption;
+        $this->selectRaaOption = $event->selectRaaOption;
+
         $this->raLocations                     = new RaLocationList([]);
         $this->isMarkedAsDestroyed             = false;
     }
@@ -469,6 +510,9 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
         $this->verifyEmailOption               = VerifyEmailOption::getDefault();
         $this->numberOfTokensPerIdentityOption = NumberOfTokensPerIdentityOption::getDefault();
         $this->allowedSecondFactorList         = AllowedSecondFactorList::blank();
+        $this->useRaOption = UseRaOption::getDefault();
+        $this->useRaaOption = UseRaaOption::getDefault();
+        $this->selectRaaOption = SelectRaaOption::getDefault();
 
         $this->isMarkedAsDestroyed             = true;
     }

--- a/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
+++ b/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
@@ -54,6 +54,15 @@ use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 use Surfnet\Stepup\Exception\DomainException;
 
 /**
+ * InstitutionConfiguration aggregate root
+ *
+ * Some things to know about this aggregate:
+ *
+ * 1. The aggregate is instantiated by InstitutionConfigurationCommandHandler by calling the
+ *    handleReconfigureInstitutionConfigurationOptionsCommand method. It does so, not by using the projections to build
+ *    the aggregate but by playing the events onto the aggregate.
+ * 2. If one of the configuration options should be nullable, take a look at the applyUseRaOptionChangedEvent doc block
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Events and value objects
  * @SuppressWarnings(PHPMD.TooManyMethods) AggregateRoot
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) AggregateRoot
@@ -432,6 +441,33 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
 
         $this->raLocations                     = new RaLocationList([]);
         $this->isMarkedAsDestroyed             = false;
+    }
+
+    /**
+     * Apply the UseRaOptionChangedEvent
+     *
+     * To ensure the aggregate is correctly populated with the FGA options we ensure the UseRaOptionChangedEvent
+     * can be applied on the aggregate. Refraining from doing this would result in the $this->useRaOption field only
+     * being applied when applyNewInstitutionConfigurationCreatedEvent is called. And this might not be the case if
+     * the fields where null'ed (removed from configuration).
+     *
+     * This also applies for applyUseRaaOptionChangedEvent & applySelectRaaOptionChangedEvent
+     *
+     * @param UseRaOptionChangedEvent $event
+     */
+    protected function applyUseRaOptionChangedEvent(UseRaOptionChangedEvent $event)
+    {
+        $this->useRaOption = $event->useRaOption;
+    }
+
+    protected function applyUseRaaOptionChangedEvent(UseRaaOptionChangedEvent $event)
+    {
+        $this->useRaaOption = $event->useRaaOption;
+    }
+
+    protected function applySelectRaaOptionChangedEvent(SelectRaaOptionChangedEvent $event)
+    {
+        $this->selectRaaOption = $event->selectRaaOption;
     }
 
     protected function applyUseRaLocationsOptionChangedEvent(UseRaLocationsOptionChangedEvent $event)

--- a/src/Surfnet/Stepup/Configuration/Value/InstitutionSet.php
+++ b/src/Surfnet/Stepup/Configuration/Value/InstitutionSet.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Value;
+
+use ArrayIterator;
+use IteratorAggregate;
+use JsonSerializable;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+final class InstitutionSet implements JsonSerializable, IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    private $institutionSet;
+
+    /**
+     * @param Institution[]
+     */
+    public function __construct(array $institutions)
+    {
+        // Verify only Institution value objects are collected in the set
+        array_walk(
+            $institutions,
+            function ($institution, $key) use ($institutions) {
+                if (!$institution instanceof Institution) {
+                    throw InvalidArgumentException::invalidType(
+                        Institution::class,
+                        'institutions',
+                        $institutions[$key]
+                    );
+                }
+            }
+        );
+
+        // Normalize (lowercase) the institutions for the test on unique entries below.
+        $institutionsLowerCased = array_map('strtolower', $institutions);
+        if ($institutionsLowerCased !== array_unique($institutionsLowerCased)) {
+            throw new InvalidArgumentException('Duplicate entries are not allowed in the InstitutionSet');
+        }
+
+        $this->institutionSet = $institutions;
+    }
+
+    public static function fromInstitutionConfig(array $institutions)
+    {
+        if (empty($institutions)) {
+            return new self($institutions);
+        }
+
+        $set = [];
+        foreach ($institutions as $institutionTitle) {
+            $set[] = new Institution($institutionTitle);
+        }
+
+        return new self($set);
+    }
+    
+    public function equals(InstitutionSet $other)
+    {
+        // Compare the institution values of the sets
+        $currentValues = $this->toScalarArray();
+        $otherValues = $other->toScalarArray();
+        return $currentValues === $otherValues;
+    }
+
+    /**
+     * Return an array of institution values represented by their string value
+     */
+    public function toScalarArray()
+    {
+        return array_map('strval', $this->toArray());
+    }
+
+    private function toArray()
+    {
+        return $this->getIterator()->getArrayCopy();
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->institutionSet;
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->institutionSet);
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
@@ -24,7 +24,7 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 class SelectRaaOption implements JsonSerializable
 {
     /**
-     * @var string[]|null
+     * @var InstitutionSet|null
      */
     private $institutions;
 
@@ -42,11 +42,10 @@ class SelectRaaOption implements JsonSerializable
             );
         }
 
-        $this->institutions = $selectRaaOption;
-
         // Sort the array values alphabetically
-        if (is_array($this->institutions)) {
-            sort($this->institutions);
+        if (is_array($selectRaaOption)) {
+            sort($selectRaaOption);
+            $this->institutions = InstitutionSet::fromInstitutionConfig($selectRaaOption);
         }
     }
 
@@ -62,11 +61,19 @@ class SelectRaaOption implements JsonSerializable
 
     public function equals(SelectRaaOption $other)
     {
-        return $this->getInstitutions() === $other->getInstitutions();
+        $thisValue = null;
+        $otherValue = null;
+        if (!is_null($this->getInstitutions())) {
+            $thisValue = $this->getInstitutions()->toScalarArray();
+        }
+        if (!is_null($other->getInstitutions())) {
+            $otherValue = $other->getInstitutions()->toScalarArray();
+        }
+        return $thisValue === $otherValue;
     }
 
     public function jsonSerialize()
     {
-        return $this->getInstitutions();
+        return $this->getInstitutions()->toScalarArray();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not select this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Value;
+
+use JsonSerializable;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+class SelectRaaOption implements JsonSerializable
+{
+    /**
+     * @var array
+     */
+    private $selectRaaOption;
+
+    public function __construct(array $selectRaaOption)
+    {
+        if (!is_null($selectRaaOption) && !is_array($selectRaaOption)) {
+            throw InvalidArgumentException::invalidType(
+                'null or string[]',
+                'selectRaaOption',
+                $selectRaaOption
+            );
+        }
+        $this->selectRaaOption = $selectRaaOption;
+    }
+
+    public function getSelectRaaOptions()
+    {
+        return $this->selectRaaOption;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->getSelectRaaOptions();
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
@@ -26,7 +26,7 @@ class SelectRaaOption implements JsonSerializable
     /**
      * @var string[]|null
      */
-    private $selectRaaOption;
+    private $institutions;
 
     /**
      * SelectRaaOption constructor.
@@ -42,11 +42,11 @@ class SelectRaaOption implements JsonSerializable
             );
         }
 
-        $this->selectRaaOption = $selectRaaOption;
+        $this->institutions = $selectRaaOption;
 
         // Sort the array values alphabetically
-        if (is_array($this->selectRaaOption)) {
-            sort($this->selectRaaOption);
+        if (is_array($this->institutions)) {
+            sort($this->institutions);
         }
     }
 
@@ -55,18 +55,18 @@ class SelectRaaOption implements JsonSerializable
         return new self(null);
     }
 
-    public function getSelectRaaOption()
+    public function getInstitutions()
     {
-        return $this->selectRaaOption;
+        return $this->institutions;
     }
 
     public function equals(SelectRaaOption $other)
     {
-        return $this->getSelectRaaOption() === $other->getSelectRaaOption();
+        return $this->getInstitutions() === $other->getInstitutions();
     }
 
     public function jsonSerialize()
     {
-        return $this->getSelectRaaOption();
+        return $this->getInstitutions();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/SelectRaaOption.php
@@ -24,11 +24,15 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 class SelectRaaOption implements JsonSerializable
 {
     /**
-     * @var array
+     * @var string[]|null
      */
     private $selectRaaOption;
 
-    public function __construct(array $selectRaaOption)
+    /**
+     * SelectRaaOption constructor.
+     * @param string[]|null $selectRaaOption
+     */
+    public function __construct($selectRaaOption)
     {
         if (!is_null($selectRaaOption) && !is_array($selectRaaOption)) {
             throw InvalidArgumentException::invalidType(
@@ -37,16 +41,32 @@ class SelectRaaOption implements JsonSerializable
                 $selectRaaOption
             );
         }
+
         $this->selectRaaOption = $selectRaaOption;
+
+        // Sort the array values alphabetically
+        if (is_array($this->selectRaaOption)) {
+            sort($this->selectRaaOption);
+        }
     }
 
-    public function getSelectRaaOptions()
+    public static function getDefault()
+    {
+        return new self(null);
+    }
+
+    public function getSelectRaaOption()
     {
         return $this->selectRaaOption;
     }
 
+    public function equals(SelectRaaOption $other)
+    {
+        return $this->getSelectRaaOption() === $other->getSelectRaaOption();
+    }
+
     public function jsonSerialize()
     {
-        return $this->getSelectRaaOptions();
+        return $this->getSelectRaaOption();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
@@ -24,7 +24,7 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 class UseRaOption implements JsonSerializable
 {
     /**
-     * @var array
+     * @var string[]|null
      */
     private $useRaOption;
 
@@ -42,7 +42,23 @@ class UseRaOption implements JsonSerializable
             );
 
         }
+
         $this->useRaOption = $useRaOption;
+
+        // Sort the array values alphabetically
+        if (is_array($this->useRaOption)) {
+            sort($this->useRaOption);
+        }
+    }
+
+    public static function getDefault()
+    {
+        return new self(null);
+    }
+
+    public function equals(UseRaOption $other)
+    {
+        return $this->getUseRaOption() === $other->getUseRaOption();
     }
 
     public function getUseRaOption()

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Value;
+
+use JsonSerializable;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+class UseRaOption implements JsonSerializable
+{
+    /**
+     * @var array
+     */
+    private $useRaOption;
+
+    /**
+     * UseRaOption constructor.
+     * @param null|array $useRaOption
+     */
+    public function __construct($useRaOption)
+    {
+        if (!is_null($useRaOption) && !is_array($useRaOption)) {
+            throw InvalidArgumentException::invalidType(
+                'null or string[]',
+                'useRaOption',
+                $useRaOption
+            );
+
+        }
+        $this->useRaOption = $useRaOption;
+    }
+
+    public function getUseRaOption()
+    {
+        return $this->useRaOption;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->getUseRaOption();
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
@@ -26,7 +26,7 @@ class UseRaOption implements JsonSerializable
     /**
      * @var string[]|null
      */
-    private $useRaOption;
+    private $institutions;
 
     /**
      * UseRaOption constructor.
@@ -43,11 +43,11 @@ class UseRaOption implements JsonSerializable
 
         }
 
-        $this->useRaOption = $useRaOption;
+        $this->institutions = $useRaOption;
 
         // Sort the array values alphabetically
-        if (is_array($this->useRaOption)) {
-            sort($this->useRaOption);
+        if (is_array($this->institutions)) {
+            sort($this->institutions);
         }
     }
 
@@ -58,16 +58,16 @@ class UseRaOption implements JsonSerializable
 
     public function equals(UseRaOption $other)
     {
-        return $this->getUseRaOption() === $other->getUseRaOption();
+        return $this->getInstitutions() === $other->getInstitutions();
     }
 
-    public function getUseRaOption()
+    public function getInstitutions()
     {
-        return $this->useRaOption;
+        return $this->institutions;
     }
 
     public function jsonSerialize()
     {
-        return $this->getUseRaOption();
+        return $this->getInstitutions();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaOption.php
@@ -24,7 +24,7 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 class UseRaOption implements JsonSerializable
 {
     /**
-     * @var string[]|null
+     * @var InstitutionSet|null
      */
     private $institutions;
 
@@ -42,12 +42,10 @@ class UseRaOption implements JsonSerializable
             );
 
         }
-
-        $this->institutions = $useRaOption;
-
         // Sort the array values alphabetically
-        if (is_array($this->institutions)) {
-            sort($this->institutions);
+        if (is_array($useRaOption)) {
+            sort($useRaOption);
+            $this->institutions = InstitutionSet::fromInstitutionConfig($useRaOption);
         }
     }
 
@@ -58,7 +56,15 @@ class UseRaOption implements JsonSerializable
 
     public function equals(UseRaOption $other)
     {
-        return $this->getInstitutions() === $other->getInstitutions();
+        $thisValue = null;
+        $otherValue = null;
+        if (!is_null($this->getInstitutions())) {
+            $thisValue = $this->getInstitutions()->toScalarArray();
+        }
+        if (!is_null($other->getInstitutions())) {
+            $otherValue = $other->getInstitutions()->toScalarArray();
+        }
+        return $thisValue === $otherValue;
     }
 
     public function getInstitutions()
@@ -68,6 +74,6 @@ class UseRaOption implements JsonSerializable
 
     public function jsonSerialize()
     {
-        return $this->getInstitutions();
+        return $this->getInstitutions()->toScalarArray();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
@@ -26,7 +26,7 @@ class UseRaaOption implements JsonSerializable
     /**
      * @var string[]|null
      */
-    private $useRaaOption;
+    private $institutions;
 
     /**
      * UseRaaOption constructor.
@@ -42,11 +42,11 @@ class UseRaaOption implements JsonSerializable
             );
         }
 
-        $this->useRaaOption = $useRaaOption;
+        $this->institutions = $useRaaOption;
         
         // Sort the array values alphabetically
-        if (is_array($this->useRaaOption)) {
-            sort($this->useRaaOption);
+        if (is_array($this->institutions)) {
+            sort($this->institutions);
         }
     }
 
@@ -55,18 +55,18 @@ class UseRaaOption implements JsonSerializable
         return new self(null);
     }
 
-    public function getUseRaaOption()
+    public function getInstitutions()
     {
-        return $this->useRaaOption;
+        return $this->institutions;
     }
 
     public function equals(UseRaaOption $other)
     {
-        return $this->getUseRaaOption() === $other->getUseRaaOption();
+        return $this->getInstitutions() === $other->getInstitutions();
     }
 
     public function jsonSerialize()
     {
-        return $this->getUseRaaOption();
+        return $this->getInstitutions();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
@@ -24,7 +24,7 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 class UseRaaOption implements JsonSerializable
 {
     /**
-     * @var string[]|null
+     * @var InstitutionSet|null
      */
     private $institutions;
 
@@ -42,11 +42,10 @@ class UseRaaOption implements JsonSerializable
             );
         }
 
-        $this->institutions = $useRaaOption;
-        
         // Sort the array values alphabetically
-        if (is_array($this->institutions)) {
-            sort($this->institutions);
+        if (is_array($useRaaOption)) {
+            sort($useRaaOption);
+            $this->institutions = InstitutionSet::fromInstitutionConfig($useRaaOption);
         }
     }
 
@@ -55,18 +54,26 @@ class UseRaaOption implements JsonSerializable
         return new self(null);
     }
 
+    public function equals(UseRaaOption $other)
+    {
+        $thisValue = null;
+        $otherValue = null;
+        if (!is_null($this->getInstitutions())) {
+            $thisValue = $this->getInstitutions()->toScalarArray();
+        }
+        if (!is_null($other->getInstitutions())) {
+            $otherValue = $other->getInstitutions()->toScalarArray();
+        }
+        return $thisValue === $otherValue;
+    }
+
     public function getInstitutions()
     {
         return $this->institutions;
     }
 
-    public function equals(UseRaaOption $other)
-    {
-        return $this->getInstitutions() === $other->getInstitutions();
-    }
-
     public function jsonSerialize()
     {
-        return $this->getInstitutions();
+        return $this->getInstitutions()->toScalarArray();
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
@@ -24,11 +24,15 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 class UseRaaOption implements JsonSerializable
 {
     /**
-     * @var array
+     * @var string[]|null
      */
     private $useRaaOption;
 
-    public function __construct(array $useRaaOption)
+    /**
+     * UseRaaOption constructor.
+     * @param string[]|null $useRaaOption
+     */
+    public function __construct($useRaaOption)
     {
         if (!is_null($useRaaOption) && !is_array($useRaaOption)) {
             throw InvalidArgumentException::invalidType(
@@ -37,12 +41,28 @@ class UseRaaOption implements JsonSerializable
                 $useRaaOption
             );
         }
+
         $this->useRaaOption = $useRaaOption;
+        
+        // Sort the array values alphabetically
+        if (is_array($this->useRaaOption)) {
+            sort($this->useRaaOption);
+        }
+    }
+
+    public static function getDefault()
+    {
+        return new self(null);
     }
 
     public function getUseRaaOption()
     {
         return $this->useRaaOption;
+    }
+
+    public function equals(UseRaaOption $other)
+    {
+        return $this->getUseRaaOption() === $other->getUseRaaOption();
     }
 
     public function jsonSerialize()

--- a/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/UseRaaOption.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Value;
+
+use JsonSerializable;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+class UseRaaOption implements JsonSerializable
+{
+    /**
+     * @var array
+     */
+    private $useRaaOption;
+
+    public function __construct(array $useRaaOption)
+    {
+        if (!is_null($useRaaOption) && !is_array($useRaaOption)) {
+            throw InvalidArgumentException::invalidType(
+                'null or string[]',
+                'useRaaOption',
+                $useRaaOption
+            );
+        }
+        $this->useRaaOption = $useRaaOption;
+    }
+
+    public function getUseRaaOption()
+    {
+        return $this->useRaaOption;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->getUseRaaOption();
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/EventSerializationAndDeserializationTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/EventSerializationAndDeserializationTest.php
@@ -47,8 +47,11 @@ use Surfnet\Stepup\Configuration\Value\Location;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
@@ -124,7 +127,10 @@ class EventSerializationAndDeserializationTest extends TestCase
                     new UseRaLocationsOption(true),
                     new ShowRaaContactInformationOption(true),
                     new VerifyEmailOption(true),
-                    new NumberOfTokensPerIdentityOption(0)
+                    new NumberOfTokensPerIdentityOption(0),
+                    new UseRaOption(null),
+                    new UseRaaOption(null),
+                    new SelectRaaOption(null)
                 )
             ],
             'UseRaLocationsOptionChangedEvent' => [

--- a/src/Surfnet/Stepup/Tests/Configuration/InstitutionConfigurationTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/InstitutionConfigurationTest.php
@@ -28,8 +28,11 @@ use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 
 class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
@@ -46,6 +49,9 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedUseRaLocationsOption = new UseRaLocationsOption(false);
+        $useRaOption = new UseRaOption(null);
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
 
         $this->scenario
             ->when(function () use ($institution, $institutionConfigurationId, $showRaaContactInformationOption, $verifyEmailOption) {
@@ -60,7 +66,10 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $expectedUseRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -82,6 +91,9 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption          = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedShowRaaContactInformationOption = new ShowRaaContactInformationOption(true);
+        $useRaOption = new UseRaOption(null);
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
 
         $this->scenario
             ->when(function () use ($institution, $institutionConfigurationId, $useRaLocationsOption, $verifyEmailOption) {
@@ -96,7 +108,10 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $useRaLocationsOption,
                     $expectedShowRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -119,6 +134,9 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $theSameUseRaLocationsOption = $originalUseRaLocationsOption;
+        $useRaOption = new UseRaOption(null);
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
 
         $this->scenario
             ->withAggregateId((string) $institutionConfigurationId->getInstitutionConfigurationId())
@@ -129,7 +147,10 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $originalUseRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($theSameUseRaLocationsOption) {
@@ -151,6 +172,9 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption                       = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $sameShowRaaContactInformationOption = $originalShowRaaContactInformationOption;
+        $useRaOption = new UseRaOption(null);
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
 
         $this->scenario
             ->withAggregateId((string) $institutionConfigurationId->getInstitutionConfigurationId())
@@ -161,7 +185,10 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $useRaLocationsOption,
                     $originalShowRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($sameShowRaaContactInformationOption) {
@@ -183,6 +210,9 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedUseRaLocationsOption = new UseRaLocationsOption(false);
+        $useRaOption = new UseRaOption(null);
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
 
         $this->scenario
             ->withAggregateId((string) $institutionConfigurationId->getInstitutionConfigurationId())
@@ -193,7 +223,10 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $originalUseRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($expectedUseRaLocationsOption) {
@@ -221,6 +254,9 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption                       = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedShowRaaContactInformationOption = new ShowRaaContactInformationOption(false);
+        $useRaOption = new UseRaOption(null);
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
 
         $this->scenario
             ->withAggregateId((string) $institutionConfigurationId->getInstitutionConfigurationId())
@@ -231,7 +267,10 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $useRaLocationsOption,
                     $originalShowRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($expectedShowRaaContactInformationOption) {
@@ -244,6 +283,48 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $expectedShowRaaContactInformationOption
                 ),
             ]);
+    }
+
+    /**
+     * @test
+     * @group aggregate
+     */
+    public function the_order_of_institutions_in_fga_option_do_not_manipulate_aggregate_state()
+    {
+        $institution                             = new Institution('Institution');
+        $institutionConfigurationId              = InstitutionConfigurationId::from($institution);
+        $useRaLocationsOption                    = new UseRaLocationsOption(true);
+        $originalShowRaaContactInformationOption = new ShowRaaContactInformationOption(true);
+        $verifyEmailOption                       = new VerifyEmailOption(true);
+        $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+
+        // Configuration might change when it comes to ordering, this should not affect the aggregate state as the value
+        // did not change, the order did.
+        $useRaOption = new UseRaOption(['institution-a', 'institution-b']);
+        $useRaOptionRevision = new UseRaOption(['institution-b', 'institution-a']);
+
+        $useRaaOption = new UseRaaOption(null);
+        $selectRaaOption = new SelectRaaOption(null);
+
+        $this->scenario
+            ->withAggregateId((string) $institutionConfigurationId->getInstitutionConfigurationId())
+            ->given([
+                new NewInstitutionConfigurationCreatedEvent(
+                    $institutionConfigurationId,
+                    $institution,
+                    $useRaLocationsOption,
+                    $originalShowRaaContactInformationOption,
+                    $verifyEmailOption,
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
+                )
+            ])
+            ->when(function (InstitutionConfiguration $institutionConfiguration) use ($useRaOptionRevision) {
+                $institutionConfiguration->configureUseRaOption($useRaOptionRevision);
+            })
+            ->then([]);
     }
 
     protected function getAggregateRootClass()

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionSetTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionSetTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Tests\Configuration\Value;
+
+use IteratorAggregate;
+use PHPUnit_Framework_TestCase as UnitTest;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\InstitutionSet;
+use Surfnet\Stepup\Configuration\Value\Location;
+
+class InstitutionSetTest extends UnitTest
+{
+    /**
+     * @test
+     * @group domain
+     */
+    public function the_set_is_built_out_of_institution_vos()
+    {
+        $institutionA = new Institution('a');
+        $institutionB = new Institution('b');
+        $institutionC = new Institution('C');
+
+        $set = new InstitutionSet([$institutionA, $institutionB, $institutionC]);
+        $this->assertTrue(is_array($set->jsonSerialize()));
+    }
+
+    /**
+     * @test
+     * @group domain
+     * @expectedException \Surfnet\Stepup\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Duplicate entries are not allowed in the InstitutionSet
+     */
+    public function duplicate_entries_are_not_allowed()
+    {
+        $institutionB = new Institution('b');
+        $institutionBDupe = new Institution('b');
+
+        new InstitutionSet([$institutionB, $institutionBDupe]);
+    }
+
+    /**
+     * @test
+     * @group domain
+     * @expectedException \Surfnet\Stepup\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Duplicate entries are not allowed in the InstitutionSet
+     */
+    public function duplicate_entries_are_not_allowed_case_insensitive()
+    {
+        $institutionB = new Institution('b');
+        $institutionBDupe = new Institution('B');
+
+        new InstitutionSet([$institutionB, $institutionBDupe]);
+    }
+
+    /**
+     * @test
+     * @group domain
+     * @expectedException \Surfnet\Stepup\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid argument type: "Surfnet\Stepup\Configuration\Value\Institution" expected, "Surfnet\Stepup\Configuration\Value\Location" given for "institutions"
+     */
+    public function only_institutions_can_be_present_in_set()
+    {
+        $institution = new Institution('b');
+        $location = new Location('Foobar');
+
+        new InstitutionSet([$institution, $location]);
+    }
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function factory_method_can_build_from_empty_array()
+    {
+        $input = [];
+        $set = InstitutionSet::fromInstitutionConfig($input);
+        $this->assertEmpty($set->jsonSerialize());
+    }
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function factory_method_can_build_from_array_of_string()
+    {
+        $input = ['a', 'b', 'c', 'd'];
+        $set = InstitutionSet::fromInstitutionConfig($input);
+        $this->assertEquals(
+            [
+                new Institution('a'),
+                new Institution('b'),
+                new Institution('c'),
+                new Institution('d')
+            ],
+            $set->jsonSerialize()
+        );
+    }
+
+    /**
+     * This test actually tests the Institution's input validation during construction time
+     *
+     * @test
+     * @group domain
+     * @dataProvider dirtyInstitutionListProvider
+     * @expectedException \Surfnet\Stepup\Exception\InvalidArgumentException
+     *
+     * @param array $invalid
+     */
+    public function factory_method_can_build_from_array_of_string_and_rejects_invalid_types(array $invalid)
+    {
+        InstitutionSet::fromInstitutionConfig($invalid);
+    }
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function the_set_is_iterable()
+    {
+        $input = ['a', 'b', 'c', 'd'];
+        $set = InstitutionSet::fromInstitutionConfig($input);
+
+        $this->assertInstanceOf(IteratorAggregate::class, $set);
+        $this->assertEquals(4, count($set->getIterator()));
+    }
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function sets_can_be_compared()
+    {
+        $input = ['a', 'b', 'c', 'd'];
+        $set = InstitutionSet::fromInstitutionConfig($input);
+        $secondSet = InstitutionSet::fromInstitutionConfig($input);
+        $this->assertTrue($set->equals($secondSet));
+    }
+
+    public function dirtyInstitutionListProvider()
+    {
+        return [
+            'numeric_entry' => [['a', 1, 'b']],
+            'array_entry' => [['a', 'b', []]],
+            'bolean_entry' => [[false, 'a', 'b']],
+            'non_scalar_entry' => [['a', 'b', new Location('location x')]],
+        ];
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/SelectRaaOptionTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/SelectRaaOptionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not select this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Tests\Configuration\Value;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
+
+class SelectRaaOptionTest extends TestCase
+{
+    /**
+     * @test
+     * @group domain
+     */
+    public function institution_entries_are_sorted()
+    {
+        $selectRaaOption = new SelectRaaOption(['z', 'y', 'x']);
+        $this->assertEquals(['x', 'y', 'z'], $selectRaaOption->getInstitutions());
+    }
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function select_raa_option_instances_can_be_compared()
+    {
+        $selectRaaOption = new SelectRaaOption(['z', 'y', 'x']);
+        $secondSelectRaaOption = new SelectRaaOption(['y', 'x', 'z']);
+        $this->assertTrue($selectRaaOption->equals($secondSelectRaaOption));
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/UseRaOptionTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/UseRaOptionTest.php
@@ -20,9 +20,9 @@ namespace Surfnet\Stepup\Tests\Configuration\Value;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\Stepup\Configuration\Value\InstitutionSet;
-use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 
-class SelectRaaOptionTest extends TestCase
+class UseRaOptionTest extends TestCase
 {
     /**
      * @test
@@ -30,8 +30,8 @@ class SelectRaaOptionTest extends TestCase
      */
     public function institution_entries_are_sorted()
     {
-        $selectRaaOption = new SelectRaaOption(['z', 'y', 'x']);
-        $this->assertEquals(['x', 'y', 'z'], $selectRaaOption->getInstitutions()->toScalarArray());
+        $useRaOption = new UseRaOption(['z', 'y', 'x']);
+        $this->assertEquals(['x', 'y', 'z'], $useRaOption->getInstitutions()->toScalarArray());
     }
 
     /**
@@ -41,9 +41,9 @@ class SelectRaaOptionTest extends TestCase
      */
     public function select_raa_option_instances_can_be_compared($expectation, $configurationA, $configurationB)
     {
-        $selectRaaOption = new SelectRaaOption($configurationA);
-        $secondSelectRaaOption = new SelectRaaOption($configurationB);
-        $this->assertEquals($expectation, $selectRaaOption->equals($secondSelectRaaOption));
+        $useRaOption = new UseRaOption($configurationA);
+        $secondUseRaOption = new UseRaOption($configurationB);
+        $this->assertEquals($expectation, $useRaOption->equals($secondUseRaOption));
     }
 
     /**
@@ -52,8 +52,8 @@ class SelectRaaOptionTest extends TestCase
      */
     public function can_be_retrieved_json_encodable()
     {
-        $selectRaaOption = new SelectRaaOption(['z', 'y', 'x']);
-        $this->assertEquals(['x', 'y', 'z'], $selectRaaOption->jsonSerialize());
+        $useRaOption = new UseRaOption(['z', 'y', 'x']);
+        $this->assertEquals(['x', 'y', 'z'], $useRaOption->jsonSerialize());
     }
 
     /**
@@ -64,7 +64,7 @@ class SelectRaaOptionTest extends TestCase
      */
     public function invalid_types_are_rejected_during_construction($arguments)
     {
-        new SelectRaaOption($arguments);
+        new UseRaOption($arguments);
     }
 
     /**
@@ -73,7 +73,7 @@ class SelectRaaOptionTest extends TestCase
      */
     public function the_default_value_is_null()
     {
-        $this->assertNull(SelectRaaOption::getDefault()->getInstitutions());
+        $this->assertNull(UseRaOption::getDefault()->getInstitutions());
     }
 
     public function institutionSetComparisonProvider()

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/UseRaaOptionTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/UseRaaOptionTest.php
@@ -20,9 +20,9 @@ namespace Surfnet\Stepup\Tests\Configuration\Value;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\Stepup\Configuration\Value\InstitutionSet;
-use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 
-class SelectRaaOptionTest extends TestCase
+class UseRaaOptionTest extends TestCase
 {
     /**
      * @test
@@ -30,8 +30,8 @@ class SelectRaaOptionTest extends TestCase
      */
     public function institution_entries_are_sorted()
     {
-        $selectRaaOption = new SelectRaaOption(['z', 'y', 'x']);
-        $this->assertEquals(['x', 'y', 'z'], $selectRaaOption->getInstitutions()->toScalarArray());
+        $useRaaOption = new UseRaaOption(['z', 'y', 'x']);
+        $this->assertEquals(['x', 'y', 'z'], $useRaaOption->getInstitutions()->toScalarArray());
     }
 
     /**
@@ -41,9 +41,9 @@ class SelectRaaOptionTest extends TestCase
      */
     public function select_raa_option_instances_can_be_compared($expectation, $configurationA, $configurationB)
     {
-        $selectRaaOption = new SelectRaaOption($configurationA);
-        $secondSelectRaaOption = new SelectRaaOption($configurationB);
-        $this->assertEquals($expectation, $selectRaaOption->equals($secondSelectRaaOption));
+        $useRaaOption = new UseRaaOption($configurationA);
+        $secondUseRaaOption = new UseRaaOption($configurationB);
+        $this->assertEquals($expectation, $useRaaOption->equals($secondUseRaaOption));
     }
 
     /**
@@ -52,8 +52,8 @@ class SelectRaaOptionTest extends TestCase
      */
     public function can_be_retrieved_json_encodable()
     {
-        $selectRaaOption = new SelectRaaOption(['z', 'y', 'x']);
-        $this->assertEquals(['x', 'y', 'z'], $selectRaaOption->jsonSerialize());
+        $useRaaOption = new UseRaaOption(['z', 'y', 'x']);
+        $this->assertEquals(['x', 'y', 'z'], $useRaaOption->jsonSerialize());
     }
 
     /**
@@ -64,7 +64,7 @@ class SelectRaaOptionTest extends TestCase
      */
     public function invalid_types_are_rejected_during_construction($arguments)
     {
-        new SelectRaaOption($arguments);
+        new UseRaaOption($arguments);
     }
 
     /**
@@ -73,7 +73,7 @@ class SelectRaaOptionTest extends TestCase
      */
     public function the_default_value_is_null()
     {
-        $this->assertNull(SelectRaaOption::getDefault()->getInstitutions());
+        $this->assertNull(UseRaaOption::getDefault()->getInstitutions());
     }
 
     public function institutionSetComparisonProvider()

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
@@ -21,8 +21,11 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 
 /**
@@ -68,12 +71,36 @@ class InstitutionConfigurationOptions
      */
     public $numberOfTokensPerIdentityOption;
 
+    /**
+     * @ORM\Column(type="stepup_use_ra_option", nullable=true)
+     *
+     * @var UseRaOption
+     */
+    public $useRaOption;
+
+    /**
+     * @ORM\Column(type="stepup_use_raa_option", nullable=true)
+     *
+     * @var UseRaaOption
+     */
+    public $useRaaOption;
+
+    /**
+     * @ORM\Column(type="stepup_select_raa_option", nullable=true)
+     *
+     * @var SelectRaaOption
+     */
+    public $selectRaaOption;
+
     public static function create(
         Institution $institution,
         UseRaLocationsOption $useRaLocationsOption,
         ShowRaaContactInformationOption $showRaaContactInformationOption,
         VerifyEmailOption $verifyEmailOption,
-        NumberOfTokensPerIdentityOption $numberOfTokensPerIdentityOption
+        NumberOfTokensPerIdentityOption $numberOfTokensPerIdentityOption,
+        UseRaOption $useRaOption,
+        UseRaaOption $useRaaOption,
+        SelectRaaOption $selectRaaOption
     ) {
         $options = new self;
 
@@ -82,6 +109,10 @@ class InstitutionConfigurationOptions
         $options->showRaaContactInformationOption = $showRaaContactInformationOption;
         $options->verifyEmailOption               = $verifyEmailOption;
         $options->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption;
+
+        $options->useRaOption = $useRaOption;
+        $options->useRaaOption = $useRaaOption;
+        $options->selectRaaOption = $selectRaaOption;
 
         return $options;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/InstitutionConfigurationOptionsProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/InstitutionConfigurationOptionsProjector.php
@@ -22,8 +22,11 @@ use Broadway\ReadModel\Projector;
 use Surfnet\Stepup\Configuration\Event\InstitutionConfigurationRemovedEvent;
 use Surfnet\Stepup\Configuration\Event\NewInstitutionConfigurationCreatedEvent;
 use Surfnet\Stepup\Configuration\Event\NumberOfTokensPerIdentityOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\SelectRaaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\ShowRaaContactInformationOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\UseRaaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\UseRaLocationsOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\UseRaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\VerifyEmailOptionChangedEvent;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionConfigurationOptions;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\AllowedSecondFactorRepository;
@@ -56,7 +59,10 @@ final class InstitutionConfigurationOptionsProjector extends Projector
             $event->useRaLocationsOption,
             $event->showRaaContactInformationOption,
             $event->verifyEmailOption,
-            $event->numberOfTokensPerIdentityOption
+            $event->numberOfTokensPerIdentityOption,
+            $event->useRaOption,
+            $event->useRaaOption,
+            $event->selectRaaOption
         );
 
         $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
@@ -98,5 +104,27 @@ final class InstitutionConfigurationOptionsProjector extends Projector
     {
         $this->institutionConfigurationOptionsRepository->removeConfigurationOptionsFor($event->institution);
         $this->allowedSecondFactorRepository->clearAllowedSecondFactorListFor($event->institution);
+    }
+
+    public function applyUseRaOptionChangedEvent(UseRaOptionChangedEvent $event)
+    {
+        $institutionConfigurationOptions = $this->institutionConfigurationOptionsRepository->findConfigurationOptionsFor($event->institution);
+        $institutionConfigurationOptions->useRaOption = $event->useRaOption;
+
+        $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
+    }
+    public function applyUseRaaOptionChangedEvent(UseRaaOptionChangedEvent $event)
+    {
+        $institutionConfigurationOptions = $this->institutionConfigurationOptionsRepository->findConfigurationOptionsFor($event->institution);
+        $institutionConfigurationOptions->useRaaOption = $event->useRaaOption;
+
+        $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
+    }
+    public function applySelectRaaOptionChangedEvent(SelectRaaOptionChangedEvent $event)
+    {
+        $institutionConfigurationOptions = $this->institutionConfigurationOptionsRepository->findConfigurationOptionsFor($event->institution);
+        $institutionConfigurationOptions->selectRaaOption = $event->selectRaaOption;
+
+        $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/SelectRaaOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/SelectRaaOptionType.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+/**
+ * Custom Type for the SelectRaaOptionType Value Object
+ */
+class SelectRaaOptionType extends Type
+{
+    const NAME = 'stepup_select_raa_option';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        if (!$value instanceof SelectRaaOption) {
+            throw new ConversionException(
+                sprintf(
+                    "Encountered illegal location of type %s '%s', expected a SelectRaaOption instance",
+                    is_object($value) ? get_class($value) : gettype($value),
+                    is_scalar($value) ? (string)$value : ''
+                )
+            );
+        }
+
+        return json_encode($value);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        try {
+            $useRaLocationsOption = new SelectRaaOption(json_decode($value));
+        } catch (InvalidArgumentException $e) {
+            // get nice standard message, so we can throw it keeping the exception chain
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
+                $value,
+                $this->getName()
+            )->getMessage();
+
+            throw new ConversionException($doctrineExceptionMessage, 0, $e);
+        }
+
+        return $useRaLocationsOption;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaOptionType.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+/**
+ * Custom Type for the UseRaOptionType Value Object
+ */
+class UseRaOptionType extends Type
+{
+    const NAME = 'stepup_select_ra_option';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        if (!$value instanceof UseRaOption) {
+            throw new ConversionException(
+                sprintf(
+                    "Encountered illegal location of type %s '%s', expected a UseRaOption instance",
+                    is_object($value) ? get_class($value) : gettype($value),
+                    is_scalar($value) ? (string) $value : ''
+                )
+            );
+        }
+
+        return json_encode($value);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        try {
+            $useRaLocationsOption = new UseRaOption(json_decode($value));
+        } catch (InvalidArgumentException $e) {
+            // get nice standard message, so we can throw it keeping the exception chain
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
+                $value,
+                $this->getName()
+            )->getMessage();
+
+            throw new ConversionException($doctrineExceptionMessage, 0, $e);
+        }
+
+        return $useRaLocationsOption;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaaOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/UseRaaOptionType.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
+use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
+
+/**
+ * Custom Type for the UseRaaOptionType Value Object
+ */
+class UseRaaOptionType extends Type
+{
+    const NAME = 'stepup_select_raa_option';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        if (!$value instanceof UseRaaOption) {
+            throw new ConversionException(
+                sprintf(
+                    "Encountered illegal location of type %s '%s', expected a UseRaaOption instance",
+                    is_object($value) ? get_class($value) : gettype($value),
+                    is_scalar($value) ? (string) $value : ''
+                )
+            );
+        }
+
+        return json_encode($value);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        try {
+            $useRaLocationsOption = new UseRaaOption(json_decode($value));
+        } catch (InvalidArgumentException $e) {
+            // get nice standard message, so we can throw it keeping the exception chain
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
+                $value,
+                $this->getName()
+            )->getMessage();
+
+            throw new ConversionException($doctrineExceptionMessage, 0, $e);
+        }
+
+        return $useRaLocationsOption;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/ReconfigureInstitutionConfigurationOptionsCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/ReconfigureInstitutionConfigurationOptionsCommand.php
@@ -64,4 +64,19 @@ final class ReconfigureInstitutionConfigurationOptionsCommand extends AbstractCo
      * @Assert\NotNull()
      */
     public $allowedSecondFactors;
+
+    /**
+     * @var array|null
+     */
+    public $useRaOption;
+
+    /**
+     * @var array|null
+     */
+    public $useRaaOption;
+
+    /**
+     * @var array|null
+     */
+    public $selectRaaOption;
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/CommandHandler/InstitutionConfigurationCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/CommandHandler/InstitutionConfigurationCommandHandler.php
@@ -30,8 +30,11 @@ use Surfnet\Stepup\Configuration\Value\Location;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\AddRaLocationCommand;
@@ -99,6 +102,12 @@ class InstitutionConfigurationCommandHandler extends CommandHandler
         $institutionConfiguration->configureShowRaaContactInformationOption(
             new ShowRaaContactInformationOption($command->showRaaContactInformationOption)
         );
+
+        // Configure the authorization options on the aggregate
+        $institutionConfiguration->configureUseRaOption(new UseRaOption($command->useRaOption));
+        $institutionConfiguration->configureUseRaaOption(new UseRaaOption($command->useRaaOption));
+        $institutionConfiguration->configureSelectRaaOption(new SelectRaaOption($command->selectRaaOption));
+
         $institutionConfiguration->updateAllowedSecondFactorList(
             AllowedSecondFactorList::ofTypes($allowedSecondFactors)
         );

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
@@ -42,8 +42,11 @@ use Surfnet\Stepup\Configuration\Value\Location;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelectRaaOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
+use Surfnet\Stepup\Configuration\Value\UseRaaOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
+use Surfnet\Stepup\Configuration\Value\UseRaOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\AddRaLocationCommand;
@@ -73,6 +76,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $defaultVerifyEmailOption               = VerifyEmailOption::getDefault();
         $numberOfTokensPerIdentityOption        = new NumberOfTokensPerIdentityOption(0);
         $defaultAllowedSecondFactorList         = AllowedSecondFactorList::blank();
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -84,7 +90,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $defaultUseRaLocationsOption,
                     $defaultShowRaaContactInformationOption,
                     $defaultVerifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -114,6 +123,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -124,7 +136,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
             ])
             ->when($command);
@@ -143,6 +158,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(1);
         $defaultAllowedSecondFactorList  = AllowedSecondFactorList::blank();
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $command                                  = new ReconfigureInstitutionConfigurationOptionsCommand();
         $command->institution                     = $institution->getInstitution();
@@ -150,6 +168,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
+        $command->useRaOption = $useRaOption->getUseRaOption();
+        $command->useRaaOption = $useRaaOption->getUseRaaOption();
+        $command->selectRaaOption = $selectRaaOption->getSelectRaaOption();
         $command->allowedSecondFactors            = [];
 
         $this->scenario
@@ -161,7 +182,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -185,6 +209,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $defaultAllowedSecondFactorList  = AllowedSecondFactorList::blank();
 
@@ -196,6 +223,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
+        $command->useRaOption = $useRaOption->getUseRaOption();
+        $command->useRaaOption = $useRaaOption->getUseRaaOption();
+        $command->selectRaaOption = $selectRaaOption->getSelectRaaOption();
         $command->allowedSecondFactors            = [];
 
         $this->scenario
@@ -207,7 +237,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -237,6 +270,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $defaultAllowedSecondFactorList  = AllowedSecondFactorList::blank();
 
@@ -259,7 +295,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -289,6 +328,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = ShowRaaContactInformationOption::getDefault();
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $originalAllowedSecondFactorList = AllowedSecondFactorList::blank();
 
@@ -315,7 +357,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -351,6 +396,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = ShowRaaContactInformationOption::getDefault();
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $originalAllowedSecondFactorList = $allowedSecondFactorList;
 
@@ -371,7 +419,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -402,6 +453,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -412,7 +466,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
             ])
             ->when($command)
@@ -449,6 +506,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -459,7 +519,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -494,6 +557,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -504,7 +570,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -546,6 +615,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -556,7 +628,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when($command);
@@ -583,6 +658,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId(self::uuid())
@@ -593,7 +671,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when($command);
@@ -621,6 +702,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -631,7 +715,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -674,6 +761,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -684,7 +774,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -724,6 +817,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId(self::uuid())
@@ -734,7 +830,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when($command);
@@ -759,6 +858,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -769,7 +871,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 )
             ])
             ->when($command);
@@ -792,6 +897,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -802,7 +910,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $useRaLocationsOption,
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
-                    $numberOfTokensPerIdentityOption
+                    $numberOfTokensPerIdentityOption,
+                    $useRaOption,
+                    $useRaaOption,
+                    $selectRaaOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -838,6 +949,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
+        $useRaOption = UseRaOption::getDefault();
+        $useRaaOption = UseRaaOption::getDefault();
+        $selectRaaOption = SelectRaaOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -849,7 +963,10 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                         $useRaLocationsOption,
                         $showRaaContactInformationOption,
                         $verifyEmailOption,
-                        $numberOfTokensPerIdentityOption
+                        $numberOfTokensPerIdentityOption,
+                        $useRaOption,
+                        $useRaaOption,
+                        $selectRaaOption
                     )
                 ]
             )

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
@@ -168,9 +168,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
-        $command->useRaOption = $useRaOption->getUseRaOption();
-        $command->useRaaOption = $useRaaOption->getUseRaaOption();
-        $command->selectRaaOption = $selectRaaOption->getSelectRaaOption();
+        $command->useRaOption = $useRaOption->getInstitutions();
+        $command->useRaaOption = $useRaaOption->getInstitutions();
+        $command->selectRaaOption = $selectRaaOption->getInstitutions();
         $command->allowedSecondFactors            = [];
 
         $this->scenario
@@ -223,9 +223,9 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
-        $command->useRaOption = $useRaOption->getUseRaOption();
-        $command->useRaaOption = $useRaaOption->getUseRaaOption();
-        $command->selectRaaOption = $selectRaaOption->getSelectRaaOption();
+        $command->useRaOption = $useRaOption->getInstitutions();
+        $command->useRaaOption = $useRaaOption->getInstitutions();
+        $command->selectRaaOption = $selectRaaOption->getInstitutions();
         $command->allowedSecondFactors            = [];
 
         $this->scenario

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
@@ -105,6 +105,11 @@ final class InstitutionConfigurationController extends Controller
             $command->numberOfTokensPerIdentityOption = $options['number_of_tokens_per_identity'];
             $command->allowedSecondFactors            = $options['allowed_second_factors'];
 
+            // The useRa, useRaa and selectRaa options are optional
+            $command->useRaOption = isset($options['use_ra']) ? $options['use_ra'] : null;
+            $command->useRaaOption = isset($options['use_raa']) ? $options['use_raa'] : null;
+            $command->selectRaaOption = isset($options['select_raa']) ? $options['select_raa'] : null;
+
             $commands[] = $command;
         }
 

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
@@ -67,6 +67,9 @@ final class InstitutionConfigurationController extends Controller
                 'allowed_second_factors' => $allowedSecondFactorMap->getAllowedSecondFactorListFor(
                     $options->institution
                 ),
+                'use_ra' => $options->useRaOption,
+                'use_raa' => $options->useRaaOption,
+                'select_raa' => $options->selectRaaOption,
             ];
         }
 

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
@@ -37,6 +37,7 @@ services:
         arguments:
             - "@surfnet_stepup_middleware_api.service.configured_institutions"
             - "@surfnet_stepup.service.second_factor_type"
+            - "@surfnet_stepup_middleware_api.service.whitelist_entry"
         tags:
             - { name: validator.constraint_validator, alias: reconfigure_institution_configuration_structure_validator }
 

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_array_use_raa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_array_use_raa.php
@@ -18,16 +18,17 @@
 
 return [
     'expectedPropertyPath' => 'Institution(surfnet.nl)',
-    'expectErrorMessageToContain' => 'must contain valid second factor types',
+    'expectErrorMessageToContain' => 'Option "use_raa" for "surfnet.nl" must be an array of strings',
     'reconfigureInstitutionRequest' => [
         'surfnet.nl' => [
-            'use_ra_locations' => true,
-            'show_raa_contact_information' => true,
-            'verify_email' => false,
-            'number_of_tokens_per_identity' => 4,
-            'allowed_second_factors' => [
-                'faux_second_factor'
-            ],
+            "use_ra_locations" => true,
+            "show_raa_contact_information" => true,
+            "verify_email" => true,
+            "allowed_second_factors" => [],
+            "number_of_tokens_per_identity" => 2,
+            "use_ra" => [],
+            "use_raa" => "surfnet.nl",
+            "select_raa" => ["surfnet.nl"],
         ]
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_whitelisted_institution_use_raa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_whitelisted_institution_use_raa.php
@@ -18,16 +18,17 @@
 
 return [
     'expectedPropertyPath' => 'Institution(surfnet.nl)',
-    'expectErrorMessageToContain' => 'must contain valid second factor types',
+    'expectErrorMessageToContain' => 'All values of option "use_raa" should be known institutions.',
     'reconfigureInstitutionRequest' => [
         'surfnet.nl' => [
-            'use_ra_locations' => true,
-            'show_raa_contact_information' => true,
-            'verify_email' => false,
-            'number_of_tokens_per_identity' => 4,
-            'allowed_second_factors' => [
-                'faux_second_factor'
-            ],
+            "use_ra_locations" => true,
+            "show_raa_contact_information" => true,
+            "verify_email" => true,
+            "allowed_second_factors" => [],
+            "number_of_tokens_per_identity" => 2,
+            "use_ra" => ["surfnet.nl"],
+            "use_raa" => ["example.com"],
+            "select_raa" => ["surfnet.nl"],
         ]
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/with_error_in_second_institution.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/with_error_in_second_institution.php
@@ -27,6 +27,6 @@ return [
             'number_of_tokens_per_identity' => 1,
             'allowed_second_factors' => [],
         ],
-        'another-organisation.test' => []
+        'another-organisation.test' => [],
     ],
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
@@ -18,12 +18,16 @@
 
 namespace Surfnet\StepupMiddleware\ManagementBundle\Tests\Validator;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Institution as IdentityInstitution;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\ConfiguredInstitution;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\ConfiguredInstitutionService;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\WhitelistEntry;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\WhitelistService;
 use Surfnet\StepupMiddleware\ManagementBundle\Validator\Constraints\ValidReconfigureInstitutionsRequest;
 use Surfnet\StepupMiddleware\ManagementBundle\Validator\ReconfigureInstitutionRequestValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -81,9 +85,14 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
         $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
         $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
 
+        $whitelistedInstitution = WhitelistEntry::createFrom(new IdentityInstitution('surfnet.nl'));
+        $whitelistServiceMock = Mockery::mock(WhitelistService::class);
+        $whitelistServiceMock->shouldReceive('getAllEntries')->andReturn(new ArrayCollection([$whitelistedInstitution]));
+
         $validator = new ReconfigureInstitutionRequestValidator(
             $configuredInstitutionServiceMock,
-            $secondFactorTypeServiceMock
+            $secondFactorTypeServiceMock,
+            $whitelistServiceMock
         );
         $validator->initialize($context);
         $validator->validate($reconfigureRequest, new ValidReconfigureInstitutionsRequest);
@@ -130,10 +139,13 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
 
         $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
         $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
+        $whitelistServiceMock = Mockery::mock(WhitelistService::class);
+        $whitelistServiceMock->shouldReceive('getAllEntries')->andReturn(new ArrayCollection([]));
 
         $validator = new ReconfigureInstitutionRequestValidator(
             $configuredInstitutionServiceMock,
-            $secondFactorTypeServiceMock
+            $secondFactorTypeServiceMock,
+            $whitelistServiceMock
         );
         $validator->initialize($context);
 
@@ -173,10 +185,13 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
             ->andReturn($existingInstitutions);
         $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
         $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
+        $whitelistServiceMock = Mockery::mock(WhitelistService::class);
+        $whitelistServiceMock->shouldReceive('getAllEntries')->andReturn(new ArrayCollection([]));
 
         $validator = new ReconfigureInstitutionRequestValidator(
             $configuredInstitutionServiceMock,
-            $secondFactorTypeServiceMock
+            $secondFactorTypeServiceMock,
+            $whitelistServiceMock
         );
         $validator->initialize($context);
 
@@ -201,6 +216,7 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
         ];
 
         $existingInstitution = ConfiguredInstitution::createFrom(new Institution($institution));
+        $whitelistedInstitution = WhitelistEntry::createFrom(new IdentityInstitution($institution));
 
         $configuredInstitutionServiceMock = Mockery::mock(ConfiguredInstitutionService::class);
         $configuredInstitutionServiceMock
@@ -212,10 +228,12 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
 
         $secondFactorTypeServiceMock = Mockery::mock(SecondFactorTypeService::class);
         $secondFactorTypeServiceMock->shouldReceive('getAvailableSecondFactorTypes')->andReturn(['yubikey', 'sms']);
-
+        $whitelistServiceMock = Mockery::mock(WhitelistService::class);
+        $whitelistServiceMock->shouldReceive('getAllEntries')->andReturn(new ArrayCollection([$whitelistedInstitution]));
         $validator = new ReconfigureInstitutionRequestValidator(
             $configuredInstitutionServiceMock,
-            $secondFactorTypeServiceMock
+            $secondFactorTypeServiceMock,
+            $whitelistServiceMock
         );
         $validator->initialize($context);
         $validator->validate($validRequest, new ValidReconfigureInstitutionsRequest);

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/Assert.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/Assert.php
@@ -40,4 +40,29 @@ final class Assert
             ['expected' => $keys, 'actual' => $keysOfValue]
         );
     }
+
+    public static function requiredAndOptionalOptions(array $value, array $required, array $optional, $message = null, $propertyPath = null)
+    {
+        // Filter out the optional items from the value array
+        $requiredValueSet = array_diff_key($value, array_flip($optional));
+
+        // Verify the required keys match.
+        self::keysMatch($requiredValueSet, $required, $message, $propertyPath);
+
+        // Verify the optional keys do not contain illegal entries.
+        $keysOfValue = array_keys($value);
+        $extraKeys = array_diff($keysOfValue, array_merge($optional, $required));
+
+        if (count($extraKeys) === 0) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            $message,
+            0,
+            $propertyPath,
+            $value,
+            ['expected' => $optional, 'actual' => $keysOfValue]
+        );
+    }
 }


### PR DESCRIPTION
**What's new?**
 * Added support for configuring the three new FGA options (useRa, useRaa, selectRaa)
 * Updated the validator, also testing the validity of the institutions against the whitelist
 * Specific tests have been added to test these points

**What's not yet working**
No projections have been touched yet. So this breaks with the 'direct consistent' rule stated in the middleware wiki. The new options are not projected directly yet. This will be taken care of in the next PR. Be sure you remove the events that are fired during test of this PR.

The showAction (InstitutionConfigurationController) was not touched yet. And it makes more sense to address this when updating the projections.

**How to test?**
Personally, I've used Postman to test the configuration post on the Middleware API. Combined with XDebug & monitoring of the log file

Updated Postman payload:
```
{
  "institution-a.example.com": {
    "use_ra_locations": true,
    "show_raa_contact_information": true,
    "verify_email": true,
    "allowed_second_factors": [],
    "number_of_tokens_per_identity": 2,
    "use_ra": ["institution-a.example.com"],
    "use_raa": ["institution-b.example.com"]
    "select_raa": ["institution-b.example.com"]
  }
}
```

Test variations of the new options. For example leave them out (they are optional after all) or provide an empty array as a value.

See: https://www.pivotaltracker.com/story/show/160546629