### PR TITLE
Add a human readable display name for tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /web/bundles/
 /web/app_dev.php
 /web/app_test.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 before_script:
   - phpenv config-add travis.php.ini
-  - composer self-update
+  - composer self-update 1.10.16
   - composer install --prefer-dist
 
 script:

--- a/config/legacy/bundles.yaml
+++ b/config/legacy/bundles.yaml
@@ -19,6 +19,7 @@ surfnet_stepup_middleware_command_handling:
 surfnet_stepup_middleware_middleware:
   email_verification_window: "%email_verification_window%"
   enabled_generic_second_factors: "%enabled_generic_second_factors%"
+  second_factors_display_name: "%second_factors_display_name%"
 
 surfnet_stepup_middleware_management:
   email_required_locale: "%default_locale%"

--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -59,6 +59,14 @@ parameters:
         tiqr:
             loa: 3
 
+    second_factors_display_name:
+      yubikey: Yubikey
+      azuremfa: AzureMFA
+      webauthn: WebAuthn
+      tiqr: Tiqr
+      demo_gssp: GSSP Demo
+      demo_gssp_2: GSSP Demo 2
+
     # Sets the number of tokens allowed for each identity.
     #
     # This is the global, application wide default. This configuration should be specified for each institution in the

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
@@ -63,6 +63,7 @@ services:
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
             - "" # Self service url is set in bundle extension
+            - "@surfnet_stepup_middleware_middleware.second_factor_display_name_resolver"
 
     surfnet_stepup_middleware_command_handling.service.second_factor_vetted_mail:
         public: false

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/DependencyInjection/Configuration.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder
             ->root('surfnet_stepup_middleware_middleware')
                 ->children()
+                    ->arrayNode('second_factors_display_name')->isRequired()->scalarPrototype()->end()->end()
                     ->scalarNode('email_verification_window')
                         ->info('The amount of seconds after which the email verification url/code expires')
                         ->defaultValue(3600)
@@ -47,8 +48,9 @@ class Configuration implements ConfigurationInterface
                         ->prototype('array')
                         ->children()
                             ->scalarNode('loa')
-                            ->isRequired()
-                            ->info('The lao level of the Gssf')
+                                ->isRequired()
+                                ->info('The lao level of the Gssf')
+                            ->end()
                         ->end()
                     ->end()
                 ->end();

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
@@ -41,3 +41,8 @@ services:
             - "@surfnet_stepup_middleware_api.service.ra_listing"
             - "@surfnet_stepup_middleware_api.service.ra_location"
             - "" # Fallback locale
+
+    surfnet_stepup_middleware_middleware.second_factor_display_name_resolver:
+        public: false
+        class: Surfnet\StepupMiddleware\MiddlewareBundle\Service\SecondFactorDisplayNameResolverService
+        arguments: ['%second_factors_display_name%']

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/SecondFactorDisplayNameResolverService.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/SecondFactorDisplayNameResolverService.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2020 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\MiddlewareBundle\Service;
+
+use Surfnet\StepupBundle\Value\SecondFactorType;
+
+final class SecondFactorDisplayNameResolverService
+{
+    /**
+     * @var array
+     */
+    private $secondFactors;
+
+    /**
+     * @param array $secondFactors
+     */
+    public function __construct(array $secondFactors)
+    {
+        $this->secondFactors = $secondFactors;
+    }
+
+    /**
+     * @param SecondFactorType $secondFactorType
+     *
+     * @return string
+     */
+    public function resolveByType(SecondFactorType $secondFactorType): string
+    {
+        return $this->secondFactors[(string) $secondFactorType] ?? ucfirst((string) $secondFactorType);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Tests/Service/SecondFactorDisplayNameResolverServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Tests/Service/SecondFactorDisplayNameResolverServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2020 SURF bv.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\MiddlewareBundle\Tests\Service;
+
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupBundle\Value\SecondFactorType;
+use Surfnet\StepupMiddleware\MiddlewareBundle\Service\SecondFactorDisplayNameResolverService;
+
+class SecondFactorDisplayNameResolverServiceTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function verify_resolve_displayname(): void
+    {
+        $factors = ['azuremfa' => 'Azure MFA'];
+        $resolver = new SecondFactorDisplayNameResolverService($factors);
+        $type = new SecondFactorType('azuremfa');
+
+        self::assertEquals('Azure MFA', $resolver->resolveByType($type));
+    }
+
+    /**
+     * @test
+     */
+    public function verify_resolve_displayname_fallback(): void
+    {
+        $factors = ['azuremfa' => 'Azure MFA'];
+        $resolver = new SecondFactorDisplayNameResolverService($factors);
+        $type = new SecondFactorType('unknowntoken');
+
+        self::assertEquals('Unknowntoken', $resolver->resolveByType($type));
+    }
+}


### PR DESCRIPTION
In some templates/emails the internal/technical name of the second
factor is used. This adds a human readable displayname for the second
factor. If the name does not exists it will fallback to the internal
name.

See also: https://github.com/OpenConext/Stepup-Deploy/pull/124

https://www.pivotaltracker.com/story/show/174985988