### PR TITLE
Fix invalid RA candidate authorization

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaCandidateRepository.php
@@ -165,11 +165,14 @@ class RaCandidateRepository extends EntityRepository
     {
         $queryBuilder = $this->createQueryBuilder('rac');
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // For the RA candidates we want the identities that we could make RA. Because we then need to look at the
+        // select_raa's we have to look at the institution of the candidate because that's the institution we could
+        // select RA's from. Hence the 'rac.institution'.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,
-            'rac.raInstitution',
+            'rac.institution',
             'iac'
         );
 
@@ -218,11 +221,14 @@ class RaCandidateRepository extends EntityRepository
         $queryBuilder = $this->createQueryBuilder('rac')
             ->select('rac.institution');
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // For the RA candidates we want the identities that we could make RA. Because we then need to look at the
+        // select_raa's we have to look at the institution of the candidate because that's the institution we could
+        // select RA's from. Hence the 'rac.institution'.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,
-            'rac.raInstitution',
+            'rac.institution',
             'iac'
         );
 
@@ -285,11 +291,14 @@ class RaCandidateRepository extends EntityRepository
             ->setParameter('identityId', $identityId)
             ->orderBy('rac.raInstitution');
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // For the RA candidates we want the identities that we could make RA. Because we then need to look at the
+        // select_raa's we have to look at the institution of the candidate because that's the institution we could
+        // select RA's from. Hence the 'rac.institution'.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $authorizationContext,
-            'rac.raInstitution',
+            'rac.institution',
             'iac'
         );
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
@@ -90,7 +90,10 @@ class RaListingRepository extends EntityRepository
             ->setParameter('raInstitution', (string)$raInstitution)
             ->orderBy('r.raInstitution');
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // For the RA listing we want identities that are already RA. Because we then need to look at the use_raa's
+        // we have to look at the RA-institutions because that's the institution the user is RA for and we should use
+        // those RA's. Hence the 'r.raInstitution'.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $authorizationContext,
@@ -167,7 +170,10 @@ class RaListingRepository extends EntityRepository
                 ->setParameter('raInstitution', (string) $query->raInstitution);
         }
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // For the RA listing we want identities that are already RA. Because we then need to look at the use_raa's
+        // we have to look at the RA-institutions because that's the institution the user is RA for and we should use
+        // those RA's. Hence the 'r.raInstitution'.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,
@@ -202,7 +208,10 @@ class RaListingRepository extends EntityRepository
             ->select('r.institution, r.raInstitution')
             ->groupBy('r.institution, r.raInstitution');
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // For the RA listing we want identities that are already RA. Because we then need to look at the use_raa's
+        // we have to look at the RA-institutions because that's the institution the user is RA for and we should use
+        // those RA's. Hence the 'r.raInstitution'.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
@@ -94,6 +94,7 @@ class RaSecondFactorRepository extends EntityRepository
             ->createQueryBuilder('sf');
 
         // Modify query to filter on authorization context
+        // We want to list all second factors of the institution we are RA for.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,
@@ -174,6 +175,7 @@ class RaSecondFactorRepository extends EntityRepository
             ->groupBy('sf.institution');
 
         // Modify query to filter on authorization context
+        // We want to list all second factors of the institution we are RA for.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/VerifiedSecondFactorRepository.php
@@ -112,7 +112,8 @@ class VerifiedSecondFactorRepository extends EntityRepository
                 ->setParameter('registrationCode', $query->registrationCode);
         }
 
-        // Modify query to filter on authorization
+        // Modify query to filter on authorization:
+        // We want to list all second factors of the institution we are RA for.
         $this->authorizationRepositoryFilter->filter(
             $queryBuilder,
             $query->authorizationContext,


### PR DESCRIPTION
The RA-Candidates were filtered on RA institution but that should have
been on institution. Because we only want to use identities from the
institutions we are currently RA for.