### PR TITLE
Ensure RA filter applied when searching verified second factor

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
@@ -83,7 +83,7 @@ class VerifiedSecondFactorController extends Controller
         $query->pageNumber       = (int) $request->get('p', 1);
         $query->authorizationContext = $this->institutionAuthorizationService->buildInstitutionAuthorizationContext(
             $actorId,
-            new InstitutionRole(InstitutionRole::ROLE_USE_RAA)
+            new InstitutionRole(InstitutionRole::ROLE_USE_RA)
         );
 
         $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);


### PR DESCRIPTION
RA's are able to vet second factor tokens, in order to be able
to find the verified second factor, the RA searches for the token by
activation code. Before this fix, the RA would not find the token as the
controller was configured to require the RAA role in order to find a
token.

https://www.pivotaltracker.com/story/show/164398880