### PR TITLE
Use DI in managment bundle controllers

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/AuditLogController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/AuditLogController.php
@@ -22,12 +22,23 @@ use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\BadApiRequestException;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\SecondFactorAuditLogQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\AuditLogService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AuditLogController extends Controller
 {
+    /**
+     * @var AuditLogService
+     */
+    private $auditLogService;
+
+    public function __construct(AuditLogService $service)
+    {
+        $this->auditLogService = $service;
+    }
+
     public function secondFactorAuditLogAction(Request $request, Institution $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
@@ -44,16 +55,8 @@ final class AuditLogController extends Controller
         $query->orderDirection      = $request->get('orderDirection', $query->orderDirection);
         $query->pageNumber          = $request->get('p', 1);
 
-        $paginator = $this->getService()->searchSecondFactorAuditLog($query);
+        $paginator = $this->auditLogService->searchSecondFactorAuditLog($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
-    }
-
-    /**
-     * @return \Surfnet\StepupMiddleware\ApiBundle\Identity\Service\AuditLogService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.audit_log');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
@@ -30,11 +30,21 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class IdentityController extends Controller
 {
+    /**
+     * @var IdentityService
+     */
+    private $identityService;
+
+    public function __construct(IdentityService $identityService)
+    {
+        $this->identityService = $identityService;
+    }
+
     public function getAction($id)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $identity = $this->getService()->find($id);
+        $identity = $this->identityService->find($id);
 
         if ($identity === null) {
             throw new NotFoundHttpException(sprintf("Identity '%s' does not exist", $id));
@@ -54,7 +64,7 @@ class IdentityController extends Controller
         $query->email       = $request->get('email');
         $query->pageNumber  = (int) $request->get('p', 1);
 
-        $paginator = $this->getService()->search($query);
+        $paginator = $this->identityService->search($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
     }
@@ -67,7 +77,7 @@ class IdentityController extends Controller
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $identityService = $this->getService();
+        $identityService = $this->identityService;
 
         $credentials = $identityService->findRegistrationAuthorityCredentialsOf($identityId);
 
@@ -76,13 +86,5 @@ class IdentityController extends Controller
         }
 
         return new JsonResponse($credentials);
-    }
-
-    /**
-     * @return IdentityService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.identity');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionListingController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionListingController.php
@@ -18,16 +18,27 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\InstitutionListingService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class InstitutionListingController extends Controller
 {
+    /**
+     * @var InstitutionListingService
+     */
+    private $listingService;
+
+    public function __construct(InstitutionListingService $allListings)
+    {
+        $this->listingService = $allListings;
+    }
+
     public function collectionAction()
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
 
-        $allListings = $this->get('surfnet_stepup_middleware_api.service.institution_listing')->getAll();
+        $allListings = $this->listingService->getAll();
 
         return new JsonResponse($allListings);
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaCandidateController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaCandidateController.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaCandidateQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaCandidateService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -28,6 +29,16 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RaCandidateController extends Controller
 {
+    /**
+     * @var RaCandidateService
+     */
+    private $raCandidateService;
+
+    public function __construct(RaCandidateService $raCandidateService)
+    {
+        $this->raCandidateService = $raCandidateService;
+    }
+
     /**
      * @param Institution $institution
      * @param Request     $request
@@ -44,7 +55,7 @@ class RaCandidateController extends Controller
         $query->secondFactorTypes = $request->get('secondFactorTypes');
         $query->pageNumber        = (int) $request->get('p', 1);
 
-        $paginator = $this->get('surfnet_stepup_middleware_api.service.ra_candidate')->search($query);
+        $paginator = $this->raCandidateService->search($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
     }
@@ -59,7 +70,7 @@ class RaCandidateController extends Controller
 
         $identityId = $request->get('identityId');
 
-        $raCandidate = $this->get('surfnet_stepup_middleware_api.service.ra_candidate')->findByIdentityId($identityId);
+        $raCandidate = $this->raCandidateService->findByIdentityId($identityId);
 
         if ($raCandidate === null) {
             throw new NotFoundHttpException(sprintf("RaCandidate with IdentityId '%s' does not exist", $identityId));

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaController.php
@@ -19,27 +19,29 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class RaController extends Controller
 {
+    /**
+     * @var RaListingService
+     */
+    private $raListingService;
+
+    public function __construct(RaListingService $raListingService)
+    {
+        $this->raListingService = $raListingService;
+    }
+
     public function listAction(Institution $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_SS']);
 
-        $service = $this->getRaListingService();
-        $registrationAuthorityCredentials = $service->listRegistrationAuthoritiesFor($institution);
+        $registrationAuthorityCredentials = $this->raListingService->listRegistrationAuthoritiesFor($institution);
         $count = count($registrationAuthorityCredentials);
 
         return new JsonCollectionResponse($count, 1, $count, $registrationAuthorityCredentials);
-    }
-
-    /**
-     * @return \Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService
-     */
-    private function getRaListingService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.ra_listing');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaListingController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaListingController.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaListingQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -29,11 +30,21 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RaListingController extends Controller
 {
+    /**
+     * @var RaListingService
+     */
+    private $raListingService;
+
+    public function __construct(RaListingService $raListingService)
+    {
+        $this->raListingService = $raListingService;
+    }
+
     public function getAction($identityId)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
 
-        $raListing = $this->getService()->findByIdentityId(new IdentityId($identityId));
+        $raListing = $this->raListingService->findByIdentityId(new IdentityId($identityId));
 
         if ($raListing === null) {
             throw new NotFoundHttpException(sprintf("RaListing '%s' does not exist", $identityId));
@@ -52,16 +63,8 @@ class RaListingController extends Controller
         $query->orderBy        = $request->get('orderBy');
         $query->orderDirection = $request->get('orderDirection');
 
-        $searchResults = $this->getService()->search($query);
+        $searchResults = $this->raListingService->search($query);
 
         return JsonCollectionResponse::fromPaginator($searchResults);
-    }
-
-    /**
-     * @return \Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.ra_listing');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaLocationController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaLocationController.php
@@ -29,6 +29,16 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class RaLocationController extends Controller
 {
+    /**
+     * @return RaLocationService
+     */
+    private $raLocationService;
+
+    public function __construct(RaLocationService $raLocationService)
+    {
+        $this->raLocationService = $raLocationService;
+    }
+
     public function searchAction(Request $request, Institution $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
@@ -38,7 +48,7 @@ final class RaLocationController extends Controller
         $query->orderBy        = $request->get('orderBy', $query->orderBy);
         $query->orderDirection = $request->get('orderDirection', $query->orderDirection);
 
-        $raLocations = $this->getRaLocationService()->search($query);
+        $raLocations = $this->raLocationService->search($query);
         $count       = count($raLocations);
 
         return new JsonCollectionResponse($count, 1, $count, $raLocations);
@@ -49,16 +59,8 @@ final class RaLocationController extends Controller
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
         $raLocationId = new RaLocationId($request->get('raLocationId'));
-        $raLocation   = $this->getRaLocationService()->findByRaLocationId($raLocationId);
+        $raLocation   = $this->raLocationService->findByRaLocationId($raLocationId);
 
         return new JsonResponse($raLocation);
-    }
-
-    /**
-     * @return RaLocationService
-     */
-    private function getRaLocationService()
-    {
-        return $this->container->get('surfnet_stepup_middleware_api.service.ra_location');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaSecondFactorQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaSecondFactorService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -27,13 +28,23 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class RaSecondFactorController extends Controller
 {
+    /**
+     * @var RaSecondFactorService
+     */
+    private $raSecondFactorService;
+
+    public function __construct(RaSecondFactorService $raSecondFactorService)
+    {
+        $this->raSecondFactorService = $raSecondFactorService;
+    }
+
     public function collectionAction(Request $request, Institution $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
 
         $query = $this->buildRaSecondFactorQuery($request, $institution);
 
-        $paginator = $this->getService()->search($query);
+        $paginator = $this->raSecondFactorService->search($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
     }
@@ -44,7 +55,7 @@ final class RaSecondFactorController extends Controller
 
         $query = $this->buildRaSecondFactorQuery($request, $institution);
 
-        $results = $this->getService()->searchUnpaginated($query);
+        $results = $this->raSecondFactorService->searchUnpaginated($query);
 
         return new JsonResponse($results);
     }
@@ -56,24 +67,17 @@ final class RaSecondFactorController extends Controller
      */
     private function buildRaSecondFactorQuery(Request $request, Institution $institution)
     {
-        $query                 = new RaSecondFactorQuery();
-        $query->institution    = $institution;
-        $query->pageNumber     = (int) $request->get('p', 1);
-        $query->name           = $request->get('name');
-        $query->type           = $request->get('type');
+        $query = new RaSecondFactorQuery();
+        $query->institution = $institution;
+        $query->pageNumber = (int)$request->get('p', 1);
+        $query->name = $request->get('name');
+        $query->type = $request->get('type');
         $query->secondFactorId = $request->get('secondFactorId');
-        $query->email          = $request->get('email');
-        $query->status         = $request->get('status');
-        $query->orderBy        = $request->get('orderBy');
+        $query->email = $request->get('email');
+        $query->status = $request->get('status');
+        $query->orderBy = $request->get('orderBy');
         $query->orderDirection = $request->get('orderDirection');
-        return $query;
-    }
 
-    /**
-     * @return \Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaSecondFactorService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.ra_second_factor');
+        return $query;
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/SraaController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/SraaController.php
@@ -19,12 +19,24 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SraaService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonNotFoundResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class SraaController extends Controller
 {
+
+    /**
+     * @var SraaService
+     */
+    private $sraaService;
+
+    public function __construct(SraaService $sraaService)
+    {
+        $this->sraaService = $sraaService;
+    }
+
     /**
      * @param string $nameId injected by symfony from the request
      * @return JsonNotFoundResponse|JsonResponse
@@ -33,20 +45,12 @@ class SraaController extends Controller
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
 
-        $sraa = $this->getService()->findByNameId(new NameId($nameId));
+        $sraa = $this->sraaService->findByNameId(new NameId($nameId));
 
         if (!$sraa) {
             return new JsonNotFoundResponse();
         }
 
         return new JsonResponse($sraa);
-    }
-
-    /**
-     * @return \Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SraaService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.sraa');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/UnverifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/UnverifiedSecondFactorController.php
@@ -29,11 +29,21 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UnverifiedSecondFactorController extends Controller
 {
+    /**
+     * @var SecondFactorService
+     */
+    private $secondFactorService;
+
+    public function __construct(SecondFactorService $secondFactorService)
+    {
+        $this->secondFactorService = $secondFactorService;
+    }
+
     public function getAction($id)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $secondFactor = $this->getService()->findUnverified(new SecondFactorId($id));
+        $secondFactor = $this->secondFactorService->findUnverified(new SecondFactorId($id));
 
         if ($secondFactor === null) {
             throw new NotFoundHttpException(sprintf("Unverified second factor '%s' does not exist", $id));
@@ -51,16 +61,8 @@ class UnverifiedSecondFactorController extends Controller
         $query->verificationNonce = $request->get('verificationNonce');
         $query->pageNumber        = (int) $request->get('p', 1);
 
-        $paginator = $this->getService()->searchUnverifiedSecondFactors($query);
+        $paginator = $this->secondFactorService->searchUnverifiedSecondFactors($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
-    }
-
-    /**
-     * @return SecondFactorService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.second_factor');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
@@ -30,11 +30,21 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class VerifiedSecondFactorController extends Controller
 {
+    /**
+     * @var SecondFactorService
+     */
+    private $secondFactorService;
+
+    public function __construct(SecondFactorService $secondFactorService)
+    {
+        $this->secondFactorService = $secondFactorService;
+    }
+
     public function getAction($id)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $secondFactor = $this->getService()->findVerified(new SecondFactorId($id));
+        $secondFactor = $this->secondFactorService->findVerified(new SecondFactorId($id));
 
         if ($secondFactor === null) {
             throw new NotFoundHttpException(sprintf("Verified second factor '%s' does not exist", $id));
@@ -60,16 +70,8 @@ class VerifiedSecondFactorController extends Controller
         $query->registrationCode = $request->get('registrationCode');
         $query->pageNumber       = (int) $request->get('p', 1);
 
-        $paginator = $this->getService()->searchVerifiedSecondFactors($query);
+        $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
-    }
-
-    /**
-     * @return SecondFactorService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.second_factor');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VettedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VettedSecondFactorController.php
@@ -29,11 +29,21 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class VettedSecondFactorController extends Controller
 {
+    /**
+     * @var SecondFactorService
+     */
+    private $secondFactorService;
+
+    public function __construct(SecondFactorService $secondFactorService)
+    {
+        $this->secondFactorService = $secondFactorService;
+    }
+
     public function getAction($id)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
-        $secondFactor = $this->getService()->findVetted(new SecondFactorId($id));
+        $secondFactor = $this->secondFactorService->findVetted(new SecondFactorId($id));
 
         if ($secondFactor === null) {
             throw new NotFoundHttpException(sprintf("Vetted second factor '%s' does not exist", $id));
@@ -50,16 +60,8 @@ class VettedSecondFactorController extends Controller
         $query->identityId = $request->get('identityId');
         $query->pageNumber = (int) $request->get('p', 1);
 
-        $paginator = $this->getService()->searchVettedSecondFactors($query);
+        $paginator = $this->secondFactorService->searchVettedSecondFactors($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
-    }
-
-    /**
-     * @return SecondFactorService
-     */
-    private function getService()
-    {
-        return $this->get('surfnet_stepup_middleware_api.service.second_factor');
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -3,6 +3,12 @@ services:
     _defaults:
         public: true
 
+    # The ManagementBundle controllers are available as a service
+    Surfnet\StepupMiddleware\ApiBundle\Controller\:
+        resource: '../../Controller'
+        autowire: true
+        tags: ['controller.service_arguments']
+
     # Repositories
     surfnet_stepup_middleware_api.repository.configured_institution:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\ConfiguredInstitutionRepository

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -1,8 +1,4 @@
 services:
-    # Remove the public: true default once DI is implemented throughout the StepUp applications. See Pivotal #138225085
-    _defaults:
-        public: true
-
     # The ManagementBundle controllers are available as a service
     Surfnet\StepupMiddleware\ApiBundle\Controller\:
         resource: '../../Controller'

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/ConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/ConfigurationController.php
@@ -22,12 +22,23 @@ use DateTime;
 use Rhumsaa\Uuid\Uuid;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\Command;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\UpdateConfigurationCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Pipeline\TransactionAwarePipeline;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class ConfigurationController extends Controller
 {
+    /**
+     * @return TransactionAwarePipeline
+     */
+    private $pipeline;
+
+    public function __construct(TransactionAwarePipeline $pipeline)
+    {
+        $this->pipeline = $pipeline;
+    }
+
     public function updateAction(Request $request)
     {
         $command                = new UpdateConfigurationCommand();
@@ -44,9 +55,7 @@ class ConfigurationController extends Controller
      */
     private function handleCommand(Request $request, Command $command)
     {
-        /** @var \Surfnet\StepupMiddleware\CommandHandlingBundle\Pipeline\Pipeline $pipeline */
-        $pipeline = $this->get('pipeline');
-        $pipeline->process($command);
+        $this->pipeline->process($command);
 
         $serverName = $request->server->get('SERVER_NAME') ?: $request->server->get('SERVER_ADDR');
         $response   = new JsonResponse([

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
@@ -1,7 +1,4 @@
 services:
-    # Remove the public: true default once DI is implemented throughout the StepUp applications. See Pivotal #138225085
-    _defaults:
-        public: true
 
     # The ManagementBundle controllers are available as a service
     Surfnet\StepupMiddleware\ManagementBundle\Controller\:
@@ -18,22 +15,18 @@ services:
             - { name: validator.constraint_validator, alias: configuration_structure_validator }
 
     surfnet_stepup_middleware_management.validator.gateway_configuration:
-        public: false
         class: Surfnet\StepupMiddleware\ManagementBundle\Validator\GatewayConfigurationValidator
         arguments:
             - "@surfnet_stepup_middleware_management.validator.identity_provider_configuration"
             - "@surfnet_stepup_middleware_management.validator.service_provider_configuration"
 
     surfnet_stepup_middleware_management.validator.service_provider_configuration:
-        public: false
         class: Surfnet\StepupMiddleware\ManagementBundle\Validator\ServiceProviderConfigurationValidator
 
     surfnet_stepup_middleware_management.validator.identity_provider_configuration:
-        public: false
         class: Surfnet\StepupMiddleware\ManagementBundle\Validator\IdentityProviderConfigurationValidator
 
     surfnet_stepup_middleware_management.validator.email_templates_configuration:
-        public: false
         class: Surfnet\StepupMiddleware\ManagementBundle\Validator\EmailTemplatesConfigurationValidator
         arguments:
             - '' # Default locale

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Resources/config/services.yml
@@ -3,6 +3,12 @@ services:
     _defaults:
         public: true
 
+    # The ManagementBundle controllers are available as a service
+    Surfnet\StepupMiddleware\ManagementBundle\Controller\:
+        resource: '../../Controller'
+        autowire: true
+        tags: ['controller.service_arguments']
+
     surfnet_stepup_middleware_management.validator.configuration:
         class: Surfnet\StepupMiddleware\ManagementBundle\Validator\ConfigurationStructureValidator
         arguments:


### PR DESCRIPTION
The controller services are autowired.

The previously used getters, who where retrieving the dependencies using
the service container, have been substituted by private fields that are
populated at construction time.

See: https://www.pivotaltracker.com/story/show/160546671
Task: "Chore: Make ApiBundle controllers services and utilize DI"