### PR TITLE
Fix files not added to root of archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,6 @@
     },
     "archive": {
         "exclude": [
-            "*",
             ".*",
             "*/Tests/*",
             "!/bin",

--- a/composer.json
+++ b/composer.json
@@ -87,8 +87,10 @@
     },
     "archive": {
         "exclude": [
+            "*",
             ".*",
             "*/Tests/*",
+            "!/component_info",
             "!/bin",
             "!/config",
             "!/public",


### PR DESCRIPTION
I'm not shure why '*' was excluded, but it caused the new component_info was missing in the archive, and deploy failing. 