### PR TITLE
Register new events in events.yml

### DIFF
--- a/app/config/events.yml
+++ b/app/config/events.yml
@@ -45,3 +45,13 @@ parameters:
         - Surfnet\Stepup\Identity\Event\WhitelistReplacedEvent
         - Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent
         - Surfnet\Stepup\Identity\Event\YubikeyPossessionProvenEvent
+        # New versions for the IdentityAccreditedAsRaEvent and IdentityAccreditedAsRaaEvent events
+        - Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent
+        - Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaForInstitutionEvent
+        # New versions for the AppointedAsRaEvent and AppointedAsRaa events
+        - Surfnet\Stepup\Identity\Event\AppointedAsRaForInstitutionEvent
+        - Surfnet\Stepup\Identity\Event\AppointedAsRaaForInstitutionEvent
+        # New versions for the RegistrationAuthorityInformationAmendedEvent
+        - Surfnet\Stepup\Identity\Event\RegistrationAuthorityInformationAmendedForInstitutionEvent
+        # New versions for the RegistrationAuthorityRetractedEvent event
+        - Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent


### PR DESCRIPTION
In #246 we saw the addition of:
- Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent
- Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaForInstitutionEvent
- Surfnet\Stepup\Identity\Event\AppointedAsRaForInstitutionEvent
- Surfnet\Stepup\Identity\Event\AppointedAsRaaForInstitutionEvent
- Surfnet\Stepup\Identity\Event\RegistrationAuthorityInformationAmendedForInstitutionEvent
- Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent

These events needed to be registered in the events.yml to be able to use
them in the middleware. To build aggregates and perform event replays.

See: https://github.com/OpenConext/Stepup-Middleware/pull/246