### PR TITLE
Add missing institution to the filter options

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -216,8 +216,7 @@ class RaCandidateRepository extends EntityRepository
     public function createOptionsQuery(RaCandidateQuery $query)
     {
         $queryBuilder = $this->createQueryBuilder('rac')
-            ->select('rac.raInstitution')
-            ->groupBy('rac.raInstitution');
+            ->select('rac.institution');
 
         // Modify query to filter on authorization
         $this->authorizationRepositoryFilter->filter(


### PR DESCRIPTION
The ra-candidate search form allows filtering search results on
institution. But that filter select list was empty. Because the
institutions where not added to the search results.

That is fixed in the RaCandidateRepository::createOptionsQuery method by
also selecting the institutions.

https://www.pivotaltracker.com/story/show/171512620