### PR TITLE
Fix sho mixed casing once and for all

### DIFF
--- a/app/DoctrineMigrations/Version20200114161618.php
+++ b/app/DoctrineMigrations/Version20200114161618.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200114161618 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // Convert all available institutions occurrences to lower case (type="institution")
+        $this->addSql('UPDATE audit_log SET actor_institution=LOWER(actor_institution)');
+        $this->addSql('UPDATE audit_log SET identity_institution=LOWER(identity_institution)');
+        $this->addSql('UPDATE identity SET institution=LOWER(institution)');
+        $this->addSql('UPDATE institution_listing SET institution=LOWER(institution)');
+        $this->addSql('UPDATE ra_candidate SET institution=LOWER(institution)');
+        $this->addSql('UPDATE ra_candidate SET ra_institution=LOWER(ra_institution)');
+        $this->addSql('UPDATE ra_listing SET institution=LOWER(institution)');
+        $this->addSql('UPDATE ra_listing SET ra_institution=LOWER(ra_institution)');
+        $this->addSql('UPDATE ra_second_factor SET institution=LOWER(institution)');
+        $this->addSql('UPDATE second_factor_revocation SET institution=LOWER(institution)');
+        $this->addSql('UPDATE whitelist_entry SET institution=LOWER(institution)');
+
+        // Convert all available configuration institutions occurrences to lower case (type="stepup_configuration_institution")
+        $this->addSql('UPDATE allowed_second_factor SET institution=LOWER(institution)');
+        $this->addSql('UPDATE configured_institution SET institution=LOWER(institution)');
+        $this->addSql('UPDATE institution_authorization SET institution=LOWER(institution)');
+        $this->addSql('UPDATE institution_authorization SET institution_relation=LOWER(institution_relation)');
+        $this->addSql('UPDATE institution_configuration_options SET institution=LOWER(institution)');
+        $this->addSql('UPDATE ra_location SET institution=LOWER(institution)');
+
+
+        $gatewaySchema  = $this->getGatewaySchema();
+        $this->addSql(sprintf('UPDATE %s.whitelist_entry SET institution=LOWER(institution)', $gatewaySchema));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+        $this->throwIrreversibleMigrationException('This migration is irreversible');
+    }
+
+    private function getGatewaySchema()
+    {
+        return $this->container->getParameter('database_gateway_name');
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Value/Institution.php
+++ b/src/Surfnet/Stepup/Configuration/Value/Institution.php
@@ -37,7 +37,7 @@ final class Institution implements JsonSerializable
             throw InvalidArgumentException::invalidType('non-empty string', 'institution', $institution);
         }
 
-        $this->institution = trim($institution);
+        $this->institution = strtolower(trim($institution));
     }
 
     /**

--- a/src/Surfnet/Stepup/Identity/Value/Institution.php
+++ b/src/Surfnet/Stepup/Identity/Value/Institution.php
@@ -37,7 +37,7 @@ final class Institution implements JsonSerializable
             throw InvalidArgumentException::invalidType('non-empty string', 'institution', $institution);
         }
 
-        $this->institution = trim($institution);
+        $this->institution = strtolower(trim($institution));
     }
 
     /**

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionConfigurationIdTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionConfigurationIdTest.php
@@ -100,7 +100,7 @@ class InstitutionConfigurationIdTest extends TestCase
      * @test
      * @group domain
      */
-    public function normalized_institution_configuration_ids_and_unnormalized_institution_configuration_ids_are_not_the_same()
+    public function normalized_institution_configuration_ids_and_unnormalized_institution_configuration_ids_are_the_same()
     {
         $mixedCaseInstitution = new Institution('An InStItUtIoN');
 
@@ -109,11 +109,7 @@ class InstitutionConfigurationIdTest extends TestCase
 
         $isSameId = $unnormalizedInstitutionConfigurationId->equals($normalizedInstitutionConfigurationId);
 
-        $this->assertFalse(
-            $isSameId,
-            'An normalized InstitutionConfigurationId based on an institution with mixed casing'
-            . 'should not match an unnormalized InstitutionConfigurationId based on the same institution'
-        );
+        $this->assertTrue($isSameId);
     }
 
     /**

--- a/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Value/InstitutionTest.php
@@ -49,7 +49,7 @@ class InstitutionTest extends UnitTest
 
         $this->assertTrue($institution->equals($theSame));
         $this->assertTrue($institution->equals($theSameWithSpaces));
-        $this->assertFalse($institution->equals($different));
+        $this->assertTrue($institution->equals($different));
     }
 
     public function nonStringOrNonEmptyStringProvider()

--- a/src/Surfnet/Stepup/Tests/Identity/Value/InstitutionTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Value/InstitutionTest.php
@@ -49,7 +49,7 @@ class InstitutionTest extends UnitTest
 
         $this->assertTrue($institution->equals($theSame));
         $this->assertTrue($institution->equals($theSameWithSpaces));
-        $this->assertFalse($institution->equals($different));
+        $this->assertTrue($institution->equals($different));
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/ConfigurationInstitutionTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/ConfigurationInstitutionTypeTest.php
@@ -83,8 +83,9 @@ class ConfigurationInstitutionTypeTest extends UnitTest
     {
         $configurationInstitution = Type::getType(ConfigurationInstitutionType::NAME);
 
-        $expected = 'An institution';
-        $input    = new Institution($expected);
+        $input = 'An institution';
+        $expected = 'an institution';
+        $input    = new Institution($input);
         $output   = $configurationInstitution->convertToDatabaseValue($input, $this->platform);
 
         $this->assertTrue(is_string($output));

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/InstitutionTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/InstitutionTypeTest.php
@@ -68,7 +68,7 @@ class InstitutionTypeTest extends UnitTest
     {
         $configurationInstitution = Type::getType(InstitutionType::NAME);
 
-        $expected = 'An institution';
+        $expected = 'an institution';
         $input    = new Institution($expected);
         $output   = $configurationInstitution->convertToDatabaseValue($input, $this->platform);
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/Processor/InstitutionConfigurationProcessorTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/Processor/InstitutionConfigurationProcessorTest.php
@@ -57,7 +57,7 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function a_create_institution_configuration_command_is_processed_when_an_identity_was_created_with_a_non_configured_institution()
     {
-        $expectedInstitution  = 'Institution';
+        $expectedInstitution  = 'institution';
         $identityCreatedEvent = new IdentityCreatedEvent(
             new IdentityId('Id'),
             new Institution($expectedInstitution),
@@ -123,8 +123,8 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function create_institution_configuration_commands_are_processed_when_a_whitelist_was_created_containing_non_configured_institutions()
     {
-        $firstInstitution  = 'First institution';
-        $secondInstitution = 'Second institution';
+        $firstInstitution  = 'first institution';
+        $secondInstitution = 'second institution';
 
         $whitelistCreatedEvent = new WhitelistCreatedEvent(
             new InstitutionCollection(
@@ -162,8 +162,8 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function no_create_institution_configuration_command_is_processed_for_an_already_configured_institution_when_a_whitelist_was_created()
     {
-        $alreadyPresentInstitution = 'Already present';
-        $newInstitution            = 'New';
+        $alreadyPresentInstitution = 'already present';
+        $newInstitution            = 'new';
 
         $whitelistCreatedEvent = new WhitelistCreatedEvent(
             new InstitutionCollection(
@@ -205,8 +205,8 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function create_institution_configuration_commands_are_created_when_a_whitelist_was_replaced_containing_non_configured_institutions()
     {
-        $firstInstitution  = 'First institution';
-        $secondInstitution = 'Second institution';
+        $firstInstitution  = 'first institution';
+        $secondInstitution = 'second institution';
 
         $whitelistReplacedEvent = new WhitelistReplacedEvent(
             new InstitutionCollection(
@@ -246,8 +246,8 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function no_create_institution_configuration_command_is_processed_for_an_already_configured_institution_when_a_whitelist_was_replaced()
     {
-        $alreadyPresentInstitution = 'Already present';
-        $newInstitution            = 'New';
+        $alreadyPresentInstitution = 'already present';
+        $newInstitution            = 'new';
 
         $whitelistCreatedEvent = new WhitelistReplacedEvent(
             new InstitutionCollection(
@@ -289,8 +289,8 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function create_institution_configuration_commands_are_created_when_non_configured_institutions_are_added_to_the_whitelist()
     {
-        $firstInstitution  = 'First institution';
-        $secondInstitution = 'Second institution';
+        $firstInstitution  = 'first institution';
+        $secondInstitution = 'second institution';
 
         $institutionsAddedToWhitelistEvent = new InstitutionsAddedToWhitelistEvent(
             new InstitutionCollection(
@@ -330,8 +330,8 @@ class InstitutionConfigurationProcessorTest extends TestCase
      */
     public function no_create_institution_configuration_command_is_created_for_an_already_configured_institution_when_institutions_are_added_to_a_whitelist()
     {
-        $alreadyPresentInstitution = 'Already present';
-        $newInstitution            = 'New';
+        $alreadyPresentInstitution = 'already present';
+        $newInstitution            = 'new';
 
         $whitelistCreatedEvent = new InstitutionsAddedToWhitelistEvent(
             new InstitutionCollection(

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/WhitelistCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/WhitelistCommandHandlerTest.php
@@ -121,7 +121,7 @@ class WhitelistCommandHandlerTest extends CommandHandlerTest
      * @group whitelist
      *
      * @expectedException \Surfnet\Stepup\Exception\DomainException
-     * @expectedExceptionMessage Cannot add institution "Already Exists" as it is already whitelisted
+     * @expectedExceptionMessage Cannot add institution "already exists" as it is already whitelisted
      */
     public function an_institution_on_the_whitelist_may_not_be_added_again()
     {


### PR DESCRIPTION
The domain accepted mixed casing sho's. This shouldn't be possible.
Therefore this is now enforced in the domain itself and a migration
is added to convert all occurrences to lowercase.