### PR TITLE
Fix invalid left join for authorizations

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/InstitutionListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/InstitutionListingRepository.php
@@ -63,7 +63,7 @@ class InstitutionListingRepository extends EntityRepository
         $qb = $this->createQueryBuilder('i')
             ->select("a.institution")
             ->innerJoin(RaListing::class, 'r', Join::WITH, "i.institution = r.raInstitution")
-            ->leftJoin(
+            ->innerJoin(
                 InstitutionAuthorization::class,
                 'a',
                 Join::WITH,
@@ -101,7 +101,7 @@ class InstitutionListingRepository extends EntityRepository
         $qb = $this->createQueryBuilder('i')
             ->select("a.institutionRelation")
             ->innerJoin(RaListing::class, 'r', Join::WITH, "i.institution = r.raInstitution")
-            ->leftJoin(
+            ->innerJoin(
                 InstitutionAuthorization::class,
                 'a',
                 Join::WITH,


### PR DESCRIPTION
The left join needed to be removed to prevent null values for
institutions. While fetching the authorized roles.