### PR TITLE
Add exception for not whitelisted RA's

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/CommandController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/CommandController.php
@@ -164,6 +164,14 @@ class CommandController extends Controller
 
         $registrationAuthorityCredentials = $this->identityService->findRegistrationAuthorityCredentialsOf($actorId);
 
+        if (!$registrationAuthorityCredentials) {
+            throw new AccessDeniedHttpException(sprintf(
+                'Institution "%s" is not on the whitelist and no RA credentials found for actor "%s", processing of command denied',
+                $institution,
+                $actorId
+            ));
+        }
+
         if ($registrationAuthorityCredentials->isSraa()) {
             return;
         }


### PR DESCRIPTION
In order to clarify the reason why a RA which institution isn't on the
whitelist isn't allowed this exception is added. Before this resulted
in an exception thrown when trying to access a method on a null object.

`Error: Call to a member function isSraa() on null`