### PR TITLE
Fix ra second factor auth level

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RaSecondFactorController.php
@@ -92,7 +92,7 @@ final class RaSecondFactorController extends Controller
         $query->orderDirection = $request->get('orderDirection');
         $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext(
             $actorId,
-            new InstitutionRole(InstitutionRole::ROLE_USE_RAA)
+            new InstitutionRole(InstitutionRole::ROLE_USE_RA)
         );
 
         return $query;


### PR DESCRIPTION
The authorization level was set to RAA while RA should be already valid.