### PR TITLE
Make prove possession step optional

### DIFF
--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -65,3 +65,9 @@ parameters:
     # institution config (middleware api). The value configured in the parameters.yml will be used as the
     # fallback/default value.
     number_of_tokens_per_identity: 1
+
+    # Sets the tokens that can skip the prove possession step.
+    #
+    # This is the global, application wide default. The configuration consists of an array with second factors types
+    # that will skip the prove possession step in RA.
+    skip_prove_possession_second_factors: []

--- a/config/packages/events.yaml
+++ b/config/packages/events.yaml
@@ -38,6 +38,7 @@ parameters:
         - Surfnet\Stepup\Identity\Event\InstitutionsRemovedFromWhitelistEvent
         - Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent
         - Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent
+        - Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession
         - Surfnet\Stepup\Identity\Event\VerifiedSecondFactorRevokedEvent
         - Surfnet\Stepup\Identity\Event\WhitelistCreatedEvent
         - Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,3 +2,10 @@
 imports:
   - { resource: 'legacy/bundles.yaml' }
   - { resource: 'legacy/parameters.yaml' }
+
+services:
+
+  Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper:
+    arguments:
+      - "@surfnet_stepup.service.second_factor_type"
+      - '%skip_prove_possession_second_factors%'

--- a/docs/personal-data.md
+++ b/docs/personal-data.md
@@ -215,6 +215,18 @@ A list of all the [Identity events]((../src/Surfnet/Stepup/Identity/Event/) in s
 - Forgettable: secondFactorIdentifier
 - Forgettable: documentNumber
 
+[SecondFactorVettedWithoutTokenProofOfPossession](../src/Surfnet/Stepup/Identity/Event/SecondFactorVettedEvent.php)
+- identity_id
+- name_id
+- identity_institution
+- second_factor_id
+- second_factor_type
+- preferred_locale
+- Forgettable: email
+- Forgettable: commonName
+- Forgettable: secondFactorIdentifier
+- Forgettable: documentNumber
+
 [U2fDevicePossessionProvenAndVerifiedEvent](../src/Surfnet/Stepup/Identity/Event/U2fDevicePossessionProvenAndVerifiedEvent.php)
 - identity_id
 - identity_institution

--- a/docs/postman/3.json
+++ b/docs/postman/3.json
@@ -30,7 +30,7 @@
 					"raw": "{\n    \"command\": {\n        \"name\": \"Identity:CreateIdentity\",\n        \"uuid\": \"4783486c-5f9d-4d5e-8ad1-721272280595\",\n        \"payload\": {\n            \"id\": \"dd98c118-0f48-401b-9013-69be3a19e571\",\n            \"name_id\": \"urn:collab:person:institution-b.example.com:joe-b1\",\n            \"institution\": \"institution-b.example.com\",\n            \"email\": \"joe+joe-b1@stepup.example.com\",\n            \"common_name\": \"joe-b1 institution-b.example.com\",\n            \"preferred_locale \": \"nl_NL\"\n        }\n    },\n    \"meta\": {\n        \"actor_id\": null,\n        \"actor_institution\": null\n    }\n}"
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/command?XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/command?XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -39,7 +39,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"command"
 					],
 					"query": [
@@ -75,7 +74,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/identity?institution=stepup.example.com&NameId=urn:collab:person:stepup.example.com:admin&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/identity?institution=stepup.example.com&NameId=urn:collab:person:stepup.example.com:admin&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -84,7 +83,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"identity"
 					],
 					"query": [
@@ -125,7 +123,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/identity/db9b8bdf-720c-44ba-a4c4-154953e45f14",
+					"raw": "http://middleware.stepup.example.com/identity/db9b8bdf-720c-44ba-a4c4-154953e45f14",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -134,7 +132,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"identity",
 						"db9b8bdf-720c-44ba-a4c4-154953e45f14"
 					]
@@ -166,7 +163,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://mw-dev.stepup.coin.surf.net/app_dev.php/unverified-second-factors?identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1",
+					"raw": "http://middleware.stepup.example.com/unverified-second-factors?identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1",
 					"protocol": "http",
 					"host": [
 						"mw-dev",
@@ -176,7 +173,6 @@
 						"net"
 					],
 					"path": [
-						"app_dev.php",
 						"unverified-second-factors"
 					],
 					"query": [
@@ -213,7 +209,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://mw-dev.stepup.coin.surf.net/app_dev.php/unverified-second-factors/4984057f-5952-4a82-a77f-44bc9cd62ce4",
+					"raw": "http://middleware.stepup.example.com/unverified-second-factor/4984057f-5952-4a82-a77f-44bc9cd62ce4",
 					"protocol": "http",
 					"host": [
 						"mw-dev",
@@ -223,9 +219,50 @@
 						"net"
 					],
 					"path": [
-						"app_dev.php",
-						"unverified-second-factors",
+						"unverified-second-factor",
 						"4984057f-5952-4a82-a77f-44bc9cd62ce4"
+					]
+				},
+				"description": "- `secondFactorId` UUIDv4 of the second factor"
+			},
+			"response": []
+		},
+		{
+			"name": "/unverified-second-factor/{secondFactorId}/skip-prove-possession",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic c3M6YmFy"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://middleware.stepup.example.com/unverified-second-factor/4984057f-5952-4a82-a77f-44bc9cd62ce4",
+					"protocol": "http",
+					"host": [
+						"mw-dev",
+						"stepup",
+						"coin",
+						"surf",
+						"net"
+					],
+					"path": [
+						"unverified-second-factors",
+						"4984057f-5952-4a82-a77f-44bc9cd62ce4",
+						"skip-prove-possession"
 					]
 				},
 				"description": "- `secondFactorId` UUIDv4 of the second factor"
@@ -255,7 +292,7 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "https://middleware.stepup.example.com/app_dev.php/verified-second-factors?actorInstitution=institution-a.example.com&actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "https://middleware.stepup.example.com/verified-second-factors?actorInstitution=institution-a.example.com&actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "https",
 					"host": [
 						"middleware",
@@ -264,7 +301,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"verified-second-factors"
 					],
 					"query": [
@@ -309,7 +345,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/verified-second-factor/4984057f-5952-4a82-a77f-44bc9cd62ce4",
+					"raw": "http://middleware.stepup.example.com/verified-second-factor/4984057f-5952-4a82-a77f-44bc9cd62ce4",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -318,7 +354,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"verified-second-factor",
 						"4984057f-5952-4a82-a77f-44bc9cd62ce4"
 					]
@@ -350,7 +385,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/vetted-second-factors?registrationCode=TEST&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/vetted-second-factors?registrationCode=TEST&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -359,7 +394,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"vetted-second-factors"
 					],
 					"query": [
@@ -400,7 +434,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/vetted-second-factor/c732d0ac-9f61-4ae1-924e-40d5172fca86",
+					"raw": "http://middleware.stepup.example.com/vetted-second-factor/c732d0ac-9f61-4ae1-924e-40d5172fca86",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -409,7 +443,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"vetted-second-factor",
 						"c732d0ac-9f61-4ae1-924e-40d5172fca86"
 					]
@@ -441,7 +474,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/vetted-second-factor/c732d0ac-9f61-4ae1-924e-40d5172fca86",
+					"raw": "http://middleware.stepup.example.com/vetted-second-factor/c732d0ac-9f61-4ae1-924e-40d5172fca86",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -450,7 +483,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"vetted-second-factor",
 						"c732d0ac-9f61-4ae1-924e-40d5172fca86"
 					]
@@ -478,7 +510,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/sraa/3858f62230ac3c915f300c664312c63f",
+					"raw": "http://middleware.stepup.example.com/sraa/3858f62230ac3c915f300c664312c63f",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -487,7 +519,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"sraa",
 						"3858f62230ac3c915f300c664312c63f"
 					]
@@ -515,7 +546,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/registration-authority?institution=institution-a.example.com&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/registration-authority?institution=institution-a.example.com&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -524,7 +555,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"registration-authority"
 					],
 					"query": [
@@ -561,7 +591,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/registration-authority/41f8aded-e21f-43f1-a4e3-e5aa84c1f82e",
+					"raw": "http://middleware.stepup.example.com/registration-authority/41f8aded-e21f-43f1-a4e3-e5aa84c1f82e",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -570,7 +600,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"registration-authority",
 						"41f8aded-e21f-43f1-a4e3-e5aa84c1f82e"
 					]
@@ -602,7 +631,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/ra-listing?actorId=b954e4a3-1ed4-489b-9996-f22512d31eef&actorInstitution=institution-a.example.com&institution=institution-a.example.com&orderBy=commonName&p=1&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/ra-listing?actorId=b954e4a3-1ed4-489b-9996-f22512d31eef&actorInstitution=institution-a.example.com&institution=institution-a.example.com&orderBy=commonName&p=1&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -611,7 +640,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-listing"
 					],
 					"query": [
@@ -664,7 +692,7 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/ra-listing/62096060-8b60-4bb1-bcc1-e00158a4051b/stepup.example.com?actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&actorInstitution=institution-a.example.com&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/ra-listing/62096060-8b60-4bb1-bcc1-e00158a4051b/stepup.example.com?actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&actorInstitution=institution-a.example.com&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -673,7 +701,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-listing",
 						"62096060-8b60-4bb1-bcc1-e00158a4051b",
 						"stepup.example.com"
@@ -720,7 +747,7 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/ra-candidate?actorId=b954e4a3-1ed4-489b-9996-f22512d31eef&actorInstitution=institution-a.example.com&secondFactorTypes%5B2%5D=yubikey&secondFactorTypes%5B3%5D=u2f&p=1&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/ra-candidate?actorId=b954e4a3-1ed4-489b-9996-f22512d31eef&actorInstitution=institution-a.example.com&secondFactorTypes%5B2%5D=yubikey&secondFactorTypes%5B3%5D=u2f&p=1&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -729,7 +756,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-candidate"
 					],
 					"query": [
@@ -782,7 +808,7 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/ra-candidate/11db6fa9-33a7-413a-8b16-6d27ffe94486/Institution-f.example.com?actorId=b954e4a3-1ed4-489b-9996-f22512d31eef&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/ra-candidate/11db6fa9-33a7-413a-8b16-6d27ffe94486/Institution-f.example.com?actorId=b954e4a3-1ed4-489b-9996-f22512d31eef&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -791,7 +817,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-candidate",
 						"11db6fa9-33a7-413a-8b16-6d27ffe94486",
 						"Institution-f.example.com"
@@ -830,7 +855,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/institution-listing",
+					"raw": "http://middleware.stepup.example.com/institution-listing",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -839,7 +864,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"institution-listing"
 					]
 				},
@@ -866,7 +890,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/audit-log/second-factors?institution=Ibuildings&identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1&orderBy=recordedOn&orderDirection=asc",
+					"raw": "http://middleware.stepup.example.com/audit-log/second-factors?institution=Ibuildings&identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1&orderBy=recordedOn&orderDirection=asc",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -875,7 +899,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"audit-log",
 						"second-factors"
 					],
@@ -925,7 +948,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://mw-dev.stepup.coin.surf.net/app_dev.php/ra-location?institution=Ibuildings",
+					"raw": "http://middleware.stepup.example.com/ra-location?institution=Ibuildings",
 					"protocol": "http",
 					"host": [
 						"mw-dev",
@@ -935,7 +958,6 @@
 						"net"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-location"
 					],
 					"query": [
@@ -972,7 +994,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://mw-dev.stepup.coin.surf.net/app_dev.php/ra-location/123e4567-e89b-12d3-a456-426655440000",
+					"raw": "http://middleware.stepup.example.com/ra-location/123e4567-e89b-12d3-a456-426655440000",
 					"protocol": "http",
 					"host": [
 						"mw-dev",
@@ -982,7 +1004,6 @@
 						"net"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-location",
 						"123e4567-e89b-12d3-a456-426655440000"
 					]
@@ -1014,7 +1035,7 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/institution-configuration-options/stepup.example.com",
+					"raw": "http://middleware.stepup.example.com/institution-configuration-options/stepup.example.com",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -1023,7 +1044,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"institution-configuration-options",
 						"stepup.example.com"
 					]
@@ -1051,7 +1071,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/ra-second-factors?actorInstitution=institution-a.example.com&actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&p=1&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/ra-second-factors?actorInstitution=institution-a.example.com&actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&p=1&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -1060,7 +1080,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-second-factors"
 					],
 					"query": [
@@ -1105,7 +1124,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "http://middleware.stepup.example.com/app_dev.php/ra-second-factors-export?actorInstitution=institution-a.example.com&actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&p=1&XDEBUG_SESSION_START=PHPSTORM",
+					"raw": "http://middleware.stepup.example.com/ra-second-factors-export?actorInstitution=institution-a.example.com&actorId=62096060-8b60-4bb1-bcc1-e00158a4051b&p=1&XDEBUG_SESSION_START=PHPSTORM",
 					"protocol": "http",
 					"host": [
 						"middleware",
@@ -1114,7 +1133,6 @@
 						"com"
 					],
 					"path": [
-						"app_dev.php",
 						"ra-second-factors-export"
 					],
 					"query": [

--- a/src/Surfnet/Stepup/Helper/SecondFactorProvePossessionHelper.php
+++ b/src/Surfnet/Stepup/Helper/SecondFactorProvePossessionHelper.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Helper;
+
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
+use Surfnet\StepupBundle\Value\SecondFactorType;
+use Webmozart\Assert\Assert;
+
+class SecondFactorProvePossessionHelper
+{
+    /**
+     * @var array
+     */
+    private $skipProvePossessionSecondFactorTypes;
+
+    /**
+     * @param SecondFactorTypeService $secondFactorTypeService
+     * @param array $skipProvePossessionSecondFactorTypes
+     */
+    public function __construct(
+        SecondFactorTypeService $secondFactorTypeService,
+        array $skipProvePossessionSecondFactorTypes
+    ) {
+        Assert::allInArray(
+            $skipProvePossessionSecondFactorTypes,
+            $secondFactorTypeService->getAvailableSecondFactorTypes(),
+            'Unsupported second factor type configured to skip prove possession'
+        );
+
+        $this->skipProvePossessionSecondFactorTypes = $skipProvePossessionSecondFactorTypes;
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     * @return bool
+     */
+    public function canSkipProvePossession(SecondFactorType $secondFactorType)
+    {
+        return in_array($secondFactorType->getSecondFactorType(), $this->skipProvePossessionSecondFactorTypes);
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Api/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Api/Identity.php
@@ -21,7 +21,7 @@ namespace Surfnet\Stepup\Identity\Api;
 use Broadway\Domain\AggregateRoot;
 use Surfnet\Stepup\Configuration\InstitutionConfiguration;
 use Surfnet\Stepup\Exception\DomainException;
-use Surfnet\Stepup\Identity\Collection\InstitutionCollection;
+use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Identity\Entity\VerifiedSecondFactor;
 use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\ContactInformation;
@@ -166,7 +166,11 @@ interface Identity extends AggregateRoot
      * @param DocumentNumber $documentNumber
      * @param bool $identityVerified
      * @param SecondFactorTypeService $secondFactorTypeService
+     * @param SecondFactorProvePossessionHelper $secondFactorProvePossessionHelper
+     * @param bool $provePossessionSkipped
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function vetSecondFactor(
         Identity $registrant,
@@ -176,7 +180,9 @@ interface Identity extends AggregateRoot
         $registrationCode,
         DocumentNumber $documentNumber,
         $identityVerified,
-        SecondFactorTypeService $secondFactorTypeService
+        SecondFactorTypeService $secondFactorTypeService,
+        SecondFactorProvePossessionHelper $secondFactorProvePossessionHelper,
+        $provePossessionSkipped
     );
 
     /**
@@ -187,6 +193,7 @@ interface Identity extends AggregateRoot
      * @param SecondFactorIdentifier $secondFactorIdentifier
      * @param string                 $registrationCode
      * @param DocumentNumber         $documentNumber
+     * @param bool                   $provePossessionSkipped
      * @throws DomainException
      * @return void
      */
@@ -195,7 +202,8 @@ interface Identity extends AggregateRoot
         SecondFactorType $secondFactorType,
         SecondFactorIdentifier $secondFactorIdentifier,
         $registrationCode,
-        DocumentNumber $documentNumber
+        DocumentNumber $documentNumber,
+        $provePossessionSkipped
     );
 
     /**

--- a/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
@@ -24,6 +24,7 @@ use Surfnet\Stepup\Exception\InvalidArgumentException;
 use Surfnet\Stepup\Identity\Api\Identity;
 use Surfnet\Stepup\Identity\Event\CompliedWithVerifiedSecondFactorRevocationEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\VerifiedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Value\DocumentNumber;
@@ -138,8 +139,26 @@ class VerifiedSecondFactor extends AbstractSecondFactor
         );
     }
 
-    public function vet(DocumentNumber $documentNumber)
+    public function vet(DocumentNumber $documentNumber, $provePossessionSkipped)
     {
+        if ($provePossessionSkipped) {
+            $this->apply(
+                new SecondFactorVettedWithoutTokenProofOfPossession(
+                    $this->identity->getId(),
+                    $this->identity->getNameId(),
+                    $this->identity->getInstitution(),
+                    $this->id,
+                    $this->type,
+                    $this->secondFactorIdentifier,
+                    $documentNumber,
+                    $this->identity->getCommonName(),
+                    $this->identity->getEmail(),
+                    $this->identity->getPreferredLocale()
+                )
+            );
+            return;
+        }
+
         $this->apply(
             new SecondFactorVettedEvent(
                 $this->identity->getId(),

--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedWithoutTokenProofOfPossession.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedWithoutTokenProofOfPossession.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * Copyright 2020 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Event;
+
+use Surfnet\Stepup\Identity\AuditLog\Metadata;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\DocumentNumber;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\Stepup\Identity\Value\SecondFactorId;
+use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
+use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
+use Surfnet\StepupBundle\Value\SecondFactorType;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class SecondFactorVettedWithoutTokenProofOfPossession extends IdentityEvent implements Forgettable
+{
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\NameId
+     */
+    public $nameId;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
+     */
+    public $secondFactorId;
+
+    /**
+     * @var \Surfnet\StepupBundle\Value\SecondFactorType
+     */
+    public $secondFactorType;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\SecondFactorIdentifier
+     */
+    public $secondFactorIdentifier;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\DocumentNumber
+     */
+    public $documentNumber;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\CommonName
+     */
+    public $commonName;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\Email
+     */
+    public $email;
+
+    /**
+     * @var \Surfnet\Stepup\Identity\Value\Locale Eg. "en_GB"
+     */
+    public $preferredLocale;
+
+    /**
+     * @param IdentityId        $identityId
+     * @param NameId            $nameId
+     * @param Institution       $institution
+     * @param SecondFactorId    $secondFactorId
+     * @param SecondFactorType  $secondFactorType
+     * @param SecondFactorIdentifier $secondFactorIdentifier
+     * @param DocumentNumber    $documentNumber
+     * @param CommonName        $commonName
+     * @param Email             $email
+     * @param Locale            $preferredLocale
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        IdentityId $identityId,
+        NameId $nameId,
+        Institution $institution,
+        SecondFactorId $secondFactorId,
+        SecondFactorType $secondFactorType,
+        SecondFactorIdentifier $secondFactorIdentifier,
+        DocumentNumber $documentNumber,
+        CommonName $commonName,
+        Email $email,
+        Locale $preferredLocale
+    ) {
+        parent::__construct($identityId, $institution);
+
+        $this->nameId                 = $nameId;
+        $this->secondFactorId         = $secondFactorId;
+        $this->secondFactorType       = $secondFactorType;
+        $this->secondFactorIdentifier = $secondFactorIdentifier;
+        $this->documentNumber         = $documentNumber;
+        $this->commonName             = $commonName;
+        $this->email                  = $email;
+        $this->preferredLocale        = $preferredLocale;
+    }
+
+    public function getAuditLogMetadata()
+    {
+        $metadata                         = new Metadata();
+        $metadata->identityId             = $this->identityId;
+        $metadata->identityInstitution    = $this->identityInstitution;
+        $metadata->secondFactorId         = $this->secondFactorId;
+        $metadata->secondFactorType       = $this->secondFactorType;
+        $metadata->secondFactorIdentifier = $this->secondFactorIdentifier;
+
+        return $metadata;
+    }
+
+    public static function deserialize(array $data)
+    {
+        $secondFactorType = new SecondFactorType($data['second_factor_type']);
+
+        return new self(
+            new IdentityId($data['identity_id']),
+            new NameId($data['name_id']),
+            new Institution($data['identity_institution']),
+            new SecondFactorId($data['second_factor_id']),
+            $secondFactorType,
+            SecondFactorIdentifierFactory::unknownForType($secondFactorType),
+            DocumentNumber::unknown(),
+            CommonName::unknown(),
+            Email::unknown(),
+            new Locale($data['preferred_locale'])
+        );
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'identity_id'              => (string) $this->identityId,
+            'name_id'                  => (string) $this->nameId,
+            'identity_institution'     => (string) $this->identityInstitution,
+            'second_factor_id'         => (string) $this->secondFactorId,
+            'second_factor_type'       => (string) $this->secondFactorType,
+            'preferred_locale'         => (string) $this->preferredLocale,
+        ];
+    }
+
+    public function getSensitiveData()
+    {
+        return (new SensitiveData)
+            ->withCommonName($this->commonName)
+            ->withEmail($this->email)
+            ->withSecondFactorIdentifier($this->secondFactorIdentifier, $this->secondFactorType)
+            ->withDocumentNumber($this->documentNumber);
+    }
+
+    public function setSensitiveData(SensitiveData $sensitiveData)
+    {
+        $this->email          = $sensitiveData->getEmail();
+        $this->commonName     = $sensitiveData->getCommonName();
+        $this->secondFactorIdentifier = $sensitiveData->getSecondFactorIdentifier();
+        $this->documentNumber = $sensitiveData->getDocumentNumber();
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Identity.php
@@ -23,6 +23,7 @@ use Surfnet\Stepup\Configuration\InstitutionConfiguration;
 use Surfnet\Stepup\Configuration\Value\Institution as ConfigurationInstitution;
 use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Exception\DomainException;
+use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Identity\Api\Identity as IdentityApi;
 use Surfnet\Stepup\Identity\Entity\RegistrationAuthority;
 use Surfnet\Stepup\Identity\Entity\RegistrationAuthorityCollection;
@@ -55,6 +56,7 @@ use Surfnet\Stepup\Identity\Event\RegistrationAuthorityInformationAmendedEvent;
 use Surfnet\Stepup\Identity\Event\RegistrationAuthorityInformationAmendedForInstitutionEvent;
 use Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent;
 use Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent;
@@ -427,6 +429,9 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
         $secondFactorToVerify->verifyEmail();
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function vetSecondFactor(
         IdentityApi $registrant,
         SecondFactorId $registrantsSecondFactorId,
@@ -435,7 +440,9 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
         $registrationCode,
         DocumentNumber $documentNumber,
         $identityVerified,
-        SecondFactorTypeService $secondFactorTypeService
+        SecondFactorTypeService $secondFactorTypeService,
+        SecondFactorProvePossessionHelper $secondFactorProvePossessionHelper,
+        $provePossessionSkipped
     ) {
         $this->assertNotForgotten();
 
@@ -470,12 +477,21 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
             throw new DomainException('Will not vet second factor when physical identity has not been verified.');
         }
 
+        if ($provePossessionSkipped && !$secondFactorProvePossessionHelper->canSkipProvePossession($registrantsSecondFactorType)) {
+            throw new DomainException(sprintf(
+                "The possession of registrants second factor with ID '%s' of type '%s' has to be physically proven",
+                $registrantsSecondFactorId,
+                $registrantsSecondFactorType->getSecondFactorType()
+            ));
+        }
+
         $registrant->complyWithVettingOfSecondFactor(
             $registrantsSecondFactorId,
             $registrantsSecondFactorType,
             $registrantsSecondFactorIdentifier,
             $registrationCode,
-            $documentNumber
+            $documentNumber,
+            $provePossessionSkipped
         );
     }
 
@@ -484,7 +500,8 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
         SecondFactorType $secondFactorType,
         SecondFactorIdentifier $secondFactorIdentifier,
         $registrationCode,
-        DocumentNumber $documentNumber
+        DocumentNumber $documentNumber,
+        $provePossessionSkipped
     ) {
         $this->assertNotForgotten();
 
@@ -507,7 +524,7 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
             throw new DomainException('Cannot vet second factor, the registration window is closed.');
         }
 
-        $secondFactorToVet->vet($documentNumber);
+        $secondFactorToVet->vet($documentNumber, $provePossessionSkipped);
     }
 
     public function revokeSecondFactor(SecondFactorId $secondFactorId)
@@ -906,6 +923,18 @@ class Identity extends EventSourcedAggregateRoot implements IdentityApi
     }
 
     protected function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $secondFactorId = (string)$event->secondFactorId;
+
+        /** @var VerifiedSecondFactor $verified */
+        $verified = $this->verifiedSecondFactors->get($secondFactorId);
+        $vetted = $verified->asVetted();
+
+        $this->verifiedSecondFactors->remove($secondFactorId);
+        $this->vettedSecondFactors->set($secondFactorId, $vetted);
+    }
+
+    protected function applySecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
     {
         $secondFactorId = (string)$event->secondFactorId;
 

--- a/src/Surfnet/Stepup/Tests/Identity/Event/ForgettableEventsTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Event/ForgettableEventsTest.php
@@ -44,6 +44,7 @@ final class ForgettableEventsTest extends TestCase
             'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent',
             'Surfnet\Stepup\Identity\Event\SecondFactorRevokedEvent',
             'Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent',
+            'Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession',
             'Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent',
             'Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenAndVerifiedEvent',
             'Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent',

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
@@ -57,6 +57,7 @@ class AuditLogEntry implements JsonSerializable
         'Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent'                        => 'possession_proven',
         'Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent'             => 'possession_proven',
         'Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent'                           => 'vetted',
+        'Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession' => 'vetted_possession_unknown',
         'Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent'                => 'revoked',
         'Surfnet\Stepup\Identity\Event\VerifiedSecondFactorRevokedEvent'                  => 'revoked',
         'Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent'                    => 'revoked',

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaSecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaSecondFactorProjector.php
@@ -30,6 +30,7 @@ use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\IdentityRenamedEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent;
@@ -258,6 +259,16 @@ class RaSecondFactorProjector extends Projector
     }
 
     public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $secondFactor = $this->raSecondFactorRepository->find((string) $event->secondFactorId);
+
+        $secondFactor->documentNumber = $event->documentNumber;
+        $secondFactor->status = SecondFactorStatus::vetted();
+
+        $this->raSecondFactorRepository->save($secondFactor);
+    }
+
+    public function applySecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
     {
         $secondFactor = $this->raSecondFactorRepository->find((string) $event->secondFactorId);
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/SecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/SecondFactorProjector.php
@@ -28,6 +28,7 @@ use Surfnet\Stepup\Identity\Event\GssfPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent;
@@ -222,6 +223,20 @@ class SecondFactorProjector extends Projector
     }
 
     public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $verified = $this->verifiedRepository->find($event->secondFactorId->getSecondFactorId());
+
+        $vetted = new VettedSecondFactor();
+        $vetted->id = $event->secondFactorId->getSecondFactorId();
+        $vetted->identityId = $event->identityId->getIdentityId();
+        $vetted->type = $event->secondFactorType->getSecondFactorType();
+        $vetted->secondFactorIdentifier = $event->secondFactorIdentifier->getValue();
+
+        $this->vettedRepository->save($vetted);
+        $this->verifiedRepository->remove($verified);
+    }
+
+    public function applySecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
     {
         $verified = $this->verifiedRepository->find($event->secondFactorId->getSecondFactorId());
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
@@ -47,6 +47,7 @@ class AuditLogRepository extends ServiceEntityRepository
         'Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent',
         'Surfnet\Stepup\Identity\Event\EmailVerifiedEvent',
         'Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent',
+        'Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession',
         'Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent',
         'Surfnet\Stepup\Identity\Event\VerifiedSecondFactorRevokedEvent',
         'Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent',

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -62,6 +62,12 @@ verified_second_factor:
     methods:  [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
+verified_second_factor_can_skip_prove_posession:
+    path:     /verified-second-factor/{id}/skip-prove-possession
+    defaults: { _controller: SurfnetStepupMiddlewareApiBundle:VerifiedSecondFactor:getCanSkipProvePossession }
+    methods:  [GET]
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 vetted_second_factor:
     path:     /vetted-second-factor/{id}
     defaults: { _controller: SurfnetStepupMiddlewareApiBundle:VettedSecondFactor:get }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/VetSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/VetSecondFactorCommand.php
@@ -90,6 +90,13 @@ class VetSecondFactorCommand extends AbstractCommand implements RaExecutable
     public $identityVerified;
 
     /**
+     * @Assert\Type(type="bool")
+     *
+     * @var boolean
+     */
+    public $provePossessionSkipped;
+
+    /**
      * @inheritDoc
      */
     public function getRaInstitution()

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Processor/SecondFactorVettedEmailProcessor.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Processor/SecondFactorVettedEmailProcessor.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Processor;
 
 use Broadway\Processor\Processor;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\SecondFactorVettedMailService;
 
@@ -35,6 +36,11 @@ final class SecondFactorVettedEmailProcessor extends Processor
     }
 
     public function handleSecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $this->secondFactorVettedMailService->sendVettedEmail($event->preferredLocale, $event->commonName, $event->email);
+    }
+
+    public function handleSecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
     {
         $this->secondFactorVettedMailService->sendVettedEmail($event->preferredLocale, $event->commonName, $event->email);
     }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
@@ -7,6 +7,7 @@ services:
             - "@identity.entity.configurable_settings"
             - "@surfnet_stepup_middleware_api.service.allowed_second_factor_list"
             - "@surfnet_stepup.service.second_factor_type"
+            - '@Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper'
             - "@surfnet_stepup_middleware_api.service.institution_configuration_options"
             - "@surfnet_stepup.repository.institution_configuration"
         tags: [{ name: command_bus.command_handler }]

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -25,12 +25,14 @@ use Broadway\EventStore\EventStore as EventStoreInterface;
 use Mockery as m;
 use Surfnet\Stepup\Configuration\EventSourcing\InstitutionConfigurationRepository;
 use Surfnet\Stepup\DateTime\DateTime;
+use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Identity\Entity\ConfigurableSettings;
 use Surfnet\Stepup\Identity\Event\CompliedWithUnverifiedSecondFactorRevocationEvent;
 use Surfnet\Stepup\Identity\Event\CompliedWithVerifiedSecondFactorRevocationEvent;
 use Surfnet\Stepup\Identity\Event\CompliedWithVettedSecondFactorRevocationEvent;
 use Surfnet\Stepup\Identity\Event\EmailVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\U2fDevicePossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent;
@@ -83,6 +85,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
             ConfigurableSettings::create(self::$window, []),
             m::mock(AllowedSecondFactorListService::class),
             m::mock(SecondFactorTypeService::class)->shouldIgnoreMissing(),
+            m::mock(SecondFactorProvePossessionHelper::class)->shouldIgnoreMissing(),
             m::mock(InstitutionConfigurationOptionsService::class)->shouldIgnoreMissing(),
             m::mock(InstitutionConfigurationRepository::class)
         );
@@ -569,6 +572,123 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     new Locale('en_GB')
                 ),
                 new SecondFactorVettedEvent(
+                    $registrantId,
+                    $registrantNameId,
+                    $registrantInstitution,
+                    $registrantSecondFactorId,
+                    $registrantSecondFactorType,
+                    $registrantSecondFactorIdentifier,
+                    new DocumentNumber('DOCUMENT_NUMBER'),
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                )
+            ])
+            ->when($command)
+            ->then([
+                new CompliedWithVettedSecondFactorRevocationEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecondFactorId,
+                    new SecondFactorType('yubikey'),
+                    $registrantSecondFactorIdentifier,
+                    $authorityId
+                ),
+                new VettedSecondFactorsAllRevokedEvent(
+                    $registrantId,
+                    $registrantInstitution
+                ),
+            ]);
+    }
+
+
+
+    /**
+     * @test
+     * @group command-handler
+     */
+    public function a_registration_authority_can_revoke_a_possession_proved_skipped_vetted_second_factor()
+    {
+        $command                 = new RevokeRegistrantsSecondFactorCommand();
+        $command->authorityId    = static::uuid();
+        $command->identityId     = static::uuid();
+        $command->secondFactorId = static::uuid();
+
+        $authorityId                = new IdentityId($command->authorityId);
+        $authorityNameId            = new NameId(static::uuid());
+        $authorityInstitution       = new Institution('Wazoo');
+        $authorityEmail             = new Email('info@domain.invalid');
+        $authorityCommonName        = new CommonName('Henk Westbroek');
+
+        $registrantId                     = new IdentityId($command->identityId);
+        $registrantInstitution            = new Institution('A Corp.');
+        $registrantNameId                 = new NameId('3');
+        $registrantSecondFactorId         = new SecondFactorId($command->secondFactorId);
+        $registrantSecondFactorType       = new SecondFactorType('yubikey');
+        $registrantSecondFactorIdentifier = new YubikeyPublicId('00890782');
+        $registrantEmail                  = new Email('matti@domain.invalid');
+        $registrantCommonName             = new CommonName('Matti Vanhanen');
+
+        $this->scenario
+            ->withAggregateId($authorityId)
+            ->given([
+                new IdentityCreatedEvent(
+                    $authorityId,
+                    $authorityInstitution,
+                    $authorityNameId,
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB')
+                ),
+                new YubikeySecondFactorBootstrappedEvent(
+                    $authorityId,
+                    $authorityNameId,
+                    $authorityInstitution,
+                    $authorityCommonName,
+                    $authorityEmail,
+                    new Locale('en_GB'),
+                    new SecondFactorId(static::uuid()),
+                    new YubikeyPublicId('12345678')
+                )
+            ])
+            ->withAggregateId($registrantId)
+            ->given([
+                new IdentityCreatedEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantNameId,
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new YubikeyPossessionProvenEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecondFactorId,
+                    $registrantSecondFactorIdentifier,
+                    true,
+                    EmailVerificationWindow::createFromTimeFrameStartingAt(
+                        TimeFrame::ofSeconds(static::$window),
+                        DateTime::now()
+                    ),
+                    'nonce',
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new EmailVerifiedEvent(
+                    $registrantId,
+                    $registrantInstitution,
+                    $registrantSecondFactorId,
+                    $registrantSecondFactorType,
+                    $registrantSecondFactorIdentifier,
+                    DateTime::now(),
+                    'REGISTRATION_CODE',
+                    $registrantCommonName,
+                    $registrantEmail,
+                    new Locale('en_GB')
+                ),
+                new SecondFactorVettedWithoutTokenProofOfPossession(
                     $registrantId,
                     $registrantNameId,
                     $registrantInstitution,

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/SecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/SecondFactorProjector.php
@@ -22,6 +22,7 @@ use Broadway\ReadModel\Projector;
 use Surfnet\Stepup\Identity\Event\CompliedWithVettedSecondFactorRevocationEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\LocalePreferenceExpressedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent;
@@ -60,6 +61,21 @@ class SecondFactorProjector extends Projector
     }
 
     public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $this->repository->save(
+            new SecondFactor(
+                (string) $event->identityId,
+                (string) $event->nameId,
+                (string) $event->identityInstitution,
+                (string) $event->preferredLocale,
+                (string) $event->secondFactorId,
+                $event->secondFactorIdentifier,
+                $event->secondFactorType
+            )
+        );
+    }
+
+    public function applySecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
     {
         $this->repository->save(
             new SecondFactor(


### PR DESCRIPTION
**Be aware that this is build on top of #307  so this needs to be merged back first!**

This change will effectively make the the prove possession step optional. It's possible to configure the second factors which do not require that step.

- [x] Changelog documentation #310 

https://www.pivotaltracker.com/story/show/172911922