### PR TITLE
Allow language switching from SelfService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+# 3.1.3
+**Bugfix**
+ * Allow language switching from SelfService #296
+ 
 # 3.1.2
 **Bugfix**
- *  Allow RA commands in RA environment #295
+ * Allow RA commands in RA environment #295
  
 ## 3.1.1
 **Bugfix**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
@@ -27,6 +27,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\Command;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\RaExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\CreateIdentityCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ExpressLocalePreferenceCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\UpdateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\VetSecondFactorCommand;
@@ -119,6 +120,7 @@ class CommandAuthorizationService
     }
 
     /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) - To keep the method readable, increased CC is allowed
      * @param Command $command
      * @param IdentityId|null $actorId
      * @param Institution|null $actorInstitution
@@ -129,6 +131,11 @@ class CommandAuthorizationService
         // Assert RAA specific authorizations
         if ($command instanceof RaExecutable) {
             $this->logger->notice('Asserting a RA command');
+
+            // No additional FGA authorization is required for this shared (SS/RA) command
+            if ($command instanceof ExpressLocalePreferenceCommand) {
+                return true;
+            }
 
             // The actor metadata should be set
             if (is_null($actorId) || is_null($actorInstitution)) {

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Authorization\Service;
 use Mockery as m;
 use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Log\LoggerInterface;
+use Rhumsaa\Uuid\Uuid;
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 use Surfnet\Stepup\Identity\Value\IdentityId;
@@ -35,6 +36,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\Command;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\RaExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\CreateIdentityCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ExpressLocalePreferenceCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\UpdateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\VetSecondFactorCommand;
@@ -78,6 +80,29 @@ class CommandAuthorizationServiceTest extends TestCase
         $this->authorizationContextService = $authorizationContextService;
 
         $this->service = $service;
+    }
+
+    public function test_shared_ra_and_ss_commands_are_correctly_authorized()
+    {
+        $actorId = new IdentityId('123');
+        $actorInstitution = new Institution('institution');
+
+        $this->logger->shouldReceive('notice');
+
+        $raCredentials = m::mock(RegistrationAuthorityCredentials::class);
+        $raCredentials->shouldReceive('isSraa')
+            ->andReturn(false);
+
+        $this->identityService->shouldReceive('findRegistrationAuthorityCredentialsOf')
+            ->with($actorId->getIdentityId())
+            ->andReturn($raCredentials);
+
+        $command = new ExpressLocalePreferenceCommand();
+        $command->identityId = $actorId->getIdentityId();
+        $command->UUID = Uuid::uuid4();
+
+        $this->assertTrue($this->service->maySelfServiceCommandBeExecutedOnBehalfOf($command, $actorId));
+        $this->assertTrue($this->service->mayRaCommandBeExecutedOnBehalfOf($command, $actorId, $actorInstitution));
     }
 
     /**


### PR DESCRIPTION
The MW command authorization service did pass this command as a valid self service command, but did not pass the successive RA check.

https://www.pivotaltracker.com/story/show/171325732