### PR TITLE
Fix authorization filter

### DIFF
--- a/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/SelectRaaOptionChangedEvent.php
@@ -57,7 +57,7 @@ final class SelectRaaOptionChangedEvent implements SerializableInterface
         return new self(
             new InstitutionConfigurationId($data['institution_configuration_id']),
             $institution,
-            InstitutionAuthorizationOption::fromInstitutionConfig(InstitutionRole::useRaa(), $data['select_raa_option'])
+            InstitutionAuthorizationOption::fromInstitutionConfig(InstitutionRole::selectRaa(), $data['select_raa_option'])
         );
     }
 

--- a/src/Surfnet/Stepup/Identity/Entity/InstitutionCollection.php
+++ b/src/Surfnet/Stepup/Identity/Entity/InstitutionCollection.php
@@ -80,4 +80,12 @@ final class InstitutionCollection
     {
         return count($this->institutions);
     }
+
+    /**
+     * @return InstitutionRole[]
+     */
+    public function institutions()
+    {
+        return $this->institutions;
+    }
 }

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -586,7 +586,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     ) {
         $this->assertNotForgotten();
 
-        if (!$institutionConfiguration->isInstitutionAllowedToAccreditRoles(new ConfigurationInstitution($institution->getInstitution()))) {
+        if (!$institutionConfiguration->isInstitutionAllowedToAccreditRoles(new ConfigurationInstitution($this->institution->getInstitution()))) {
             throw new DomainException('An Identity may only be accredited by configured institutions.');
         }
 
@@ -661,7 +661,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     ) {
         $this->assertNotForgotten();
 
-        if (!$institutionConfiguration->isInstitutionAllowedToAccreditRoles(new ConfigurationInstitution($institution->getInstitution()))) {
+        if (!$institutionConfiguration->isInstitutionAllowedToAccreditRoles(new ConfigurationInstitution($this->institution->getInstitution()))) {
             throw new DomainException(
                 'Cannot appoint as different RegistrationAuthorityRole: identity is not a registration authority for institution'
             );

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
@@ -42,12 +42,14 @@ class InstitutionAuthorizationRepositoryFilter
         $authorizationAlias
     ) {
         $condition = sprintf(
-            '(%s AND (%s))',
+            '(%s AND (%s)) OR (%s AND (%s))',
             $this->getInstitutionDql($authorizationAlias, $institutionField),
-            $this->getRolesDql($authorizationAlias, $authorizationContext->getRoleRequirements())
+            $this->getRolesDql($authorizationAlias, $authorizationContext->getRoleRequirements()),
+            $this->getInstitutionRelationDql($authorizationAlias, $institutionField),
+            $this->getRolesDql($authorizationAlias, new InstitutionRoleSet([InstitutionRole::selectRaa()]))
         );
 
-        $queryBuilder->andWhere("{$authorizationAlias}.institutionRelation = :{$this->getInstitutionParameterName($authorizationAlias)}");
+        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getInstitutionParameterName($authorizationAlias)}");
         $queryBuilder->innerJoin(InstitutionAuthorization::class, $authorizationAlias, Join::WITH, $condition);
         if (!is_array($groupBy)) {
             $queryBuilder->groupBy($groupBy);
@@ -82,6 +84,17 @@ class InstitutionAuthorizationRepositoryFilter
      * @return string
      */
     private function getInstitutionDql($authorizationAlias, $institutionField)
+    {
+        return sprintf('%s.institutionRelation = %s', $authorizationAlias, $institutionField);
+    }
+
+
+    /**
+     * @param string $authorizationAlias
+     * @param string $institutionField
+     * @return string
+     */
+    private function getInstitutionRelationDql($authorizationAlias, $institutionField)
     {
         return sprintf('%s.institution = %s', $authorizationAlias, $institutionField);
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
@@ -25,6 +25,8 @@ use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\InstitutionListing;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaListing;
 
 class InstitutionAuthorizationRepositoryFilter
 {
@@ -42,16 +44,43 @@ class InstitutionAuthorizationRepositoryFilter
         $institutionField,
         $authorizationAlias
     ) {
-        $condition = sprintf(
-            '(%s AND (%s)) OR (%s AND (%s))',
-            $this->getInstitutionDql($authorizationAlias, $institutionField),
-            $this->getRolesDql($authorizationAlias, $authorizationContext->getRoleRequirements()),
-            $this->getInstitutionRelationDql($authorizationAlias, $institutionField),
-            $this->getRolesDql($authorizationAlias, new InstitutionRoleSet([InstitutionRole::selectRaa()]))
+
+        $authorizationAliasListing = $authorizationAlias.'_listing';
+        $authorizationAliasInstitution = $authorizationAlias.'_institution';
+
+        $institutionCondition = sprintf(
+            '(%s.institution = %s)',
+            $authorizationAliasInstitution,
+            $institutionField
+        );
+        $listingCondition = sprintf(
+            '(%s.raInstitution = %s.institution)',
+            $authorizationAliasListing,
+            $authorizationAliasInstitution
+        );
+        $authorizationCondition = sprintf(
+            '(%s.institution = %s.institutionRelation AND (%s))',
+            $authorizationAliasInstitution,
+            $authorizationAlias,
+            $this->getRolesDql($authorizationAlias, $authorizationContext->getRoleRequirements())
+
         );
 
-        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getInstitutionParameterName($authorizationAlias)}");
-        $queryBuilder->innerJoin(InstitutionAuthorization::class, $authorizationAlias, Join::WITH, $condition);
+        $whereCondition = sprintf("
+            ((%s.identityId = :%s AND (%s)) OR (%s = %s.institution))
+            ",
+            $authorizationAliasListing,
+            $this->getParameterName($authorizationAliasListing, 'identityId'),
+            $this->getListingRolesDql($authorizationAliasListing, $authorizationContext->getRoleRequirements()),
+            $institutionField,
+            $authorizationAliasInstitution
+        );
+
+        $queryBuilder->leftJoin(InstitutionListing::class, $authorizationAliasInstitution, Join::WITH, $institutionCondition);
+        $queryBuilder->leftJoin(RaListing::class, $authorizationAliasListing, Join::WITH, $listingCondition);
+        $queryBuilder->leftJoin(InstitutionAuthorization::class, $authorizationAlias, Join::WITH, $authorizationCondition);
+        $queryBuilder->andWhere($whereCondition);
+
         if (!is_array($groupBy)) {
             $queryBuilder->groupBy($groupBy);
         } else {
@@ -60,7 +89,7 @@ class InstitutionAuthorizationRepositoryFilter
             }
         }
 
-        $queryBuilder->setParameter($this->getInstitutionParameterName($authorizationAlias), (string)$authorizationContext->getActorInstitution());
+        $queryBuilder->setParameter($this->getParameterName($authorizationAliasListing, 'identityId'), (string)$authorizationContext->getIdentityId());
     }
 
     /**
@@ -83,7 +112,7 @@ class InstitutionAuthorizationRepositoryFilter
             $this->getRolesDql($authorizationAlias, $authorizationContext->getRoleRequirements())
         );
 
-        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getInstitutionParameterName($authorizationAlias)}");
+        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getParameterName($authorizationAlias, 'institution')}");
         $queryBuilder->innerJoin(InstitutionAuthorization::class, $authorizationAlias, Join::WITH, $condition);
         if (!is_array($groupBy)) {
             $queryBuilder->groupBy($groupBy);
@@ -93,7 +122,7 @@ class InstitutionAuthorizationRepositoryFilter
             }
         }
 
-        $queryBuilder->setParameter($this->getInstitutionParameterName($authorizationAlias), (string)$authorizationContext->getActorInstitution());
+        $queryBuilder->setParameter($this->getParameterName($authorizationAlias, 'institution'), (string)$authorizationContext->getActorInstitution());
     }
 
     /**
@@ -116,7 +145,7 @@ class InstitutionAuthorizationRepositoryFilter
             $this->getRolesDql($authorizationAlias, new InstitutionRoleSet([InstitutionRole::selectRaa()]))
         );
 
-        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getInstitutionParameterName($authorizationAlias)}");
+        $queryBuilder->andWhere("{$authorizationAlias}.institution = :{$this->getParameterName($authorizationAlias, 'institution')}");
         $queryBuilder->innerJoin(InstitutionAuthorization::class, $authorizationAlias, Join::WITH, $condition);
         if (!is_array($groupBy)) {
             $queryBuilder->groupBy($groupBy);
@@ -126,7 +155,7 @@ class InstitutionAuthorizationRepositoryFilter
             }
         }
 
-        $queryBuilder->setParameter($this->getInstitutionParameterName($authorizationAlias), (string)$institution);
+        $queryBuilder->setParameter($this->getParameterName($authorizationAlias, 'institution'), (string)$institution);
     }
 
     /**
@@ -139,6 +168,27 @@ class InstitutionAuthorizationRepositoryFilter
         $keys = array_map(
             function (InstitutionRole $role) use ($authorizationAlias) {
                 return $authorizationAlias.".institutionRole = '{$role->getType()}'";
+            },
+            $roleSet->getRoles()
+        );
+        return implode(' OR ', $keys);
+    }
+
+
+    /**
+     * @param string $authorizationAlias
+     * @param InstitutionRoleSet $roleSet
+     * @return string
+     */
+    private function getListingRolesDql($authorizationAlias, InstitutionRoleSet $roleSet)
+    {
+        $map = [
+            InstitutionRole::ROLE_USE_RA => 'ra',
+            InstitutionRole::ROLE_USE_RAA => 'raa',
+        ];
+        $keys = array_map(
+            function (InstitutionRole $role) use ($authorizationAlias, $map) {
+                return $authorizationAlias . ".role = '{$map[$role->getType()]}'";
             },
             $roleSet->getRoles()
         );
@@ -169,10 +219,11 @@ class InstitutionAuthorizationRepositoryFilter
 
     /**
      * @param $authorizationAlias
+     * @param $name
      * @return string
      */
-    private function getInstitutionParameterName($authorizationAlias)
+    private function getParameterName($authorizationAlias, $name)
     {
-        return "{$authorizationAlias}_institution";
+        return "{$authorizationAlias}_{$name}";
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Filter/InstitutionAuthorizationRepositoryFilter.php
@@ -87,7 +87,10 @@ class InstitutionAuthorizationRepositoryFilter
             }
         }
 
-        $queryBuilder->setParameter($this->getParameterName($authorizationAlias, 'institution'), (string)$authorizationContext->getActorInstitution());
+        $queryBuilder->setParameter(
+            $this->getParameterName($authorizationAlias, 'institution'),
+            (string)$authorizationContext->getActorInstitution()
+        );
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/InstitutionAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/InstitutionAuthorizationService.php
@@ -89,5 +89,4 @@ class InstitutionAuthorizationService
 
         return new InstitutionAuthorizationContext($actorInstitution, $roleRequirements, $institutions, $isSraa);
     }
-
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/InstitutionAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/InstitutionAuthorizationService.php
@@ -18,11 +18,17 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Service;
 
+use Doctrine\ORM\Query\Expr\Join;
+use Surfnet\Stepup\Configuration\Value\InstitutionRole;
+use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
+use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\InvalidArgumentException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaListing;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\InstitutionListingRepository;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SraaService;
 
@@ -43,11 +49,19 @@ class InstitutionAuthorizationService
      * @var IdentityService
      */
     private $identityService;
+    /**
+     * @var InstitutionListingRepository
+     */
+    private $institutionListingRepository;
 
-    public function __construct(SraaService $sraaService, IdentityService $identityService)
-    {
+    public function __construct(
+        SraaService $sraaService,
+        IdentityService $identityService,
+        InstitutionListingRepository $institutionListingRepository
+    ) {
         $this->sraaService = $sraaService;
         $this->identityService = $identityService;
+        $this->institutionListingRepository = $institutionListingRepository;
     }
 
     /**
@@ -71,6 +85,9 @@ class InstitutionAuthorizationService
         $sraa = $this->sraaService->findByNameId($identity->nameId);
         $isSraa = !is_null($sraa);
 
-        return new InstitutionAuthorizationContext($actorInstitution, $roleRequirements, $isSraa);
+        $institutions = $this->institutionListingRepository->getInstitutions($roleRequirements, $actorId);
+
+        return new InstitutionAuthorizationContext($actorInstitution, $roleRequirements, $institutions, $isSraa);
     }
+
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContext.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContext.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Value;
 
+use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 use Surfnet\Stepup\Identity\Value\Institution;
 
 class InstitutionAuthorizationContext implements InstitutionAuthorizationContextInterface
@@ -33,6 +34,11 @@ class InstitutionAuthorizationContext implements InstitutionAuthorizationContext
     private $roleRequirements;
 
     /**
+     * @var InstitutionCollection|null
+     */
+    private $institutions;
+
+    /**
      * @var bool
      */
     private $isSraa;
@@ -41,15 +47,18 @@ class InstitutionAuthorizationContext implements InstitutionAuthorizationContext
      * AuthorizationContext constructor.
      * @param Institution $actorInstitution
      * @param InstitutionRoleSetInterface $roleRequirements
+     * @param InstitutionCollection $institutions[]
      * @param bool $isSraa describes if the actor is SRAA or not. Default: false
      */
     public function __construct(
         Institution $actorInstitution,
         InstitutionRoleSetInterface $roleRequirements,
+        InstitutionCollection $institutions = null,
         $isSraa = false
     ) {
         $this->actorInstitution = $actorInstitution;
         $this->roleRequirements = $roleRequirements;
+        $this->institutions = $institutions;
         $this->isSraa = $isSraa;
     }
 
@@ -67,6 +76,14 @@ class InstitutionAuthorizationContext implements InstitutionAuthorizationContext
     public function getRoleRequirements()
     {
         return $this->roleRequirements;
+    }
+
+    /**
+     * @return InstitutionCollection
+     */
+    public function getInstitutions()
+    {
+        return $this->institutions;
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContextInterface.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContextInterface.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Value;
 
+use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 use Surfnet\Stepup\Identity\Value\Institution;
 
 /**
@@ -42,4 +43,14 @@ interface InstitutionAuthorizationContextInterface
      * @return InstitutionRoleSet
      */
     public function getRoleRequirements();
+
+    /**
+     * @return InstitutionCollection
+     */
+    public function getInstitutions();
+
+    /**
+     * @return bool
+     */
+    public function isActorSraa();
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -19,8 +19,9 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
+use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\InstitutionAuthorizationService;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaSecondFactorService;
@@ -40,14 +41,21 @@ final class RaSecondFactorController extends Controller
      * @var InstitutionRoleSet
      */
     private $roleRequirements;
+    /**
+     * @var InstitutionAuthorizationService
+     */
+    private $authorizationService;
 
-    public function __construct(RaSecondFactorService $raSecondFactorService)
-    {
+    public function __construct(
+        RaSecondFactorService $raSecondFactorService,
+        InstitutionAuthorizationService $authorizationService
+    ) {
         $this->raSecondFactorService = $raSecondFactorService;
 
         $this->roleRequirements = new InstitutionRoleSet(
             [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
         );
+        $this->authorizationService = $authorizationService;
     }
 
     public function collectionAction(Request $request, Institution $actorInstitution)
@@ -74,11 +82,13 @@ final class RaSecondFactorController extends Controller
 
     /**
      * @param Request $request
-     * @param Institution $institution
+     * @param Institution $actorInstitution
      * @return RaSecondFactorQuery
      */
     private function buildRaSecondFactorQuery(Request $request, Institution $actorInstitution)
     {
+        $actorId = new IdentityId($request->get('actorId'));
+
         $query = new RaSecondFactorQuery();
         $query->actorInstitution = $actorInstitution;
         $query->pageNumber = (int)$request->get('p', 1);
@@ -90,7 +100,7 @@ final class RaSecondFactorController extends Controller
         $query->status = $request->get('status');
         $query->orderBy = $request->get('orderBy');
         $query->orderDirection = $request->get('orderDirection');
-        $query->authorizationContext = new InstitutionAuthorizationContext($actorInstitution, $this->roleRequirements);
+        $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext($actorInstitution, $this->roleRequirements, $actorId);
 
         return $query;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -100,7 +100,11 @@ final class RaSecondFactorController extends Controller
         $query->status = $request->get('status');
         $query->orderBy = $request->get('orderBy');
         $query->orderDirection = $request->get('orderDirection');
-        $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext($actorInstitution, $this->roleRequirements, $actorId);
+        $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext(
+            $actorInstitution,
+            $this->roleRequirements,
+            $actorId
+        );
 
         return $query;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -230,7 +230,7 @@ class RaCandidateProjector extends Projector
         // loop through authorized institutions
         foreach ($raInstitutions as $raInstitution) {
             // add new identities
-            $raSecondFactors = $this->raSecondFactorRepository->findByInstitution($raInstitution->getIstitution());
+            $raSecondFactors = $this->raSecondFactorRepository->findByInstitution($raInstitution->getInstitution());
             foreach ($raSecondFactors as $raSecondFactor) {
                 $identity = $this->identityRepository->find($raSecondFactor->identityId);
                 $identityId = new IdentityId($identity->id);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -91,6 +91,38 @@ class RaCandidateProjector extends Projector
     }
 
     /**
+     * @param SecondFactorVettedEvent $event
+     * @return void
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $this->addCandidateToProjection(
+            $event->identityInstitution,
+            $event->identityId,
+            $event->nameId,
+            $event->commonName,
+            $event->email
+        );
+    }
+
+    /**
+     * @param YubikeySecondFactorBootstrappedEvent $event
+     * @return void
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function applyYubikeySecondFactorBootstrappedEvent(YubikeySecondFactorBootstrappedEvent $event)
+    {
+        $this->addCandidateToProjection(
+            $event->identityInstitution,
+            $event->identityId,
+            $event->nameId,
+            $event->commonName,
+            $event->email
+        );
+    }
+
+    /**
      * @param VettedSecondFactorRevokedEvent $event
      * @return void
      */

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -84,36 +84,6 @@ class RaCandidateProjector extends Projector
     }
 
     /**
-     * @param SecondFactorVettedEvent $event
-     * @return void
-     */
-    public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
-    {
-        $this->addCandidateToProjection(
-            $event->identityInstitution,
-            $event->identityId,
-            $event->nameId,
-            $event->commonName,
-            $event->email
-        );
-    }
-
-    /**
-     * @param YubikeySecondFactorBootstrappedEvent $event
-     * @return void
-     */
-    public function applyYubikeySecondFactorBootstrappedEvent(YubikeySecondFactorBootstrappedEvent $event)
-    {
-        $this->addCandidateToProjection(
-            $event->identityInstitution,
-            $event->identityId,
-            $event->nameId,
-            $event->commonName,
-            $event->email
-        );
-    }
-
-    /**
      * @param VettedSecondFactorRevokedEvent $event
      * @return void
      */

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -45,6 +45,7 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaCandidate;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaListingRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaSecondFactorRepository;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -70,17 +71,23 @@ class RaCandidateProjector extends Projector
      * @var IdentityRepository
      */
     private $identityRepository;
+    /**
+     * @var RaSecondFactorRepository
+     */
+    private $raSecondFactorRepository;
 
     public function __construct(
         RaCandidateRepository $raCandidateRepository,
         RaListingRepository $raListingRepository,
         InstitutionAuthorizationRepository $institutionAuthorizationRepository,
-        IdentityRepository $identityRepository
+        IdentityRepository $identityRepository,
+        RaSecondFactorRepository $raSecondFactorRepository
     ) {
         $this->raCandidateRepository = $raCandidateRepository;
         $this->raListingRepository = $raListingRepository;
         $this->institutionAuthorizationRepository = $institutionAuthorizationRepository;
         $this->identityRepository = $identityRepository;
+        $this->raSecondFactorRepository = $raSecondFactorRepository;
     }
 
     /**
@@ -223,8 +230,9 @@ class RaCandidateProjector extends Projector
         // loop through authorized institutions
         foreach ($raInstitutions as $raInstitution) {
             // add new identities
-            $identities = $this->identityRepository->findByInstitution($raInstitution);
-            foreach ($identities as $identity) {
+            $raSecondFactors = $this->raSecondFactorRepository->findByInstitution($raInstitution->getIstitution());
+            foreach ($raSecondFactors as $raSecondFactor) {
+                $identity = $this->identityRepository->find($raSecondFactor->identityId);
                 $identityId = new IdentityId($identity->id);
 
                 // check if persistent in ra listing

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -176,13 +176,16 @@ class RaCandidateProjector extends Projector
      */
     public function applyRegistrationAuthorityRetractedForInstitutionEvent(RegistrationAuthorityRetractedForInstitutionEvent $event)
     {
-        $this->addCandidateToProjection(
-            $event->identityInstitution,
+        $candidate = RaCandidate::nominate(
             $event->identityId,
+            $event->identityInstitution,
             $event->nameId,
             $event->commonName,
-            $event->email
+            $event->email,
+            $event->raInstitution
         );
+
+        $this->raCandidateRepository->merge($candidate);
     }
 
     protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentityRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentityRepository.php
@@ -76,12 +76,6 @@ class IdentityRepository extends EntityRepository
     ) {
         $queryBuilder = $this->createQueryBuilder('i');
 
-        // If no institution context is provided, we are not able to query with authorization context
-        if ($query->authorizationContext) {
-            // Modify query to filter on authorization
-            $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'i.id', 'i.institution', 'iac');
-        }
-
         if ($query->institution) {
             $queryBuilder
                 ->andWhere('i.institution = :institution')

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/InstitutionListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/InstitutionListingRepository.php
@@ -59,18 +59,36 @@ class InstitutionListingRepository extends EntityRepository
      * @param IdentityId $actorId
      * @return InstitutionCollection
      */
-    public function getInstitutions(InstitutionRoleSet $roleRequirements, IdentityId $actorId) {
+    public function getInstitutions(InstitutionRoleSet $roleRequirements, IdentityId $actorId)
+    {
         $qb = $this->createQueryBuilder('i')
             ->select("a.institution")
             ->innerJoin(RaListing::class, 'r', Join::WITH, "i.institution = r.raInstitution")
-            ->leftJoin(InstitutionAuthorization::class, 'a', Join::WITH, "i.institution = a.institutionRelation AND a.institutionRole IN (:authorizationRoles)")
+            ->leftJoin(
+                InstitutionAuthorization::class,
+                'a',
+                Join::WITH,
+                "i.institution = a.institutionRelation AND a.institutionRole IN (:authorizationRoles)"
+            )
             ->where("r.identityId = :identityId AND r.role IN(:roles)")
             ->groupBy("a.institution");
 
 
         $qb->setParameter('identityId', (string)$actorId);
-        $qb->setParameter('authorizationRoles', $this->getAuthorizationRoles($roleRequirements, [InstitutionRole::ROLE_USE_RA => InstitutionRole::ROLE_USE_RA, InstitutionRole::ROLE_USE_RAA => InstitutionRole::ROLE_USE_RAA]));
-        $qb->setParameter('roles', $this->getAuthorizationRoles($roleRequirements, [InstitutionRole::ROLE_USE_RA => 'ra', InstitutionRole::ROLE_USE_RAA => 'raa']));
+        $qb->setParameter(
+            'authorizationRoles',
+            $this->getAuthorizationRoles(
+                $roleRequirements,
+                [InstitutionRole::ROLE_USE_RA => InstitutionRole::ROLE_USE_RA, InstitutionRole::ROLE_USE_RAA => InstitutionRole::ROLE_USE_RAA]
+            )
+        );
+        $qb->setParameter(
+            'roles',
+            $this->getAuthorizationRoles(
+                $roleRequirements,
+                [InstitutionRole::ROLE_USE_RA => 'ra', InstitutionRole::ROLE_USE_RAA => 'raa']
+            )
+        );
 
         $institutions = $qb->getQuery()->getArrayResult();
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -163,9 +163,13 @@ class RaCandidateRepository extends EntityRepository
         $queryBuilder = $this->createQueryBuilder('rac');
 
         // Modify query to filter on authorization
-        $queryBuilder
-            ->andWhere('rac.raInstitution = :raInstitution')
-            ->setParameter('raInstitution', $query->authorizationContext->getActorInstitution());
+        $this->authorizationRepositoryFilter->filterCandidate(
+            $queryBuilder,
+            $query->authorizationContext->getActorInstitution(),
+            'rac.identityId',
+            'rac.raInstitution',
+            'iac'
+        );
 
         if ($query->institution) {
             $queryBuilder
@@ -237,6 +241,31 @@ class RaCandidateRepository extends EntityRepository
             ->setParameter('raInstitution', $raInstitution)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+
+    /**
+     * @param string $identityId
+     * @param Institution $raInstitution
+     * @return RaCandidate[]
+     */
+    public function findAllRaasByIdentityIdAndRaInstitution($identityId, Institution $raInstitution)
+    {
+        $queryBuilder = $this->createQueryBuilder('rac')
+            ->where('rac.identityId = :identityId')
+            ->setParameter('identityId', $identityId)
+            ->orderBy('rac.raInstitution');
+
+            // Modify query to filter on authorization
+        $this->authorizationRepositoryFilter->filterCandidateReverse(
+            $queryBuilder,
+            $raInstitution,
+            'rac.raInstitution',
+            'rac.raInstitution',
+            'iac'
+        );
+
+        return $queryBuilder->getQuery()->getResult();
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -257,7 +257,7 @@ class RaCandidateRepository extends EntityRepository
             ->orderBy('rac.raInstitution');
 
             // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filterCandidateReverse(
+        $this->authorizationRepositoryFilter->filterCandidate(
             $queryBuilder,
             $raInstitution,
             'rac.raInstitution',

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -163,13 +163,9 @@ class RaCandidateRepository extends EntityRepository
         $queryBuilder = $this->createQueryBuilder('rac');
 
         // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'rac.identityId', 'rac.institution', 'iac');
-
-        if ($query->actorInstitution) {
-            $queryBuilder
-                ->andWhere('rac.raInstitution = :raInstitution')
-                ->setParameter('raInstitution', $query->actorInstitution);
-        }
+        $queryBuilder
+            ->andWhere('rac.raInstitution = :raInstitution')
+            ->setParameter('raInstitution', $query->authorizationContext->getActorInstitution());
 
         if ($query->institution) {
             $queryBuilder

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
@@ -95,7 +95,7 @@ class RaListingRepository extends EntityRepository
         $queryBuilder = $this->createQueryBuilder('r');
 
         // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filter(
+        $this->authorizationRepositoryFilter->filterListing(
             $queryBuilder,
             $query->authorizationContext,
             ['r.identityId', 'r.institution', 'r.raInstitution'],

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
@@ -94,7 +94,10 @@ class RaSecondFactorRepository extends EntityRepository
             ->createQueryBuilder('sf');
 
         // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'sf.id', 'sf.institution', 'iac');
+        // The SRAA user does not adhere to the FGA filter rules when searching for tokens
+        if (!$query->authorizationContext->isActorSraa()) {
+            $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'sf.id', 'sf.institution', 'iac');
+        }
 
         if ($query->name) {
             $queryBuilder->andWhere('sf.name LIKE :name')->setParameter('name', sprintf('%%%s%%', $query->name));

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
@@ -69,6 +69,16 @@ class RaSecondFactorRepository extends EntityRepository
         return parent::findBy(['identityId' => $identityId]);
     }
 
+
+    /**
+     * @param string $institution
+     * @return RaSecondFactor[]
+     */
+    public function findByInstitution($institution)
+    {
+        return parent::findBy(['institution' => $institution]);
+    }
+
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) The amount of if statements do not necessarily make the method
      *                                               below complex or hard to maintain.

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
@@ -96,7 +96,12 @@ class RaSecondFactorRepository extends EntityRepository
         // Modify query to filter on authorization
         // The SRAA user does not adhere to the FGA filter rules when searching for tokens
         if (!$query->authorizationContext->isActorSraa()) {
-            $this->authorizationRepositoryFilter->filter($queryBuilder, $query->authorizationContext, 'sf.id', 'sf.institution', 'iac');
+            $this->authorizationRepositoryFilter->filter(
+                $queryBuilder,
+                $query->authorizationContext,
+                'sf.institution',
+                'iac'
+            );
         }
 
         if ($query->name) {

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
@@ -125,7 +125,6 @@ class VerifiedSecondFactorRepository extends EntityRepository
             $this->authorizationRepositoryFilter->filter(
                 $queryBuilder,
                 $query->authorizationContext,
-                'sf.id',
                 'sf.institution',
                 'iac'
             );

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RaCandidateService.php
@@ -53,13 +53,12 @@ class RaCandidateService extends AbstractSearchService
     /**
      * @param string $identityId
      * @param Institution $institution
-     * @return null|\Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaCandidate
-     * @throws \Doctrine\ORM\NonUniqueResultException
+     * @return null|\Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaCandidate[]
      */
     public function findByIdentityIdAndRaInstitution($identityId, Institution $institution)
     {
-        $raCandidate = $this->raCandidateRepository->findByIdentityIdAndRaInstitution($identityId, $institution);
+        $raCandidates = $this->raCandidateRepository->findAllRaasByIdentityIdAndRaInstitution($identityId, $institution);
 
-        return $raCandidate;
+        return $raCandidates;
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RaListingService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RaListingService.php
@@ -39,13 +39,9 @@ class RaListingService extends AbstractSearchService
 
     /**
      * @param IdentityId $identityId
-     * @return null|RaListing[]
+     * @param Institution $raInstitution
+     * @return null|\Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaListing
      */
-    public function findByIdentityId(IdentityId $identityId)
-    {
-        return $this->raListingRepository->findByIdentityId($identityId);
-    }
-
     public function findByIdentityIdAndRaInstitution(IdentityId $identityId, Institution $raInstitution)
     {
         return $this->raListingRepository->findByIdentityIdAndRaInstitution($identityId, $raInstitution);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
@@ -41,6 +41,7 @@ services:
             - "@surfnet_stepup_middleware_api.repository.ra_listing"
             - "@surfnet_stepup_middleware_api.repository.institution_authorization"
             - "@surfnet_stepup_middleware_api.repository.identity"
+            - "@surfnet_stepup_middleware_api.repository.ra_second_factor"
         tags: [{ name: event_bus.event_listener, disable_for_replay: false }]
 
     surfnet_stepup_middleware_api.projector.sraa:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -229,3 +229,4 @@ services:
         arguments:
             - '@surfnet_stepup_middleware_api.service.sraa'
             - '@surfnet_stepup_middleware_api.service.identity'
+            - '@surfnet_stepup_middleware_api.repository.institution_listing'

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
@@ -77,7 +77,7 @@ class InstitutionAuthorizationRepositoryFilterTest extends TestCase
         $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
         $authorizationRepositoryFilter->filter($this->queryBuilder, $this->mockedAuthorizationContext, 'i.id', 'i.institution', 'iacalias');
 
-        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institution = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) WHERE iacalias.institutionRelation = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
+        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) OR (iacalias.institution = i.institution AND (iacalias.institutionRole = \'select_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
         $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
         $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
@@ -22,6 +22,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Authorization\Filter;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Surfnet\Stepup\Identity\Value\Institution as InstitutionValue;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
@@ -77,8 +78,52 @@ class InstitutionAuthorizationRepositoryFilterTest extends TestCase
         $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
         $authorizationRepositoryFilter->filter($this->queryBuilder, $this->mockedAuthorizationContext, 'i.id', 'i.institution', 'iacalias');
 
-        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) OR (iacalias.institution = i.institution AND (iacalias.institutionRole = \'select_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
+        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
         $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
         $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
     }
+
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function a_querybuilder_object_is_filtered_with_an_institution_authorization_context_for_candidates()
+    {
+        $institution = new InstitutionValue('institution.example.com');
+
+        $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
+        $authorizationRepositoryFilter->filterCandidate($this->queryBuilder, $institution, 'i.id', 'i.institution', 'iacalias');
+
+        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'select_raa\')) WHERE iacalias.institutionRelation = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
+        $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
+        $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
+    }
+
+
+    /**
+     * @test
+     * @group domain
+     */
+    public function a_querybuilder_object_is_filtered_with_an_institution_authorization_context_for_listing()
+    {
+        $roleSet = new InstitutionRoleSet([
+            InstitutionRole::useRa(),
+            InstitutionRole::useRaa(),
+        ]);
+
+        $this->mockedAuthorizationContext->method('getRoleRequirements')
+            ->willReturn($roleSet);
+
+        $this->mockedAuthorizationContext->method('getActorInstitution')
+            ->willReturn(new Institution('institution.example.com'));
+
+        $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
+        $authorizationRepositoryFilter->filterListing($this->queryBuilder, $this->mockedAuthorizationContext, 'i.id', 'i.institution', 'iacalias');
+
+        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
+        $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
+        $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
+    }
+
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
@@ -101,7 +101,7 @@ class RegistrationAuthorityCommandHandler extends CommandHandler
         /** @var \Surfnet\Stepup\Identity\Api\Identity $identity */
         $identity = $this->repository->load(new IdentityId($command->identityId));
 
-        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->raInstitution));
+        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->institution));
 
         $newRole = $this->assertValidRoleAndConvertIfValid($command->role, $command->UUID);
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
@@ -101,7 +101,7 @@ class RegistrationAuthorityCommandHandler extends CommandHandler
         /** @var \Surfnet\Stepup\Identity\Api\Identity $identity */
         $identity = $this->repository->load(new IdentityId($command->identityId));
 
-        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->institution));
+        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->raInstitution));
 
         $newRole = $this->assertValidRoleAndConvertIfValid($command->role, $command->UUID);
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/RegistrationAuthorityCommandHandler.php
@@ -67,7 +67,7 @@ class RegistrationAuthorityCommandHandler extends CommandHandler
         /** @var \Surfnet\Stepup\Identity\Api\Identity $identity */
         $identity = $this->repository->load(new IdentityId($command->identityId));
 
-        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->institution));
+        $institutionConfiguration = $this->loadInstitutionConfigurationFor(new Institution($command->raInstitution));
 
         $role = $this->assertValidRoleAndConvertIfValid($command->role, $command->UUID);
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
@@ -271,6 +271,7 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $command->role               = 'A role that does not exist';
         $command->location           = 'Somewhere behind you';
         $command->contactInformation = 'Call me Maybe';
+        $command->raInstitution      = 'RA institution';
 
         $identityId           = new IdentityId($command->identityId);
         $institution          = new Institution($command->institution);
@@ -745,6 +746,8 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
         $command->role               = 'sraa';
         $command->location           = 'somewhere';
         $command->contactInformation = 'Call me maybe';
+        $command->raInstitution      = 'Babelfish Inc.';
+
 
         $identityId           = new IdentityId($command->identityId);
         $institution          = new Institution($command->institution);


### PR DESCRIPTION
In the filtering based on the authorization, there is a bug which prevents fetching the correct RA candidates and RAs themselves.

The problem was that initially the flattened ra_lsiting and ra_candidate listings didn't store an identity in combination with a ra_institution and joined the identity based on the institution configuration. We later decided to flatten the projections and store those entries with both identity and raInstitution. Therefore the join wasn't valid anymore and should have been removed.

Also, there seemed to be a problem with the reuse of the ra_lising projections to determine authorizations based on the view which should be fixed later on by for example introduce a new endpoint in MW for authorizations. This to prevent breaking things when changing unrelated logic. This could be better addressed when solving #163520641 (remove RAA switcher).

I also encountered that in the RA environment the select box to select an institution when selecting an institution for an identity didn't work as expected. This should also be addressed when fixing the RAA switcher. I've also created an issue for this #163520412

## Done ##
https://www.pivotaltracker.com/story/show/163520315
https://www.pivotaltracker.com/story/show/163520412
https://www.pivotaltracker.com/story/show/163520641