### PR TITLE
Display the new events in auditlog

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
@@ -64,9 +64,14 @@ class AuditLogEntry implements JsonSerializable
         'Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent'              => 'bootstrapped',
         'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaEvent'                      => 'accredited_as_raa',
         'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaEvent'                       => 'accredited_as_ra',
+        'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent'         => 'accredited_as_ra',
+        'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaForInstitutionEvent'        => 'accredited_as_raa',
         'Surfnet\Stepup\Identity\Event\AppointedAsRaaEvent'                               => 'appointed_as_raa',
         'Surfnet\Stepup\Identity\Event\AppointedAsRaEvent'                                => 'appointed_as_ra',
+        'Surfnet\Stepup\Identity\Event\AppointedAsRaaForInstitutionEvent'                 => 'appointed_as_raa',
+        'Surfnet\Stepup\Identity\Event\AppointedAsRaForInstitutionEvent'                  => 'appointed_as_ra',
         'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent'               => 'retracted_as_ra',
+        'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent' => 'retracted_as_ra',
     ];
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
@@ -49,9 +49,14 @@ class AuditLogRepository extends EntityRepository
         'Surfnet\Stepup\Identity\Event\CompliedWithVettedSecondFactorRevocationEvent',
         'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaEvent',
         'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaEvent',
+        'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent',
+        'Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaForInstitutionEvent',
         'Surfnet\Stepup\Identity\Event\AppointedAsRaaEvent',
+        'Surfnet\Stepup\Identity\Event\AppointedAsRaForInstitutionEvent',
+        'Surfnet\Stepup\Identity\Event\AppointedAsRaaForInstitutionEvent',
         'Surfnet\Stepup\Identity\Event\AppointedAsRaEvent',
         'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent',
+        'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent',
     ];
 
     /**


### PR DESCRIPTION
The previously added events where not yet projected in the event log.
This change registers the relevant events on the AuditLogEntry entity
and the AuditLogRepository. Enabling the new events for display.

What is not yet in this PR is the actual RA institution you have been appointed RA(A) privileges for. This feature is discussed in this Pivotal issue in the comment section: https://www.pivotaltracker.com/story/show/160283522/comments/195972803