### PR TITLE
Add additional allowed sandbox methods

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -45,6 +45,8 @@ services:
             - [ if, else, elseif, for ] # Allowed tags
             - [ escape, localizeddate ] # Allowed filters
             - # Allowed methods
+                Surfnet\Stepup\Identity\Value\CommonName:
+                    - __toString
                 Surfnet\Stepup\Configuration\Value\ContactInformation:
                     - __toString
                 Surfnet\Stepup\Configuration\Value\Location:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -45,6 +45,14 @@ services:
             - [ if, else, elseif, for ] # Allowed tags
             - [ escape, localizeddate ] # Allowed filters
             - # Allowed methods
+                Surfnet\Stepup\Configuration\Value\ContactInformation:
+                    - __toString
+                Surfnet\Stepup\Configuration\Value\Location:
+                    - __toString
+                Surfnet\Stepup\Configuration\Value\RaLocationName:
+                    - __toString
+                Surfnet\Stepup\DateTime\DateTime:
+                    - __toString
                 Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCredentials:
                     - getCommonName
                     - getLocation


### PR DESCRIPTION
The implicit __toString call is no longer allowed, and a critical error is raised by Twig. The solution is to add the __toString calls to the list of allowed sandbox methods.

This change fixes the problem where sending the verification mail message would trigger an error.