### PR TITLE
Update vetting procedure endpoints

### DIFF
--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -201,6 +201,7 @@ Request parameters:
 URL: `http://middleware.tld/verified-second-factors?{identityId=}{&secondFactorId=}{&registrationCode=}(&p=}`
 Method: GET
 Request parameters:
+- institution: (required))
 - IdentityId: (optional) UUIDv4 of the identity to search for
 - secondFactorId: (optional) UUIDv4 of the second factor to search for
 - registrationCode: (optional) string, registration code to search for

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Repository/AuthorizationRepositoryFactory.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Repository/AuthorizationRepositoryFactory.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
+
+class AuthorizationRepositoryFactory
+{
+    /**
+     * @var InstitutionAuthorizationRepositoryFilter
+     */
+    private $filter;
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * AuthorizationRepositoryFactory constructor.
+     * @param EntityManagerInterface $entityManager
+     * @param InstitutionAuthorizationRepositoryFilter $filter
+     */
+    public function __construct(EntityManagerInterface $entityManager, InstitutionAuthorizationRepositoryFilter $filter)
+    {
+        $this->entityManager = $entityManager;
+        $this->filter = $filter;
+    }
+
+    /**
+     * @param string $entityName
+     * @return \Doctrine\Common\Persistence\ObjectRepository
+     */
+    public function getRepository($entityName)
+    {
+        /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
+        $metadata = $this->entityManager->getClassMetadata($entityName);
+        $repositoryClassName = $metadata->customRepositoryClassName
+            ?: $this->entityManager->getConfiguration()->getDefaultRepositoryClassName();
+
+        return new $repositoryClassName($this->entityManager, $metadata, $this->filter);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
@@ -20,7 +20,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\InstitutionAuthorizationContextFactoryInterface;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\IdentityQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService;
@@ -39,21 +39,14 @@ class IdentityController extends Controller
     private $identityService;
 
     /**
-     * @var InstitutionAuthorizationContextFactoryInterface
-     */
-    private $institutionAuthorizationContextFactory;
-
-    /**
      * @var InstitutionRoleSet
      */
     private $roleRequirements;
 
     public function __construct(
-        IdentityService $identityService,
-        InstitutionAuthorizationContextFactoryInterface $institutionAuthorizationContextFactory
+        IdentityService $identityService
     ) {
         $this->identityService = $identityService;
-        $this->institutionAuthorizationContextFactory = $institutionAuthorizationContextFactory;
 
         $this->roleRequirements = new InstitutionRoleSet(
             [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
@@ -83,11 +76,7 @@ class IdentityController extends Controller
         $query->commonName = $request->get('commonName');
         $query->email = $request->get('email');
         $query->pageNumber = (int)$request->get('p', 1);
-
-        $query->authorizationContext = $this->institutionAuthorizationContextFactory->buildFrom(
-            $institution,
-            $this->roleRequirements
-        );
+        $query->authorizationContext = new InstitutionAuthorizationContext($query->institution, $this->roleRequirements);
 
         $paginator = $this->identityService->search($query);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -18,7 +18,10 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
+use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaSecondFactorService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
@@ -33,9 +36,18 @@ final class RaSecondFactorController extends Controller
      */
     private $raSecondFactorService;
 
+    /**
+     * @var InstitutionRoleSet
+     */
+    private $roleRequirements;
+
     public function __construct(RaSecondFactorService $raSecondFactorService)
     {
         $this->raSecondFactorService = $raSecondFactorService;
+
+        $this->roleRequirements = new InstitutionRoleSet(
+            [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
+        );
     }
 
     public function collectionAction(Request $request, Institution $institution)
@@ -77,6 +89,7 @@ final class RaSecondFactorController extends Controller
         $query->status = $request->get('status');
         $query->orderBy = $request->get('orderBy');
         $query->orderDirection = $request->get('orderDirection');
+        $query->authorizationContext = new InstitutionAuthorizationContext($query->institution, $this->roleRequirements);
 
         return $query;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/IdentityQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/IdentityQuery.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
 
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
 
 class IdentityQuery extends AbstractQuery
 {
@@ -43,7 +43,7 @@ class IdentityQuery extends AbstractQuery
     public $email;
 
     /**
-     * @var InstitutionAuthorizationContext|null
+     * @var InstitutionAuthorizationContextInterface
      */
     public $authorizationContext;
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaSecondFactorQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaSecondFactorQuery.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
 
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
+
 final class RaSecondFactorQuery extends AbstractQuery
 {
     /**
@@ -59,4 +61,9 @@ final class RaSecondFactorQuery extends AbstractQuery
      * @var string|null
      */
     public $orderDirection;
+
+    /**
+     * @var InstitutionAuthorizationContextInterface
+     */
+    public $authorizationContext;
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/VerifiedSecondFactorQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/VerifiedSecondFactorQuery.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
 
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
 
 class VerifiedSecondFactorQuery extends AbstractQuery
 {
@@ -37,4 +38,14 @@ class VerifiedSecondFactorQuery extends AbstractQuery
      * @var string|null
      */
     public $registrationCode;
+
+    /**
+     * @var string|\Surfnet\Stepup\Identity\Value\Institution
+     */
+    public $institution;
+
+    /**
+     * @var InstitutionAuthorizationContext
+     */
+    public $authorizationContext;
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentityRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentityRepository.php
@@ -18,7 +18,9 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Repository;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
@@ -28,6 +30,20 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\IdentityQuery;
 
 class IdentityRepository extends EntityRepository
 {
+    /**
+     * @var InstitutionAuthorizationRepositoryFilter
+     */
+    private $authorizationRepositoryFilter;
+
+    public function __construct(
+        EntityManager $em,
+        Mapping\ClassMetadata $class,
+        InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter
+    ) {
+        parent::__construct($em, $class);
+        $this->authorizationRepositoryFilter = $authorizationRepositoryFilter;
+    }
+
     /**
      * @param string $id
      * @return Identity|null
@@ -52,16 +68,15 @@ class IdentityRepository extends EntityRepository
 
     /**
      * @param IdentityQuery $query
-     * @param InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter The authorization filter is used
-     *        to filter the results for the given institution
      * @return \Doctrine\ORM\Query
      */
-    public function createSearchQuery(IdentityQuery $query, InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter)
-    {
+    public function createSearchQuery(
+        IdentityQuery $query
+    ) {
         $queryBuilder = $this->createQueryBuilder('i');
 
         // Modify query to filter on authorization
-        $authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'i.id', 'i.institution', 'iac');
+        $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'i.id', 'i.institution', 'iac');
 
         if ($query->nameId) {
             $queryBuilder

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/IdentityService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/IdentityService.php
@@ -21,7 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Service;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\RuntimeException;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\IdentityQuery;
@@ -46,28 +46,20 @@ class IdentityService extends AbstractSearchService
      * @var SraaRepository
      */
     private $sraaRepository;
-    /**
-     * @var InstitutionAuthorizationRepositoryFilter
-     */
-    private $authorizationRepositoryFilter;
 
     /**
      * @param IdentityRepository $repository
      * @param RaListingRepository $raListingRepository
      * @param SraaRepository $sraaRepository
-     * @param InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter The authorization filter is used
-     *        to filter the results for a specific institution based on it's given roles
      */
     public function __construct(
         IdentityRepository $repository,
         RaListingRepository $raListingRepository,
-        SraaRepository $sraaRepository,
-        InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter
+        SraaRepository $sraaRepository
     ) {
         $this->repository = $repository;
         $this->raListingRepository = $raListingRepository;
         $this->sraaRepository = $sraaRepository;
-        $this->authorizationRepositoryFilter = $authorizationRepositoryFilter;
     }
 
     /**
@@ -81,11 +73,12 @@ class IdentityService extends AbstractSearchService
 
     /**
      * @param IdentityQuery $query
+     * @param InstitutionRoleSet $institutionRoles
      * @return \Pagerfanta\Pagerfanta
      */
     public function search(IdentityQuery $query)
     {
-        $searchQuery = $this->repository->createSearchQuery($query, $this->authorizationRepositoryFilter);
+        $searchQuery = $this->repository->createSearchQuery($query);
 
         $paginator = $this->createPaginatorFrom($searchQuery, $query);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -5,6 +5,13 @@ services:
         autowire: true
         tags: ['controller.service_arguments']
 
+    # Authorization repository factory
+    surfnet_stepup_middleware_api.repository_factory.authorization:
+        class: Surfnet\StepupMiddleware\ApiBundle\Authorization\Repository\AuthorizationRepositoryFactory
+        arguments:
+            - "@doctrine.orm.middleware_entity_manager"
+            - "@surfnet_stepup_middleware_api.repository_filter.authorization"
+
     # Repositories
     surfnet_stepup_middleware_api.repository.configured_institution:
         class: Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\ConfiguredInstitutionRepository
@@ -33,7 +40,7 @@ services:
 
     surfnet_stepup_middleware_api.repository.identity:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository
-        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
+        factory: ["@surfnet_stepup_middleware_api.repository_factory.authorization", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity ]
 
     surfnet_stepup_middleware_api.repository.institution_listing:
@@ -63,7 +70,7 @@ services:
 
     surfnet_stepup_middleware_api.repository.verified_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\VerifiedSecondFactorRepository
-        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
+        factory: ["@surfnet_stepup_middleware_api.repository_factory.authorization", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\VerifiedSecondFactor ]
 
     surfnet_stepup_middleware_api.repository.vetted_second_factor:
@@ -73,7 +80,7 @@ services:
 
     surfnet_stepup_middleware_api.repository.ra_second_factor:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaSecondFactorRepository
-        factory: ["@doctrine.orm.middleware_entity_manager", getRepository]
+        factory: ["@surfnet_stepup_middleware_api.repository_factory.authorization", getRepository]
         arguments: [ Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaSecondFactor ]
 
     surfnet_stepup_middleware_api.repository.audit_log:
@@ -156,7 +163,6 @@ services:
             - "@surfnet_stepup_middleware_api.repository.identity"
             - "@surfnet_stepup_middleware_api.repository.ra_listing"
             - "@surfnet_stepup_middleware_api.repository.sraa"
-            - "@surfnet_stepup_middleware_api.repository_filter.authorization"
 
     surfnet_stepup_middleware_api.service.ra_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaListingService


### PR DESCRIPTION
The main purpose of this PR is to add middleware endpoints used in RA to start a vetting procedure.

Also a bit of boyscouting was done to prevent coupling to allow changes in the authcontext logic much easier later on. Therefore the authorization context was added to the query in the controller. Also a special factory is added to set a AuthorizationFilter by DI to the repositories which needed filtering based on the authorization context to prevent coupling of the filter with the services.

This PR also removed the AuthContextFactory from the identity endpoint. 

See: https://www.pivotaltracker.com/story/show/160283514