### PR TITLE
 Allow storing of the ra institution in audit log

### DIFF
--- a/app/DoctrineMigrations/Version20181101103348.php
+++ b/app/DoctrineMigrations/Version20181101103348.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add the ra_institution column to the audit_log
+ *
+ * This column is set with the ra institution that was in context at the time of the event that is logged.
+ *
+ * Example: John Doe is accredited to become RA by Joe from institution-a. The actual institution John is
+ * appointed RA for is stored in this field.
+ */
+class Version20181101103348 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE audit_log ADD ra_institution VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE audit_log DROP ra_institution;');
+    }
+}

--- a/src/Surfnet/Stepup/Identity/AuditLog/Metadata.php
+++ b/src/Surfnet/Stepup/Identity/AuditLog/Metadata.php
@@ -31,6 +31,11 @@ final class Metadata
     public $identityInstitution;
 
     /**
+     * @var \Surfnet\Stepup\Identity\Value\Institution
+     */
+    public $raInstitution;
+
+    /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId|null
      */
     public $secondFactorId;

--- a/src/Surfnet/Stepup/Identity/Event/AppointedAsRaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/AppointedAsRaForInstitutionEvent.php
@@ -52,6 +52,7 @@ class AppointedAsRaForInstitutionEvent extends IdentityEvent
         $metadata = new Metadata();
         $metadata->identityId = $this->identityId;
         $metadata->identityInstitution = $this->identityInstitution;
+        $metadata->raInstitution = $this->raInstitution;
 
         return $metadata;
     }

--- a/src/Surfnet/Stepup/Identity/Event/AppointedAsRaaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/AppointedAsRaaForInstitutionEvent.php
@@ -52,6 +52,7 @@ class AppointedAsRaaForInstitutionEvent extends IdentityEvent
         $metadata = new Metadata();
         $metadata->identityId = $this->identityId;
         $metadata->identityInstitution = $this->identityInstitution;
+        $metadata->raInstitution = $this->raInstitution;
 
         return $metadata;
     }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaForInstitutionEvent.php
@@ -85,6 +85,7 @@ class IdentityAccreditedAsRaForInstitutionEvent extends IdentityEvent
         $metadata                      = new Metadata();
         $metadata->identityId          = $this->identityId;
         $metadata->identityInstitution = $this->identityInstitution;
+        $metadata->raInstitution       = $this->raInstitution;
 
         return $metadata;
     }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaForInstitutionEvent.php
@@ -84,6 +84,7 @@ class IdentityAccreditedAsRaaForInstitutionEvent extends IdentityEvent
         $metadata                      = new Metadata();
         $metadata->identityId          = $this->identityId;
         $metadata->identityInstitution = $this->identityInstitution;
+        $metadata->raInstitution       = $this->raInstitution;
 
         return $metadata;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
@@ -171,6 +171,7 @@ class AuditLogEntry implements JsonSerializable
             'actor_common_name'        => $this->actorCommonName,
             'identity_id'              => $this->identityId,
             'identity_institution'     => (string) $this->identityInstitution,
+            'ra_institution'           => (string) $this->raInstitution,
             'second_factor_id'         => $this->secondFactorId,
             'second_factor_type'       => $this->secondFactorType ? (string) $this->secondFactorType : null,
             'second_factor_identifier' => $this->secondFactorIdentifier,

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
@@ -104,6 +104,17 @@ class AuditLogEntry implements JsonSerializable
     public $actorInstitution;
 
     /**
+     * Only in certain situations will this field be filled, It represents the RA institution the
+     * event log entry is targeted at. For example. John Doe is accredited to become RA by Joe from
+     * institution-a. The actual institution John is appointed RA for is stored in this field.
+     *
+     * @ORM\Column(length=255, nullable=true)
+     *
+     * @var string|null
+     */
+    public $raInstitution;
+
+    /**
      * @ORM\Column(length=36)
      *
      * @var string

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/AuditLogProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/AuditLogProjector.php
@@ -113,6 +113,10 @@ class AuditLogProjector implements ProjectorInterface
             $entry->secondFactorIdentifier = (string) $auditLogMetadata->secondFactorIdentifier;
         }
 
+        if ($auditLogMetadata->raInstitution) {
+            $entry->raInstitution = (string) $auditLogMetadata->raInstitution;
+        }
+
         $this->auditLogRepository->save($entry);
     }
 


### PR DESCRIPTION
The RA institution is saved to the auditlog projection when it is set on the metadata context.

This resulted in a small schema change. So run the migration!

Think/discuss: do we need to facilitate additional support for the previous versions of these events?

See: https://github.com/OpenConext/Stepup-RA/pull/181
See: https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/71
See: https://github.com/OpenConext/Stepup-Middleware/pull/253