### PR TITLE
Whitelist missing toString methods

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -59,6 +59,10 @@ services:
                     - getCommonName
                     - getLocation
                     - getContactInformation
+                Surfnet\Stepup\Identity\Value\Location:
+                    - __toString
+                Surfnet\Stepup\Identity\Value\ContactInformation:
+                    - __toString
             - # Allowed properties
                 Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\RaLocation:
                     - name


### PR DESCRIPTION
When testing SS registration the process failed because the mail
templates were using __toString methods from value objects while
the specific class methods weren't whitelisted for twig.

This was started in:
https://github.com/OpenConext/Stepup-Middleware/pull/276

https://www.pivotaltracker.com/story/show/166204879