### PR TITLE
Remove migration logic from Version20160719090052

### DIFF
--- a/src/Surfnet/Migrations/Version20160719090052.php
+++ b/src/Surfnet/Migrations/Version20160719090052.php
@@ -4,76 +4,20 @@ namespace Surfnet\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use Rhumsaa\Uuid\Uuid;
-use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\InstitutionListing;
-use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\WhitelistEntry;
-use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\InstitutionListingRepository;
-use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\WhitelistEntryRepository;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Command\CreateInstitutionConfigurationCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Pipeline\TransactionAwarePipeline;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
-class Version20160719090052 extends AbstractMigration implements ContainerAwareInterface
+class Version20160719090052 extends AbstractMigration
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
-
     /**
      * @param Schema $schema
      */
     public function up(Schema $schema): void
     {
-        $tokenStorage = $this->getTokenStorage();
-
-        // Authenticate as management user, so commands requiring the management role can be sent
-        $tokenStorage->setToken(
-            new UsernamePasswordToken(
-                'management',
-                $this->container->getParameter('management_password'),
-                'in_memory',
-                ['ROLE_MANAGEMENT']
-            )
-        );
-
-        $whitelistEntryInstitutions = array_map(
-            function (WhitelistEntry $whitelistEntry) {
-                return $whitelistEntry->institution;
-            },
-            $this->getWhitelistEntryRepository()->findAll()
-        );
-        $institutionListingInstitutions = array_map(
-            function (InstitutionListing $institutionListing) {
-                return $institutionListing->institution;
-            },
-            $this->getInstitutionListingRepository()->findAll()
-        );
-
-        $allInstitutions = array_unique(array_merge($whitelistEntryInstitutions, $institutionListingInstitutions));
-
-        $pipeline = $this->getPipeline();
-
-        foreach ($allInstitutions as $institution) {
-            $createInstitutionConfigurationCommand = new CreateInstitutionConfigurationCommand();
-            $createInstitutionConfigurationCommand->UUID = (string) Uuid::uuid4();
-            $createInstitutionConfigurationCommand->institution = $institution->getInstitution();
-
-            $pipeline->process($createInstitutionConfigurationCommand);
-        }
-
-        $tokenStorage->setToken(null);
+        // This migration used to create InstitutionConfiguration for institutions. We no longer support this construction
+        // as the code required to achieve this is no longer supported in our current Symfony version.
+        //
+        // Users migrating from a pre InstitutionConfiguration era might run into problems here. I suggest they watch
+        // git history of this file and work from there to create a custom migration.
+        $this->write('No up migration executed: this was a data migration that we no longer support.');
     }
 
     /**
@@ -83,37 +27,5 @@ class Version20160719090052 extends AbstractMigration implements ContainerAwareI
     {
         // No down-migration needed as the structure has not changed.
         $this->write('No down migration executed: this was a data only migration.');
-    }
-
-    /**
-     * @return WhitelistEntryRepository
-     */
-    private function getWhitelistEntryRepository()
-    {
-        return $this->container->get('surfnet_stepup_middleware_api.repository.whitelist_entry');
-    }
-
-    /**
-     * @return InstitutionListingRepository
-     */
-    private function getInstitutionListingRepository()
-    {
-        return $this->container->get('surfnet_stepup_middleware_api.repository.institution_listing');
-    }
-
-    /**
-     * @return TransactionAwarePipeline
-     */
-    private function getPipeline()
-    {
-        return $this->container->get('pipeline');
-    }
-
-    /**
-     * @return TokenStorage
-     */
-    private function getTokenStorage()
-    {
-        return $this->container->get('security.token_storage');
     }
 }


### PR DESCRIPTION
The migration is not removed from the project as the 'migration play head' would be corrupted. Instead a message is printed and a comment is added instructing users struck by the loss of this migration on how to deal with this problem.

See https://www.pivotaltracker.com/story/show/174702937