### PR TITLE
Decouple identity creation

### DIFF
--- a/docs/test-data.md
+++ b/docs/test-data.md
@@ -1,0 +1,23 @@
+# Regarding test data
+During development and test it is important to have representable data in the event stream. Adding this data via
+SelfService and RA is a tedious task to say the least. To simplify this procedure, but to ensure a valid event stream,
+console commands where created to bootstrap identities and second factor tokens. This readme will instruct the reader 
+how to use these commands
+
+## Bootstrap an identity
+
+**Required arguments**
+
+In order of appearance:
+1. NameID: Example: `urn:collab:person:institution-b.example.com:joe-b1`
+2. Institution: the institution identifier, should be a whitelisted institution known in your StepUp installation. Example: `institution-b.example.com` 
+3. Common name: Example: `Joe Be-one`
+4. Email
+5. Preferred locale: Example `nl_NL` or `en_GB` 
+5. Actor ID: The identity id of the actor that is adding the user (Uuid found in identity projection). Example: `112e8d3e-b748-416f-9501-eda1eac0daad` 
+
+**Example usage**
+
+```bash
+$ 
+```

--- a/docs/test-data.md
+++ b/docs/test-data.md
@@ -19,5 +19,31 @@ In order of appearance:
 **Example usage**
 
 ```bash
-$ 
+$ app/console middleware:bootstrap:identity urn:collab:person:institution-b:joe-beone institution-b.example.com "Joe Beone" "joe@institution-b.co.uk" en_GB db9b8bdf-720c-44ba-a4c4-154953e45f14
+Adding an identity named: Joe Beone
+Creating a new identity
+Successfully created identity with UUID 16c40d6b-9808-429f-b906-30655dd74429
+
+```
+
+## Bootstrap a SMS second factor token
+
+**Required arguments**
+
+In order of appearance:
+1. NameID: Example: `urn:collab:person:institution-b.example.com:joe-b1`
+2. Institution: the institution identifier, should be a whitelisted institution known in your StepUp installation. Example: `institution-b.example.com`
+3. Token identifier: phone number formatted like `+31 (0) 612345678`
+4. Token state: allowed states: `unverified`, `verified` or `vetted` 
+5. Actor ID: The identity id of the actor that is adding the user (Uuid found in identity projection). Example: `112e8d3e-b748-416f-9501-eda1eac0daad` 
+
+**Example usage**
+
+```bash
+$ app/console middleware:bootstrap:sms urn:collab:person:institution-b:joe-beone institution-b.example.com "+31 (0) 612345678" vetted 'db9b8bdf-720c-44ba-a4c4-154953e45f14'
+Adding a vetted SMS token for Joe Beone
+Creating an unverified SMS token
+Creating a verified SMS token
+Vetting the verified SMS token
+Successfully created identity with UUID 16c40d6b-9808-429f-b906-30655dd74429 and vetted second factor with UUID 29c5204e-604d-4975-ab14-7706643f88b9
 ```

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapIdentityCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapIdentityCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command;
+
+use Exception;
+use Rhumsaa\Uuid\Uuid;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\CreateIdentityCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+
+final class BootstrapIdentityCommand extends AbstractBootstrapCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setDescription('Creates an identity')
+            ->addArgument('name-id', InputArgument::REQUIRED, 'The NameID of the identity to create')
+            ->addArgument('institution', InputArgument::REQUIRED, 'The institution of the identity to create')
+            ->addArgument('common-name', InputArgument::REQUIRED, 'The Common Name of the identity to create')
+            ->addArgument('email', InputArgument::REQUIRED, 'The e-mail address of the identity to create')
+            ->addArgument('preferred-locale', InputArgument::REQUIRED, 'The preferred locale of the identity to create')
+            ->addArgument('actor-id', InputArgument::REQUIRED, 'The id of the vetting actor');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->tokenStorage->setToken(
+            new AnonymousToken('cli.bootstrap-identity-with-sms-token', 'cli', ['ROLE_SS'])
+        );
+
+        $nameId = new NameId($input->getArgument('name-id'));
+        $institutionText = $input->getArgument('institution');
+        $institution = new Institution($institutionText);
+        $commonName = $input->getArgument('common-name');
+        $email = $input->getArgument('email');
+        $preferredLocale = $input->getArgument('preferred-locale');
+        $actorId = $input->getArgument('actor-id');
+
+        $this->enrichEventMetadata($actorId);
+
+        $output->writeln(sprintf('<comment>Adding an identity named: %s</comment>', $commonName));
+        if ($this->tokenBootstrapService->hasIdentityWithNameIdAndInstitution($nameId, $institution)) {
+            $output->writeln(
+                sprintf(
+                    '<error>An identity with name ID "%s" from institution "%s" already exists</error>',
+                    $nameId->getNameId(),
+                    $institution->getInstitution()
+                )
+            );
+            return;
+        }
+        try {
+            $this->beginTransaction();
+            $output->writeln('<info>Creating a new identity</info>');
+            $identity = $this->createIdentity($institution, $nameId, $commonName, $email, $preferredLocale);
+            $this->finishTransaction();
+        } catch (Exception $e) {
+            $output->writeln(
+                sprintf(
+                    '<error>An Error occurred when trying to bootstrap the identity: "%s"</error>',
+                    $e->getMessage()
+                )
+            );
+            $this->rollback();
+            throw $e;
+        }
+        $output->writeln(
+            sprintf('<info>Successfully created identity with UUID %s</info>', $identity->id)
+        );
+    }
+
+    protected function createIdentity(
+        Institution $institution,
+        NameId $nameId,
+        $commonName,
+        $email,
+        $preferredLocale
+    ) {
+        $identity = new CreateIdentityCommand();
+        $identity->UUID = (string)Uuid::uuid4();
+        $identity->id = (string)Uuid::uuid4();
+        $identity->institution = $institution->getInstitution();
+        $identity->nameId = $nameId->getNameId();
+        $identity->commonName = $commonName;
+        $identity->email = $email;
+        $identity->preferredLocale = $preferredLocale;
+        $this->process($identity);
+
+        return $identity;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapIdentityWithSmsSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapIdentityWithSmsSecondFactorCommand.php
@@ -23,7 +23,6 @@ use Rhumsaa\Uuid\Uuid;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\UnverifiedSecondFactor;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\CreateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhonePossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\VerifyEmailCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -31,9 +30,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
-/**
- * @SuppressWarnings(PHPMD.ExcessiveClassLength)
- */
 final class BootstrapIdentityWithSmsSecondFactorCommand extends AbstractBootstrapCommand
 {
     protected function configure()
@@ -42,9 +38,6 @@ final class BootstrapIdentityWithSmsSecondFactorCommand extends AbstractBootstra
             ->setDescription('Creates an identity with a SMS second factor')
             ->addArgument('name-id', InputArgument::REQUIRED, 'The NameID of the identity to create')
             ->addArgument('institution', InputArgument::REQUIRED, 'The institution of the identity to create')
-            ->addArgument('common-name', InputArgument::REQUIRED, 'The Common Name of the identity to create')
-            ->addArgument('email', InputArgument::REQUIRED, 'The e-mail address of the identity to create')
-            ->addArgument('preferred-locale', InputArgument::REQUIRED, 'The preferred locale of the identity to create')
             ->addArgument(
                 'phone-number',
                 InputArgument::REQUIRED,
@@ -67,57 +60,52 @@ final class BootstrapIdentityWithSmsSecondFactorCommand extends AbstractBootstra
         $institutionText = $input->getArgument('institution');
         $institution = new Institution($institutionText);
         $mailVerificationRequired = $this->requiresMailVerification($institutionText);
-        $commonName = $input->getArgument('common-name');
-        $email = $input->getArgument('email');
-        $preferredLocale = $input->getArgument('preferred-locale');
         $registrationStatus = $input->getArgument('registration-status');
         $phoneNumber = $input->getArgument('phone-number');
         $actorId = $input->getArgument('actor-id');
         $this->enrichEventMetadata($actorId);
-        $identity = false;
-        $output->writeln(sprintf('<notice>Adding a %s SMS token for %s</notice>', $registrationStatus, $commonName));
-        if ($this->tokenBootstrapService->hasIdentityWithNameIdAndInstitution($nameId, $institution)) {
+        if (!$this->tokenBootstrapService->hasIdentityWithNameIdAndInstitution($nameId, $institution)) {
             $output->writeln(
                 sprintf(
-                    '<notice>An identity with name ID "%s" from institution "%s" already exists, using that identity</notice>',
+                    '<error>An identity with name ID "%s" from institution "%s" does not exist, create it first.</error>',
                     $nameId->getNameId(),
                     $institution->getInstitution()
                 )
             );
-            $identity = $this->tokenBootstrapService->findOneByNameIdAndInstitution($nameId, $institution);
+
+            return;
         }
+        $identity = $this->tokenBootstrapService->findOneByNameIdAndInstitution($nameId, $institution);
+        $output->writeln(sprintf('<comment>Adding a %s SMS token for %s</comment>', $registrationStatus, $identity->commonName));
         $this->beginTransaction();
         $secondFactorId = Uuid::uuid4()->toString();
-        if (!$identity) {
-            $output->writeln('<notice>Creating a new identity</notice>');
-            $identity = $this->createIdentity($institution, $nameId, $commonName, $email, $preferredLocale);
-        }
+
         try {
             switch ($registrationStatus) {
                 case "unverified":
-                    $output->writeln('<notice>Creating an unverified SMS token</notice>');
+                    $output->writeln('<comment>Creating an unverified SMS token</comment>');
                     $this->provePossession($secondFactorId, $identity, $phoneNumber);
                     break;
                 case "verified":
-                    $output->writeln('<notice>Creating an unverified SMS token</notice>');
+                    $output->writeln('<comment>Creating an unverified SMS token</comment>');
                     $this->provePossession($secondFactorId, $identity, $phoneNumber);
                     $unverifiedSecondFactor = $this->tokenBootstrapService->findUnverifiedToken($identity->id, 'sms');
                     if ($mailVerificationRequired) {
-                        $output->writeln('<notice>Creating a verified SMS token</notice>');
+                        $output->writeln('<comment>Creating a verified SMS token</comment>');
                         $this->verifyEmail($identity, $unverifiedSecondFactor);
                     }
                     break;
                 case "vetted":
-                    $output->writeln('<notice>Creating an unverified SMS token</notice>');
+                    $output->writeln('<comment>Creating an unverified SMS token</comment>');
                     $this->provePossession($secondFactorId, $identity, $phoneNumber);
                     /** @var UnverifiedSecondFactor $unverifiedSecondFactor */
                     $unverifiedSecondFactor = $this->tokenBootstrapService->findUnverifiedToken($identity->id, 'sms');
                     if ($mailVerificationRequired) {
-                        $output->writeln('<notice>Creating a verified SMS token</notice>');
+                        $output->writeln('<comment>Creating a verified SMS token</comment>');
                         $this->verifyEmail($identity, $unverifiedSecondFactor);
                     }
                     $verifiedSecondFactor = $this->tokenBootstrapService->findVerifiedToken($identity->id, 'sms');
-                    $output->writeln('<notice>Vetting the verified SMS token</notice>');
+                    $output->writeln('<comment>Vetting the verified SMS token</comment>');
                     $this->vetSecondFactor(
                         'sms',
                         $actorId,
@@ -166,25 +154,5 @@ final class BootstrapIdentityWithSmsSecondFactorCommand extends AbstractBootstra
         $command->identityId = $identity->id;
         $command->verificationNonce = $unverifiedSecondFactor->verificationNonce;
         $this->process($command);
-    }
-
-    protected function createIdentity(
-        Institution $institution,
-        NameId $nameId,
-        $commonName,
-        $email,
-        $preferredLocale
-    ) {
-        $identity = new CreateIdentityCommand();
-        $identity->UUID = (string)Uuid::uuid4();
-        $identity->id = (string)Uuid::uuid4();
-        $identity->institution = $institution->getInstitution();
-        $identity->nameId = $nameId->getNameId();
-        $identity->commonName = $commonName;
-        $identity->email = $email;
-        $identity->preferredLocale = $preferredLocale;
-        $this->process($identity);
-
-        return $identity;
     }
 }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapSmsSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapSmsSecondFactorCommand.php
@@ -30,12 +30,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
-final class BootstrapIdentityWithSmsSecondFactorCommand extends AbstractBootstrapCommand
+final class BootstrapSmsSecondFactorCommand extends AbstractBootstrapCommand
 {
     protected function configure()
     {
         $this
-            ->setDescription('Creates an identity with a SMS second factor')
+            ->setDescription('Creates a SMS second factor for a specified user')
             ->addArgument('name-id', InputArgument::REQUIRED, 'The NameID of the identity to create')
             ->addArgument('institution', InputArgument::REQUIRED, 'The institution of the identity to create')
             ->addArgument(

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/console_commands.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/console_commands.yml
@@ -21,7 +21,7 @@ services:
         tags:
             - { name: 'console.command', command: 'middleware:bootstrap:identity' }
 
-    Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\BootstrapIdentityWithSmsSecondFactorCommand:
+    Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\BootstrapSmsSecondFactorCommand:
         parent: Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\AbstractBootstrapCommand
         tags:
-            - { name: 'console.command', command: 'middleware:bootstrap:identity-with-sms' }
+            - { name: 'console.command', command: 'middleware:bootstrap:sms' }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/console_commands.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/console_commands.yml
@@ -16,6 +16,11 @@ services:
             - "@security.token_storage"
             - '@Surfnet\StepupMiddleware\MiddlewareBundle\Service\TokenBootstrapService'
 
+    Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\BootstrapIdentityCommand:
+        parent: Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\AbstractBootstrapCommand
+        tags:
+            - { name: 'console.command', command: 'middleware:bootstrap:identity' }
+
     Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\BootstrapIdentityWithSmsSecondFactorCommand:
         parent: Surfnet\StepupMiddleware\MiddlewareBundle\Console\Command\AbstractBootstrapCommand
         tags:


### PR DESCRIPTION
Creating identities is now handled with a separate command. This improves maintainability of the command significantly. Added bonus is that the class complexity is no longer unacceptable according to PHP MD.

https://www.pivotaltracker.com/story/show/172429585