### PR TITLE
Add actorId to management

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContext.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContext.php
@@ -19,20 +19,9 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Value;
 
 use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
-use Surfnet\Stepup\Identity\Value\Institution;
 
 class InstitutionAuthorizationContext implements InstitutionAuthorizationContextInterface
 {
-    /**
-     * @var Institution
-     */
-    private $actorInstitution;
-
-    /**
-     * @var InstitutionRoleSet
-     */
-    private $roleRequirements;
-
     /**
      * @var InstitutionCollection|null
      */
@@ -45,37 +34,15 @@ class InstitutionAuthorizationContext implements InstitutionAuthorizationContext
 
     /**
      * AuthorizationContext constructor.
-     * @param Institution $actorInstitution
-     * @param InstitutionRoleSetInterface $roleRequirements
      * @param InstitutionCollection $institutions[]
      * @param bool $isSraa describes if the actor is SRAA or not. Default: false
      */
     public function __construct(
-        Institution $actorInstitution,
-        InstitutionRoleSetInterface $roleRequirements,
         InstitutionCollection $institutions = null,
         $isSraa = false
     ) {
-        $this->actorInstitution = $actorInstitution;
-        $this->roleRequirements = $roleRequirements;
         $this->institutions = $institutions;
         $this->isSraa = $isSraa;
-    }
-
-    /**
-     * @return Institution
-     */
-    public function getActorInstitution()
-    {
-        return $this->actorInstitution;
-    }
-
-    /**
-     * @return InstitutionRoleSet
-     */
-    public function getRoleRequirements()
-    {
-        return $this->roleRequirements;
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContextInterface.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Value/InstitutionAuthorizationContextInterface.php
@@ -19,7 +19,6 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Value;
 
 use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
-use Surfnet\Stepup\Identity\Value\Institution;
 
 /**
  * Interface to implement InstitutionAuthorizationContext
@@ -34,16 +33,6 @@ use Surfnet\Stepup\Identity\Value\Institution;
  */
 interface InstitutionAuthorizationContextInterface
 {
-    /**
-     * @return Institution
-     */
-    public function getActorInstitution();
-
-    /**
-     * @return InstitutionRoleSet
-     */
-    public function getRoleRequirements();
-
     /**
      * @return InstitutionCollection
      */

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/IdentityController.php
@@ -20,7 +20,6 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\Institution;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\IdentityQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService;
@@ -66,20 +65,16 @@ class IdentityController extends Controller
         return new JsonResponse($identity);
     }
 
-    public function collectionAction(Request $request)
+    public function collectionAction(Request $request, Institution $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
 
         $query = new IdentityQuery();
-        $query->institution = $request->get('institution');
+        $query->institution = $institution;
         $query->nameId = $request->get('NameID');
         $query->commonName = $request->get('commonName');
         $query->email = $request->get('email');
         $query->pageNumber = (int)$request->get('p', 1);
-
-        if ($query->institution) {
-            $query->authorizationContext = new InstitutionAuthorizationContext(new Institution($query->institution), $this->roleRequirements);
-        }
 
         $paginator = $this->identityService->search($query);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -58,22 +58,22 @@ final class RaSecondFactorController extends Controller
         $this->authorizationService = $authorizationService;
     }
 
-    public function collectionAction(Request $request, Institution $actorInstitution)
+    public function collectionAction(Request $request)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
 
-        $query = $this->buildRaSecondFactorQuery($request, $actorInstitution);
+        $query = $this->buildRaSecondFactorQuery($request);
 
         $paginator = $this->raSecondFactorService->search($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
     }
 
-    public function exportAction(Request $request, Institution $actorInstitution)
+    public function exportAction(Request $request)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA']);
 
-        $query = $this->buildRaSecondFactorQuery($request, $actorInstitution);
+        $query = $this->buildRaSecondFactorQuery($request);
 
         $results = $this->raSecondFactorService->searchUnpaginated($query);
 
@@ -82,15 +82,13 @@ final class RaSecondFactorController extends Controller
 
     /**
      * @param Request $request
-     * @param Institution $actorInstitution
      * @return RaSecondFactorQuery
      */
-    private function buildRaSecondFactorQuery(Request $request, Institution $actorInstitution)
+    private function buildRaSecondFactorQuery(Request $request)
     {
         $actorId = new IdentityId($request->get('actorId'));
 
         $query = new RaSecondFactorQuery();
-        $query->actorInstitution = $actorInstitution;
         $query->pageNumber = (int)$request->get('p', 1);
         $query->name = $request->get('name');
         $query->type = $request->get('type');
@@ -101,9 +99,8 @@ final class RaSecondFactorController extends Controller
         $query->orderBy = $request->get('orderBy');
         $query->orderDirection = $request->get('orderDirection');
         $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext(
-            $actorInstitution,
-            $this->roleRequirements,
-            $actorId
+            $actorId,
+            $this->roleRequirements
         );
 
         return $query;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
@@ -20,7 +20,6 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\IdentityId;
-use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\InstitutionAuthorizationService;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
@@ -74,9 +73,11 @@ class VerifiedSecondFactorController extends Controller
         return new JsonResponse($secondFactor);
     }
 
-    public function collectionAction(Request $request, Institution $actorInstitution)
+    public function collectionAction(Request $request)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
+
+        $actorId = new IdentityId($request->get('actorId'));
 
         $query = new VerifiedSecondFactorQuery();
 
@@ -88,15 +89,11 @@ class VerifiedSecondFactorController extends Controller
             $query->secondFactorId = new SecondFactorId($request->get('secondFactorId'));
         }
 
-        $actorId = new IdentityId($request->get('actorId'));
-
-        $query->actorInstitution = $actorInstitution;
         $query->registrationCode = $request->get('registrationCode');
         $query->pageNumber       = (int) $request->get('p', 1);
         $query->authorizationContext = $this->institutionAuthorizationService->buildInstitutionAuthorizationContext(
-            $actorInstitution,
-            $this->roleRequirements,
-            $actorId
+            $actorId,
+            $this->roleRequirements
         );
 
         $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/IdentityQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/IdentityQuery.php
@@ -18,8 +18,6 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
 
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
-
 class IdentityQuery extends AbstractQuery
 {
     /**
@@ -41,9 +39,4 @@ class IdentityQuery extends AbstractQuery
      * @var string
      */
     public $email;
-
-    /**
-     * @var InstitutionAuthorizationContextInterface
-     */
-    public $authorizationContext;
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaCandidateQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaCandidateQuery.php
@@ -25,11 +25,6 @@ class RaCandidateQuery extends AbstractQuery
     /**
      * @var string|\Surfnet\Stepup\Identity\Value\Institution
      */
-    public $actorInstitution;
-
-    /**
-     * @var string|\Surfnet\Stepup\Identity\Value\Institution
-     */
     public $institution;
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaListingQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaListingQuery.php
@@ -26,11 +26,6 @@ class RaListingQuery extends AbstractQuery
     /**
      * @var string|\Surfnet\Stepup\Identity\Value\Institution
      */
-    public $actorInstitution;
-
-    /**
-     * @var string|\Surfnet\Stepup\Identity\Value\Institution
-     */
     public $institution;
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaSecondFactorQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RaSecondFactorQuery.php
@@ -23,11 +23,6 @@ use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizat
 final class RaSecondFactorQuery extends AbstractQuery
 {
     /**
-     * @var string|\Surfnet\Stepup\Identity\Value\Institution
-     */
-    public $actorInstitution;
-
-    /**
      * @var string|null
      */
     public $name;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/VerifiedSecondFactorQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/VerifiedSecondFactorQuery.php
@@ -40,11 +40,6 @@ class VerifiedSecondFactorQuery extends AbstractQuery
     public $registrationCode;
 
     /**
-     * @var string|\Surfnet\Stepup\Identity\Value\Institution
-     */
-    public $actorInstitution;
-
-    /**
      * @var InstitutionAuthorizationContext
      */
     public $authorizationContext;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
@@ -95,11 +95,10 @@ class RaListingRepository extends EntityRepository
         $queryBuilder = $this->createQueryBuilder('r');
 
         // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filterListing(
+        $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,
-            ['r.identityId', 'r.institution', 'r.raInstitution'],
-            'r.institution',
+            'r.raInstitution',
             'iac'
         );
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RaCandidateService.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Service;
 
-use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaCandidateQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository;
 
@@ -52,12 +52,12 @@ class RaCandidateService extends AbstractSearchService
 
     /**
      * @param string $identityId
-     * @param Institution $institution
+     * @param InstitutionAuthorizationContextInterface $authorizationContext
      * @return null|\Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaCandidate[]
      */
-    public function findByIdentityIdAndRaInstitution($identityId, Institution $institution)
+    public function findByIdentityIdAndRaInstitution($identityId, InstitutionAuthorizationContextInterface $authorizationContext)
     {
-        $raCandidates = $this->raCandidateRepository->findAllRaasByIdentityIdAndRaInstitution($identityId, $institution);
+        $raCandidates = $this->raCandidateRepository->findAllRaasByIdentityIdAndRaInstitution($identityId, $authorizationContext);
 
         return $raCandidates;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Filter/InstitutionAuthorizationRepositoryFilterTest.php
@@ -24,11 +24,8 @@ use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 use Surfnet\Stepup\Identity\Value\Institution as InstitutionValue;
-use Surfnet\Stepup\Configuration\Value\Institution;
-use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 
 class InstitutionAuthorizationRepositoryFilterTest extends TestCase
 {
@@ -65,14 +62,6 @@ class InstitutionAuthorizationRepositoryFilterTest extends TestCase
      */
     public function a_querybuilder_object_is_filtered_with_an_institution_authorization_context()
     {
-        $roleSet = new InstitutionRoleSet([
-            InstitutionRole::useRa(),
-            InstitutionRole::useRaa(),
-        ]);
-
-        $this->mockedAuthorizationContext->method('getRoleRequirements')
-            ->willReturn($roleSet);
-
         $this->mockedAuthorizationContext->method('getInstitutions')
             ->willReturn(new InstitutionCollection([
                 new InstitutionValue('institution-a'),
@@ -85,49 +74,6 @@ class InstitutionAuthorizationRepositoryFilterTest extends TestCase
         $this->assertEquals('SELECT FROM institution i WHERE i.institution IN (:iacalias_institutions)', $this->queryBuilder->getDQL());
         $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
         $this->assertEquals(['institution-a','institution-c'], $this->queryBuilder->getParameter('iacalias_institutions')->getValue());
-    }
-
-
-    /**
-     * @test
-     * @group domain
-     */
-    public function a_querybuilder_object_is_filtered_with_an_institution_authorization_context_for_candidates()
-    {
-        $institution = new InstitutionValue('institution.example.com');
-
-        $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
-        $authorizationRepositoryFilter->filterCandidate($this->queryBuilder, $institution, 'i.id', 'i.institution', 'iacalias');
-
-        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'select_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
-        $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
-        $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
-    }
-
-
-    /**
-     * @test
-     * @group domain
-     */
-    public function a_querybuilder_object_is_filtered_with_an_institution_authorization_context_for_listing()
-    {
-        $roleSet = new InstitutionRoleSet([
-            InstitutionRole::useRa(),
-            InstitutionRole::useRaa(),
-        ]);
-
-        $this->mockedAuthorizationContext->method('getRoleRequirements')
-            ->willReturn($roleSet);
-
-        $this->mockedAuthorizationContext->method('getActorInstitution')
-            ->willReturn(new Institution('institution.example.com'));
-
-        $authorizationRepositoryFilter = new InstitutionAuthorizationRepositoryFilter();
-        $authorizationRepositoryFilter->filterListing($this->queryBuilder, $this->mockedAuthorizationContext, 'i.id', 'i.institution', 'iacalias');
-
-        $this->assertEquals('SELECT FROM institution i INNER JOIN Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionAuthorization iacalias WITH (iacalias.institutionRelation = i.institution AND (iacalias.institutionRole = \'use_ra\' OR iacalias.institutionRole = \'use_raa\')) WHERE iacalias.institution = :iacalias_institution GROUP BY i.id', $this->queryBuilder->getDQL());
-        $this->assertEquals(1, $this->queryBuilder->getParameters()->count());
-        $this->assertEquals('institution.example.com', $this->queryBuilder->getParameter('iacalias_institution')->getValue());
     }
 
 }


### PR DESCRIPTION
Because the Raa switcher was removed we needed the actorId to
check if the actor is allowed to update RAA's from a given institution
or to determine if an actor is an SRAA.