### PR TITLE
Fix the select_raa check when appointing roles

### DIFF
--- a/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
+++ b/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
@@ -469,19 +469,14 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
     }
 
     /**
-     * Check if role is allowed
+     * Check if role from institution is allowed to accredit roles
      *
-     * @param RegistrationAuthorityRole $role
      * @param Institution $institution
      * @return bool
      */
-    public function isAllowed(RegistrationAuthorityRole $role, Institution $institution)
+    public function isInstitutionAllowedToAccreditRoles(Institution $institution)
     {
-        if ($role->isRa() && $this->useRaOption->hasInstitution($institution)) {
-            return true;
-        }
-
-        if ($role->isRaa() && $this->useRaaOption->hasInstitution($institution)) {
+        if ($this->selectRaaOption->hasInstitution($institution, $this->institution)) {
             return true;
         }
 

--- a/src/Surfnet/Stepup/Configuration/Value/InstitutionAuthorizationOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/InstitutionAuthorizationOption.php
@@ -182,11 +182,12 @@ final class InstitutionAuthorizationOption implements JsonSerializable
 
     /**
      * @param Institution $institution
+     * @param Institution $default
      * @return bool
      */
-    public function hasInstitution(Institution $institution)
+    public function hasInstitution(Institution $institution, Institution $default)
     {
-        $institutions = $this->getInstitutions($institution);
+        $institutions = $this->getInstitutions($default);
         $list = array_map(
             function (Institution $institution) {
                 return $institution->getInstitution();

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -586,8 +586,8 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     ) {
         $this->assertNotForgotten();
 
-        if (!$institutionConfiguration->isAllowed($role, new ConfigurationInstitution($institution->getInstitution()))) {
-            throw new DomainException('An Identity may only be accredited with configured institutions');
+        if (!$institutionConfiguration->isInstitutionAllowedToAccreditRoles(new ConfigurationInstitution($institution->getInstitution()))) {
+            throw new DomainException('An Identity may only be accredited by configured institutions.');
         }
 
         if (!$this->vettedSecondFactors->count()) {
@@ -661,7 +661,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     ) {
         $this->assertNotForgotten();
 
-        if (!$institutionConfiguration->isAllowed($role, new ConfigurationInstitution($institution->getInstitution()))) {
+        if (!$institutionConfiguration->isInstitutionAllowedToAccreditRoles(new ConfigurationInstitution($institution->getInstitution()))) {
             throw new DomainException(
                 'Cannot appoint as different RegistrationAuthorityRole: identity is not a registration authority for institution'
             );

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionAuthorizationOptionTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionAuthorizationOptionTest.php
@@ -162,7 +162,7 @@ class InstitutionAuthorizationOptionTest extends TestCase
         }
         $option = InstitutionAuthorizationOption::fromInstitutions(InstitutionRole::useRa(), $this->institution, $list);
 
-        $this->assertEquals($expectation, $option->hasInstitution($institution));
+        $this->assertEquals($expectation, $option->hasInstitution($institution, $this->institution));
     }
 
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
@@ -101,7 +101,7 @@ class RegistrationAuthorityCommandHandler extends CommandHandler
         /** @var \Surfnet\Stepup\Identity\Api\Identity $identity */
         $identity = $this->repository->load(new IdentityId($command->identityId));
 
-        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($identity->getInstitution()->getInstitution()));
+        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->raInstitution));
 
         $newRole = $this->assertValidRoleAndConvertIfValid($command->role, $command->UUID);
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
@@ -100,9 +100,9 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
      * @group                    command-handler
      * @group                    ra-command-handler
      * @expectedException        \Surfnet\Stepup\Exception\DomainException
-     * @expectedExceptionMessage An Identity may only be accredited with configured institutions
+     * @expectedExceptionMessage An Identity may only be accredited by configured institutions
      */
-    public function an_identity_cannot_be_accredited_for_another_institution_than_its_own()
+    public function an_identity_cannot_be_accredited_for_another_institution_than_configured()
     {
         $command                     = new AccreditIdentityCommand();
         $command->identityId         = static::uuid();
@@ -121,7 +121,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(false);
 
         $this->scenario
@@ -173,7 +173,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $commonName           = new CommonName('Henk Westbroek');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -218,7 +218,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -332,7 +332,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $raInstitution        = new Institution($command->raInstitution);
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -398,7 +398,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -584,7 +584,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $commonName           = new CommonName('Henk Westbroek');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -627,7 +627,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $raInstitution        = new Institution($command->raInstitution);
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -694,7 +694,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -800,7 +800,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -867,7 +867,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(true);
 
         $this->scenario
@@ -935,7 +935,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $secondFactorPublicId = new YubikeyPublicId('8329283834');
 
         $this->institutionConfiguration
-            ->shouldReceive('isAllowed')
+            ->shouldReceive('isInstitutionAllowedToAccreditRoles')
             ->andReturn(false);
 
         $this->scenario


### PR DESCRIPTION
The check for appointing roles in the identity aggregate was
incorrect. This change will fix this behavior.