### PR TITLE
Make institution parameter optional

### DIFF
--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -85,7 +85,7 @@ Request parameters:
 URL: `http://middleware.tld/identity/?insitution=Ibuildings{&NameID=}{&commonName=}{&email=}{&p=3}`
 Method: GET
 Request parameters:
-- Institution: (required) string, the institution as scope determination
+- Institution: (optional) string, the institution as scope determination
 - NameID: (optional) string, the NameID to search (equality check)
 - commonName: (optional) string, the commonName to match against
 - email: (optional) string, the email to match against

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaEvent.php
@@ -26,7 +26,6 @@ use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\RegistrationAuthorityRole;
 
-
 /**
  * @deprecated This event is superseded by the IdentityAccreditedAsRaaForInstitutionEvent because an RA institution was needed
  */

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
@@ -66,17 +66,20 @@ class IdentityController extends Controller
         return new JsonResponse($identity);
     }
 
-    public function collectionAction(Request $request, Institution $institution)
+    public function collectionAction(Request $request)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
         $query = new IdentityQuery();
-        $query->institution = $institution;
+        $query->institution = $request->get('institution');
         $query->nameId = $request->get('NameID');
         $query->commonName = $request->get('commonName');
         $query->email = $request->get('email');
         $query->pageNumber = (int)$request->get('p', 1);
-        $query->authorizationContext = new InstitutionAuthorizationContext($query->institution, $this->roleRequirements);
+
+        if ($query->institution) {
+            $query->authorizationContext = new InstitutionAuthorizationContext($query->institution, $this->roleRequirements);
+        }
 
         $paginator = $this->identityService->search($query);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentityRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentityRepository.php
@@ -76,8 +76,17 @@ class IdentityRepository extends EntityRepository
     ) {
         $queryBuilder = $this->createQueryBuilder('i');
 
-        // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'i.id', 'i.institution', 'iac');
+        // If no institution context is provided, we are not able to query with authorization context
+        if ($query->authorizationContext) {
+            // Modify query to filter on authorization
+            $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'i.id', 'i.institution', 'iac');
+        }
+
+        if ($query->institution) {
+            $queryBuilder
+                ->andWhere('i.institution = :institution')
+                ->setParameter('institution', $query->institution);
+        }
 
         if ($query->nameId) {
             $queryBuilder


### PR DESCRIPTION
In order to ensure we can find an identity, we no longer need to set
the institution of that identity. As the RA(A) might be RA for an
institution it does not have a SHO for.

This change was applied in:

 - https://github.com/OpenConext/Stepup-RA/pull/183
 - https://github.com/OpenConext/Stepup-SelfService/pull/161
 - Middleware-clientbundle https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/72