### PR TITLE
Fix ra-authorization filter

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
@@ -47,7 +47,7 @@ class InstitutionAuthorizationRepositoryFilter
             $this->getRolesDql($authorizationAlias, $authorizationContext->getRoleRequirements())
         );
 
-        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getInstitutionParameterName($authorizationAlias)}");
+        $queryBuilder->andWhere("{$authorizationAlias}.institutionRelation = :{$this->getInstitutionParameterName($authorizationAlias)}");
         $queryBuilder->innerJoin(InstitutionAuthorization::class, $authorizationAlias, Join::WITH, $condition);
         if (!is_array($groupBy)) {
             $queryBuilder->groupBy($groupBy);
@@ -83,7 +83,7 @@ class InstitutionAuthorizationRepositoryFilter
      */
     private function getInstitutionDql($authorizationAlias, $institutionField)
     {
-        return sprintf('%s.institutionRelation = %s', $authorizationAlias, $institutionField);
+        return sprintf('%s.institution = %s', $authorizationAlias, $institutionField);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
@@ -77,7 +77,7 @@ class InstitutionAuthorizationRepositoryFilterTest extends TestCase
         $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
         $authorizationRepositoryFilter->filter($this->queryBuilder, $this->mockedAuthorizationContext, 'i.id', 'i.institution', 'iacalias');
 
-        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
+        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institution = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) WHERE iacalias.institutionRelation = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
         $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
         $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
     }


### PR DESCRIPTION
There was a bug in the authorization filter which filtered out
the ra's which could act on behalf of another institution.