### PR TITLE
Fix RA removal when token gets removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,13 @@ cache:
   directories:
     - ~/.composer
 
+# The hook below makes sure ant is anstalled
+before_install:
+  - echo $(ant -version)
+  - sudo apt-get -qq update
+  - sudo apt-get install ant
+  - echo $(ant -version)
+
 before_script:
   - phpenv config-add travis.php.ini
   - composer self-update

--- a/src/Surfnet/Stepup/Identity/Entity/VettedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VettedSecondFactor.php
@@ -21,6 +21,7 @@ namespace Surfnet\Stepup\Identity\Entity;
 use Surfnet\Stepup\Identity\Api\Identity;
 use Surfnet\Stepup\Identity\Event\CompliedWithVettedSecondFactorRevocationEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
+use Surfnet\Stepup\Identity\Event\VettedSecondFactorsAllRevokedEvent;
 use Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;

--- a/src/Surfnet/Stepup/Identity/Event/VettedSecondFactorsAllRevokedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/VettedSecondFactorsAllRevokedEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Event;
+
+use Surfnet\Stepup\Identity\AuditLog\Metadata;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+
+class VettedSecondFactorsAllRevokedEvent extends IdentityEvent
+{
+
+    final public function __construct(
+        IdentityId $identityId,
+        Institution $identityInstitution
+    ) {
+        parent::__construct($identityId, $identityInstitution);
+    }
+
+    public function getAuditLogMetadata()
+    {
+        $metadata                         = new Metadata();
+        $metadata->identityId             = $this->identityId;
+        $metadata->identityInstitution    = $this->identityInstitution;
+
+        return $metadata;
+    }
+
+    final public static function deserialize(array $data)
+    {
+        return new static(
+            new IdentityId($data['identity_id']),
+            new Institution($data['identity_institution'])
+        );
+    }
+
+    final public function serialize()
+    {
+        return [
+            'identity_id'              => (string) $this->identityId,
+            'identity_institution'     => (string) $this->identityInstitution,
+        ];
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -69,13 +69,15 @@ class RaCandidateRepository extends EntityRepository
      */
     public function removeByIdentityId(IdentityId $identityId)
     {
-        $raCandidate = $this->findByIdentityId($identityId);
+        $raCandidates = $this->findByIdentityId($identityId);
 
-        if (!$raCandidate) {
+        if (empty($raCandidates)) {
             return;
         }
 
-        $this->getEntityManager()->remove($raCandidate);
+        foreach ($raCandidates as $candidate) {
+            $this->getEntityManager()->remove($candidate);
+        }
         $this->getEntityManager()->flush();
     }
 
@@ -243,7 +245,7 @@ class RaCandidateRepository extends EntityRepository
 
     /**
      * @param string $identityId
-     * @return null|RaCandidate
+     * @return RaCandidate[]
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
     public function findByIdentityId($identityId)
@@ -252,7 +254,7 @@ class RaCandidateRepository extends EntityRepository
             ->where('rac.identityId = :identityId')
             ->setParameter('identityId', $identityId)
             ->getQuery()
-            ->getOneOrNullResult();
+            ->getResult();
     }
 
     /**
@@ -271,7 +273,6 @@ class RaCandidateRepository extends EntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
-
 
     /**
      * @param string $identityId


### PR DESCRIPTION
When a token gets removed the identity also gets removed from the
ra candidate projection. This also occurs when a identity still
has valid tokens left.

This fix will make sure that a candidate only is removed when his last
token gets removed.