### PR TITLE
Fix ra-listing static factory method

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
@@ -131,14 +131,6 @@ class RaListingRepository extends EntityRepository
     {
         $queryBuilder = $this->createQueryBuilder('r');
 
-        // Modify query to filter on authorization
-        $this->authorizationRepositoryFilter->filter(
-            $queryBuilder,
-            $query->authorizationContext,
-            'r.raInstitution',
-            'iac'
-        );
-
         if ($query->institution) {
             $queryBuilder
                 ->andWhere('r.institution = :institution')
@@ -174,6 +166,14 @@ class RaListingRepository extends EntityRepository
                 ->andWhere('r.raInstitution = :raInstitution')
                 ->setParameter('raInstitution', (string) $query->raInstitution);
         }
+
+        // Modify query to filter on authorization
+        $this->authorizationRepositoryFilter->filter(
+            $queryBuilder,
+            $query->authorizationContext,
+            'r.raInstitution',
+            'iac'
+        );
 
         if (!$query->orderBy) {
             return $queryBuilder->getQuery();

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/RegistrationAuthorityCredentials.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/RegistrationAuthorityCredentials.php
@@ -137,6 +137,28 @@ final class RegistrationAuthorityCredentials implements \JsonSerializable
         return $credentials;
     }
 
+
+    /**
+     * @param RaListing $raListing
+     * @return RegistrationAuthorityCredentials
+     */
+    public static function fromRaListing(RaListing $raListing)
+    {
+        $credentials = new self(
+            $raListing->identityId,
+            $raListing->role->equals(AuthorityRole::ra()),
+            $raListing->role->equals(AuthorityRole::raa()),
+            false
+        );
+
+        $credentials->institution        = $raListing->institution;
+        $credentials->commonName         = $raListing->commonName;
+        $credentials->location           = $raListing->location;
+        $credentials->contactInformation = $raListing->contactInformation;
+
+        return $credentials;
+    }
+
     /**
      * @param string $nameId
      * @param string $identityNameId


### PR DESCRIPTION
After the fix to be able to login with the highest ra(a) level the
original static method was removed, but this shouldn't be removed.
Restored the original method to allow construction of ra-listings.