### PR TITLE
Add input validation for registration-status argument

### DIFF
--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapGsspSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapGsspSecondFactorCommand.php
@@ -57,6 +57,9 @@ final class BootstrapGsspSecondFactorCommand extends AbstractBootstrapCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $registrationStatus = $input->getArgument('registration-status');
+        $this->validRegistrationStatus($registrationStatus);
+
         $this->tokenStorage->setToken(
             new AnonymousToken('cli.bootstrap-gssp-token', 'cli', ['ROLE_SS', 'ROLE_RA'])
         );
@@ -64,7 +67,6 @@ final class BootstrapGsspSecondFactorCommand extends AbstractBootstrapCommand
         $institutionText = $input->getArgument('institution');
         $institution = new Institution($institutionText);
         $mailVerificationRequired = $this->requiresMailVerification($institutionText);
-        $registrationStatus = $input->getArgument('registration-status');
         $tokenType = $input->getArgument('gssp-token-type');
         $tokenIdentifier = $input->getArgument('gssp-token-identifier');
         $actorId = $input->getArgument('actor-id');

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapSmsSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapSmsSecondFactorCommand.php
@@ -53,6 +53,9 @@ final class BootstrapSmsSecondFactorCommand extends AbstractBootstrapCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $registrationStatus = $input->getArgument('registration-status');
+        $this->validRegistrationStatus($registrationStatus);
+
         $this->tokenStorage->setToken(
             new AnonymousToken('cli.bootstrap-sms-token', 'cli', ['ROLE_SS', 'ROLE_RA'])
         );
@@ -60,7 +63,6 @@ final class BootstrapSmsSecondFactorCommand extends AbstractBootstrapCommand
         $institutionText = $input->getArgument('institution');
         $institution = new Institution($institutionText);
         $mailVerificationRequired = $this->requiresMailVerification($institutionText);
-        $registrationStatus = $input->getArgument('registration-status');
         $phoneNumber = $input->getArgument('phone-number');
         $actorId = $input->getArgument('actor-id');
         $this->enrichEventMetadata($actorId);

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapYubikeySecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Console/Command/BootstrapYubikeySecondFactorCommand.php
@@ -52,6 +52,9 @@ final class BootstrapYubikeySecondFactorCommand extends AbstractBootstrapCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $registrationStatus = $input->getArgument('registration-status');
+        $this->validRegistrationStatus($registrationStatus);
+
         $this->tokenStorage->setToken(
             new AnonymousToken('cli.bootstrap-yubikey-token', 'cli', ['ROLE_SS', 'ROLE_RA'])
         );


### PR DESCRIPTION
Input validation was added for the registration status. This prevents strange behaviour in the execution of the command when a wrong argument is passed.

This was implemented for the three SF bootstrap commands

https://www.pivotaltracker.com/story/show/172429585