### PR TITLE
Add Self Service verified SF collection endpoint

### DIFF
--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -1,5 +1,31 @@
 # Middleware APIs
 
+## Required headers
+
+Each POST request must include the following headers:
+
+```
+Accept: application/json
+Content-Type: application/json
+```
+
+Each GET request must include the header:
+
+```
+Accept: application/json
+```
+
+## Authentication
+
+The enpoints are protected using HTTP Basic authentication for the 'ss', 'ra' and 'management' users.
+
+## CURL Examples
+
+### Example GET request
+```
+curl -u ss:password -H 'Accept: application/json' 'http://middleware.dev.surfconext.nl/vetted-second-factors?identityId=f9913e4b-8f50-4729-97b9-87ca9b33f0b8'
+```
+
 ## Standard Error Responses
 
 | Response Code | Definition            | Used When | Response Format |
@@ -237,6 +263,15 @@ Request parameters:
 - secondFactorId: (optional) UUIDv4 of the second factor to search for
 - registrationCode: (optional) string, registration code to search for
 - p: (optional, default 1) integer, the requested result page
+
+#### Request
+URL: `http://middleware.tld/verified-second-factors-of-identity?{identityId=}(&p=}`
+Method: GET
+Request parameters:
+- IdentityId: (optional) UUIDv4 of the identity to search for
+- p: (optional, default 1) integer, the requested result page
+
+Note that the `verified-second-factors-of-identity` (used by self service) endpoint does not apply the authorization context.
 
 #### Response
 `200 OK`

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
@@ -65,7 +65,7 @@ class VerifiedSecondFactorController extends Controller
 
     public function collectionAction(Request $request)
     {
-        $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS']);
+        $this->denyAccessUnlessGranted(['ROLE_RA']);
 
         $actorId = new IdentityId($request->get('actorId'));
 
@@ -80,11 +80,26 @@ class VerifiedSecondFactorController extends Controller
         }
 
         $query->registrationCode = $request->get('registrationCode');
-        $query->pageNumber       = (int) $request->get('p', 1);
+        $query->pageNumber = (int) $request->get('p', 1);
         $query->authorizationContext = $this->institutionAuthorizationService->buildInstitutionAuthorizationContext(
             $actorId,
             new InstitutionRole(InstitutionRole::ROLE_USE_RA)
         );
+
+        $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);
+
+        return JsonCollectionResponse::fromPaginator($paginator);
+    }
+
+    public function collectionOfIdentityAction(Request $request)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_SS']);
+        $query = new VerifiedSecondFactorQuery();
+
+        if ($request->get('identityId')) {
+            $query->identityId = new IdentityId($request->get('identityId'));
+        }
+        $query->pageNumber = (int) $request->get('p', 1);
 
         $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/VerifiedSecondFactorController.php
@@ -22,6 +22,7 @@ use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\InstitutionAuthorizationService;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorOfIdentityQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\SecondFactorService;
 use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
@@ -94,14 +95,12 @@ class VerifiedSecondFactorController extends Controller
     public function collectionOfIdentityAction(Request $request)
     {
         $this->denyAccessUnlessGranted(['ROLE_SS']);
-        $query = new VerifiedSecondFactorQuery();
+        $query = new VerifiedSecondFactorOfIdentityQuery();
 
-        if ($request->get('identityId')) {
-            $query->identityId = new IdentityId($request->get('identityId'));
-        }
+        $query->identityId = new IdentityId($request->get('identityId'));
         $query->pageNumber = (int) $request->get('p', 1);
 
-        $paginator = $this->secondFactorService->searchVerifiedSecondFactors($query);
+        $paginator = $this->secondFactorService->searchVerifiedSecondFactorsOfIdentity($query);
 
         return JsonCollectionResponse::fromPaginator($paginator);
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/VerifiedSecondFactorOfIdentityQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/VerifiedSecondFactorOfIdentityQuery.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
+
+use Surfnet\Stepup\Identity\Value\IdentityId;
+
+class VerifiedSecondFactorOfIdentityQuery extends AbstractQuery
+{
+    /**
+     * @var IdentityId|null
+     */
+    public $identityId;
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
@@ -98,7 +98,8 @@ class VerifiedSecondFactorRepository extends EntityRepository
 
         // The SRAA user does not adhere to the FGA filter rules when searching for a registration code.
         // This way the SRAA does not have to switch to a certain institution to start the vetting process.
-        if ($query->authorizationContext->isActorSraa() && is_string($query->registrationCode)) {
+        // And if the authzcontext is explicitly not set, that also signals that the fga filter should not be applied!
+        if (is_null($query->authorizationContext) || ($query->authorizationContext->isActorSraa() && is_string($query->registrationCode))) {
             $applyFgaFilter = false;
         }
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
@@ -27,6 +27,7 @@ use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\VerifiedSecondFactor;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorOfIdentityQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorQuery;
 
 class VerifiedSecondFactorRepository extends EntityRepository
@@ -98,8 +99,7 @@ class VerifiedSecondFactorRepository extends EntityRepository
 
         // The SRAA user does not adhere to the FGA filter rules when searching for a registration code.
         // This way the SRAA does not have to switch to a certain institution to start the vetting process.
-        // And if the authzcontext is explicitly not set, that also signals that the fga filter should not be applied!
-        if (is_null($query->authorizationContext) || ($query->authorizationContext->isActorSraa() && is_string($query->registrationCode))) {
+        if ($query->authorizationContext->isActorSraa() && is_string($query->registrationCode)) {
             $applyFgaFilter = false;
         }
 
@@ -130,6 +130,21 @@ class VerifiedSecondFactorRepository extends EntityRepository
                 'iac'
             );
         }
+
+        return $queryBuilder->getQuery();
+    }
+
+    /**
+     * @param VerifiedSecondFactorOfIdentityQuery $query
+     * @return Query
+     */
+    public function createSearchForIdentityQuery(VerifiedSecondFactorOfIdentityQuery $query)
+    {
+        $queryBuilder = $this->createQueryBuilder('sf');
+
+        $queryBuilder
+            ->andWhere('sf.identityId = :identityId')
+            ->setParameter('identityId', (string) $query->identityId);
 
         return $queryBuilder->getQuery();
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/SecondFactorService.php
@@ -23,6 +23,7 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\UnverifiedSecondFactor;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\VerifiedSecondFactor;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\VettedSecondFactor;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\UnverifiedSecondFactorQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorOfIdentityQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VerifiedSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\VettedSecondFactorQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\UnverifiedSecondFactorRepository;
@@ -81,6 +82,20 @@ class SecondFactorService extends AbstractSearchService
     public function searchVerifiedSecondFactors(VerifiedSecondFactorQuery $query)
     {
         $doctrineQuery = $this->verifiedRepository->createSearchQuery($query);
+
+        $paginator = $this->createPaginatorFrom($doctrineQuery, $query);
+
+        return $paginator;
+    }
+
+
+    /**
+     * @param VerifiedSecondFactorOfIdentityQuery $query
+     * @return \Pagerfanta\Pagerfanta
+     */
+    public function searchVerifiedSecondFactorsOfIdentity(VerifiedSecondFactorOfIdentityQuery $query)
+    {
+        $doctrineQuery = $this->verifiedRepository->createSearchForIdentityQuery($query);
 
         $paginator = $this->createPaginatorFrom($doctrineQuery, $query);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -38,6 +38,12 @@ verified_second_factors:
     methods:  [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
+verified_second_factors_of_identity:
+    path:     /verified-second-factors-of-identity
+    defaults: { _controller: SurfnetStepupMiddlewareApiBundle:VerifiedSecondFactor:collectionOfIdentity }
+    methods:  [GET]
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 vetted_second_factors:
     path:     /vetted-second-factors
     defaults: { _controller: SurfnetStepupMiddlewareApiBundle:VettedSecondFactor:collection }


### PR DESCRIPTION
This endpoint does not apply the FGA authz filtering. Allowing the self
service user to see all it's tokens regardless of institution