### PR TITLE
Include implicit roles on the profile endpoint

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/InstitutionAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/InstitutionAuthorizationService.php
@@ -18,10 +18,10 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Authorization\Service;
 
+use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\InvalidArgumentException;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\InstitutionListingRepository;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService;
@@ -65,10 +65,10 @@ class InstitutionAuthorizationService
      * The additional test is performed to indicate if the actor is SRAA.
      *
      * @param IdentityId $actorId
-     * @param InstitutionRoleSet $roleRequirements
+     * @param InstitutionRole $role
      * @return InstitutionAuthorizationContext
      */
-    public function buildInstitutionAuthorizationContext(IdentityId $actorId, InstitutionRoleSet $roleRequirements)
+    public function buildInstitutionAuthorizationContext(IdentityId $actorId, InstitutionRole $role)
     {
         $identity = $this->identityService->find((string) $actorId);
 
@@ -79,7 +79,7 @@ class InstitutionAuthorizationService
         $sraa = $this->sraaService->findByNameId($identity->nameId);
         $isSraa = !is_null($sraa);
 
-        $institutions = $this->institutionListingRepository->getInstitutionsForRaa($roleRequirements, $actorId);
+        $institutions = $this->institutionListingRepository->getInstitutionsForRole($role, $actorId);
 
         return new InstitutionAuthorizationContext($institutions, $isSraa);
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/ProfileController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/ProfileController.php
@@ -18,8 +18,6 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
-use Surfnet\Stepup\Configuration\Value\InstitutionRole;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\ProfileService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -34,17 +32,10 @@ class ProfileController extends Controller
      */
     private $profileService;
 
-    /**
-     * @var InstitutionRoleSet
-     */
-    private $roleRequirements;
-
-    public function __construct(ProfileService $profileService)
-    {
+    public function __construct(
+        ProfileService $profileService
+    ) {
         $this->profileService = $profileService;
-        $this->roleRequirements = new InstitutionRoleSet(
-            [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
-        );
     }
 
     public function getAction(Request $request, $identityId)

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -21,7 +21,6 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\InstitutionAuthorizationService;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RaSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RaSecondFactorService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
@@ -37,10 +36,6 @@ final class RaSecondFactorController extends Controller
     private $raSecondFactorService;
 
     /**
-     * @var InstitutionRoleSet
-     */
-    private $roleRequirements;
-    /**
      * @var InstitutionAuthorizationService
      */
     private $authorizationService;
@@ -50,10 +45,6 @@ final class RaSecondFactorController extends Controller
         InstitutionAuthorizationService $authorizationService
     ) {
         $this->raSecondFactorService = $raSecondFactorService;
-
-        $this->roleRequirements = new InstitutionRoleSet(
-            [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
-        );
         $this->authorizationService = $authorizationService;
     }
 
@@ -99,7 +90,7 @@ final class RaSecondFactorController extends Controller
         $query->orderDirection = $request->get('orderDirection');
         $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext(
             $actorId,
-            $this->roleRequirements
+            new InstitutionRole(InstitutionRole::ROLE_USE_RAA)
         );
 
         return $query;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
@@ -22,7 +22,6 @@ use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\InstitutionAuthorizationService;
-use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionRoleSet;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SecondFactorService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
@@ -39,11 +38,6 @@ class VerifiedSecondFactorController extends Controller
     private $secondFactorService;
 
     /**
-     * @var InstitutionRoleSet
-     */
-    private $roleRequirements;
-
-    /**
      * @var InstitutionAuthorizationService
      */
     private $institutionAuthorizationService;
@@ -54,10 +48,6 @@ class VerifiedSecondFactorController extends Controller
     ) {
         $this->secondFactorService = $secondFactorService;
         $this->institutionAuthorizationService = $authorizationService;
-
-        $this->roleRequirements = new InstitutionRoleSet(
-            [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
-        );
     }
 
     public function getAction($id)
@@ -93,7 +83,7 @@ class VerifiedSecondFactorController extends Controller
         $query->pageNumber       = (int) $request->get('p', 1);
         $query->authorizationContext = $this->institutionAuthorizationService->buildInstitutionAuthorizationContext(
             $actorId,
-            $this->roleRequirements
+            new InstitutionRole(InstitutionRole::ROLE_USE_RAA)
         );
 
         $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/InstitutionListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/InstitutionListingRepository.php
@@ -105,7 +105,7 @@ class InstitutionListingRepository extends EntityRepository
                 InstitutionAuthorization::class,
                 'a',
                 Join::WITH,
-                "i.institution = a.institution AND a.institutionRole IN (:authorizationRoles)"
+                "r.institution = a.institution AND a.institutionRole IN (:authorizationRoles)"
             )
             ->where("r.identityId = :identityId AND r.role IN(:roles)")
             ->groupBy("a.institutionRelation");
@@ -142,7 +142,7 @@ class InstitutionListingRepository extends EntityRepository
                 InstitutionAuthorization::class,
                 'a',
                 Join::WITH,
-                "i.institution = a.institution AND a.institutionRole IN (:authorizationRoles)"
+                "r.institution = a.institution AND a.institutionRole IN (:authorizationRoles)"
             )
             ->where("a.institution = :institution")
             ->groupBy("a.institution");

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/AuthorizedInstitutionCollection.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/AuthorizedInstitutionCollection.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Value;
 
-use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RaListing;
+use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 
 class AuthorizedInstitutionCollection
 {
@@ -32,20 +32,32 @@ class AuthorizedInstitutionCollection
      *      'institution-3' => [select_raa],
      * ]
      *
-     * @var AuthorityRole[]
+     * @var string[]
      */
     private $authorizations = [];
 
     /**
-     * @param RaListing[] $authorizations
+     * @param InstitutionCollection $raInstitutions
+     * @param InstitutionCollection|null $raaInstitutions
      * @return AuthorizedInstitutionCollection
      */
-    public static function fromInstitutionAuthorization($authorizations)
+    public static function from(InstitutionCollection $raInstitutions, InstitutionCollection $raaInstitutions = null)
     {
         $collection = new self();
 
-        foreach ($authorizations as $authorization) {
-            $collection->authorizations[(string) $authorization->raInstitution][] = (string) $authorization->role;
+        foreach ($raInstitutions as $institution) {
+            $collection->authorizations[(string) $institution][] = (string) AuthorityRole::ROLE_RA;
+        }
+        if ($raaInstitutions) {
+            foreach ($raaInstitutions as $institution) {
+                // Override existing lower role
+                if (isset($collection->authorizations[(string) $institution])
+                    && in_array(AuthorityRole::ROLE_RA, $collection->authorizations[(string) $institution])
+                ) {
+                    $collection->authorizations[(string) $institution] = [];
+                }
+                $collection->authorizations[(string) $institution][] = (string) AuthorityRole::ROLE_RAA;
+            }
         }
         return $collection;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/InstitutionAuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/InstitutionAuthorizationServiceTest.php
@@ -78,9 +78,7 @@ class InstitutionAuthorizationServiceTest extends TestCase
     public function it_can_build_a_context()
     {
         $actorInstitution = new Institution('institution-a');
-        $roleRequirements = new InstitutionRoleSet(
-            [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
-        );
+        $role = new InstitutionRole(InstitutionRole::ROLE_USE_RAA);
 
         $arbitraryId = 'dc4cc738-5f1c-4d8c-84a2-d6faf8aded89';
 
@@ -113,13 +111,13 @@ class InstitutionAuthorizationServiceTest extends TestCase
             ->andReturn(null);
 
         $this->institutionListingRepository
-            ->shouldReceive('getInstitutionsForRaa')
-            ->withArgs([$roleRequirements, $identityId])
+            ->shouldReceive('getInstitutionsForRole')
+            ->withArgs([$role, $identityId])
             ->andReturn($institutions);
 
         $context = $this->service->buildInstitutionAuthorizationContext(
             $identityId,
-            $roleRequirements
+            $role
         );
 
         $this->assertEquals($institutions, $context->getInstitutions());
@@ -188,9 +186,7 @@ class InstitutionAuthorizationServiceTest extends TestCase
      */
     public function it_rejects_unknown_actor()
     {
-        $roleRequirements = new InstitutionRoleSet(
-            [new InstitutionRole(InstitutionRole::ROLE_USE_RA), new InstitutionRole(InstitutionRole::ROLE_USE_RAA)]
-        );
+        $role = new InstitutionRole(InstitutionRole::ROLE_USE_RAA);
 
         $actorId = 'dc4cc738-5f1c-4d8c-84a2-d6faf8aded89';
 
@@ -201,7 +197,7 @@ class InstitutionAuthorizationServiceTest extends TestCase
 
         $this->service->buildInstitutionAuthorizationContext(
             new IdentityId($actorId),
-            $roleRequirements
+            $role
         );
     }
 }


### PR DESCRIPTION
By including the implicit roles on the profile page, the user can see for which institutions he/she can perform RA(A) tasks.

This PR might be a little rough around the edges. @pablothedude feel free to rework this PR. I would also greatly appreciate your feedback on my solution. Your proposal did not seem to cut the bill fully, but I might have misunderstood some of your intentions.

This is in support of https://www.pivotaltracker.com/story/show/164244620 (task 2)
And behat test coverage is found in: https://github.com/OpenConext/Stepup-Deploy/pull/83
