### PR TITLE
Show the correct RA candidates for the virtual institution use case

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/InstitutionAuthorizationRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Repository/InstitutionAuthorizationRepository.php
@@ -59,16 +59,15 @@ class InstitutionAuthorizationRepository extends EntityRepository
 
     /**
      * @param Institution $institution
-     * @param InstitutionRole $role
      * @return InstitutionAuthorization[]
      */
-    public function findSelectRaasForInstitution(Institution $institution, InstitutionRole $role)
+    public function findSelectRaasForInstitution(Institution $institution)
     {
         return $this->createQueryBuilder('ia')
             ->where('ia.institutionRelation = :institution')
             ->andWhere('ia.institutionRole = :role')
             ->setParameter('institution', $institution->getInstitution())
-            ->setParameter('role', $role->getType())
+            ->setParameter('role', InstitutionRole::selectRaa()->getType())
             ->getQuery()
             ->getResult();
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaCandidateProjector.php
@@ -22,6 +22,7 @@ use Broadway\ReadModel\Projector;
 use Surfnet\Stepup\Configuration\Event\InstitutionConfigurationRemovedEvent;
 use Surfnet\Stepup\Configuration\Event\SelectRaaOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\SraaUpdatedEvent;
+use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
 use Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaaForInstitutionEvent;
 use Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent;
@@ -308,13 +309,13 @@ class RaCandidateProjector extends Projector
         CommonName $identityCommonName,
         Email $identityEmail
     ) {
-        $institutionAuthorizations = $this->institutionAuthorizationRepository
-            ->findAuthorizationOptionsForInstitution(new ConfigurationInstitution($identityInstitution->getInstitution()));
+        $selectRaaInstitutions = $this->institutionAuthorizationRepository->findSelectRaasForInstitution(
+            new ConfigurationInstitution($identityInstitution->getInstitution())
+        );
 
         $institutions = [];
-        foreach ($institutionAuthorizations as $authorization) {
-            $raInstitutionName = $authorization->institutionRelation->getInstitution();
-            $institutions[$raInstitutionName] = new Institution($raInstitutionName);
+        foreach ($selectRaaInstitutions as $institution) {
+            $institutions[$institution->institution->getInstitution()] = new Institution($institution->institution->getInstitution());
         }
 
         foreach ($institutions as $institution) {


### PR DESCRIPTION
When retracting an RA role the identity should have been added to the
candidate projection. This however didn't work as intended and the user
was reverted to his own institution and not the ra-institution.

A test was added in deploy to reproduce and mitigate the bug.
https://github.com/OpenConext/Stepup-Deploy/pull/101/commits/2e5e5bee32014c292a2af8e5b070ca9f6dca012c