### PR TITLE
Allow vetting_type sensitive data deserialization

### DIFF
--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedEvent.php
@@ -20,17 +20,14 @@ namespace Surfnet\Stepup\Identity\Event;
 
 use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\CommonName;
-use Surfnet\Stepup\Identity\Value\DocumentNumber;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\NameId;
-use Surfnet\Stepup\Identity\Value\OnPremiseVettingType;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
-use Surfnet\Stepup\Identity\Value\SelfVetVettingType;
 use Surfnet\Stepup\Identity\Value\UnknownVettingType;
 use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupBundle\Value\SecondFactorType;
@@ -123,25 +120,6 @@ class SecondFactorVettedEvent extends IdentityEvent implements Forgettable
     public static function deserialize(array $data)
     {
         $secondFactorType = new SecondFactorType($data['second_factor_type']);
-        $vettingType = new UnknownVettingType();
-        if (isset($data['vetting_type'])) {
-            switch ($data['vetting_type']['type']) {
-                case VettingType::TYPE_SELF_VET:
-                    $vettingType = SelfVetVettingType::deserialize($data['vetting_type']);
-                    break;
-                case VettingType::TYPE_ON_PREMISE:
-                    $vettingType = OnPremiseVettingType::deserialize($data['vetting_type']);
-                    break;
-            }
-        }
-        // BC fix for older events without a vetting type, they default back to ON_PREMISE.
-        if ($vettingType instanceof UnknownVettingType &&
-            isset($data['document_number']) &&
-            $data['document_number'] !== null
-        ) {
-            $vettingType = new OnPremiseVettingType(new DocumentNumber($data['document_number']));
-        }
-
         return new self(
             new IdentityId($data['identity_id']),
             new NameId($data['name_id']),
@@ -152,7 +130,7 @@ class SecondFactorVettedEvent extends IdentityEvent implements Forgettable
             CommonName::unknown(),
             Email::unknown(),
             new Locale($data['preferred_locale']),
-            $vettingType
+            new UnknownVettingType()
         );
     }
 

--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedWithoutTokenProofOfPossession.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedWithoutTokenProofOfPossession.php
@@ -20,17 +20,14 @@ namespace Surfnet\Stepup\Identity\Event;
 
 use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\CommonName;
-use Surfnet\Stepup\Identity\Value\DocumentNumber;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\NameId;
-use Surfnet\Stepup\Identity\Value\OnPremiseVettingType;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
-use Surfnet\Stepup\Identity\Value\SelfVetVettingType;
 use Surfnet\Stepup\Identity\Value\UnknownVettingType;
 use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupBundle\Value\SecondFactorType;
@@ -128,22 +125,6 @@ class SecondFactorVettedWithoutTokenProofOfPossession extends IdentityEvent impl
     public static function deserialize(array $data)
     {
         $secondFactorType = new SecondFactorType($data['second_factor_type']);
-
-        // BC fix for older events without a vetting type, they default back to ON_PREMISE.
-        $vettingType = new UnknownVettingType();
-        if (isset($data['vetting_type']['type'])) {
-            switch ($data['vetting_type']['type']) {
-                case VettingType::TYPE_SELF_VET:
-                    $vettingType = SelfVetVettingType::deserialize($data['vetting_type']);
-                    break;
-                case VettingType::TYPE_ON_PREMISE:
-                    $vettingType = OnPremiseVettingType::deserialize($data['vetting_type']);
-                    break;
-            }
-        } elseif (isset($data['document_number'])) {
-            $vettingType = new OnPremiseVettingType(new DocumentNumber($data['vetting_type']));
-        }
-
         return new self(
             new IdentityId($data['identity_id']),
             new NameId($data['name_id']),
@@ -154,7 +135,7 @@ class SecondFactorVettedWithoutTokenProofOfPossession extends IdentityEvent impl
             CommonName::unknown(),
             Email::unknown(),
             new Locale($data['preferred_locale']),
-            $vettingType
+            new UnknownVettingType()
         );
     }
 

--- a/src/Surfnet/Stepup/Identity/Value/VettingTypeFactory.php
+++ b/src/Surfnet/Stepup/Identity/Value/VettingTypeFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+final class VettingTypeFactory
+{
+    public static function fromData(array $data): VettingType
+    {
+        $vettingType = new UnknownVettingType();
+        if (isset($data['vetting_type'])) {
+            switch ($data['vetting_type']['type']) {
+                case VettingType::TYPE_SELF_VET:
+                    $vettingType = SelfVetVettingType::deserialize($data['vetting_type']);
+                    break;
+                case VettingType::TYPE_ON_PREMISE:
+                    $vettingType = OnPremiseVettingType::deserialize($data['vetting_type']);
+                    break;
+            }
+        }
+        // BC fix for older events without a vetting type, they default back to ON_PREMISE.
+        if ($vettingType instanceof UnknownVettingType &&
+            isset($data['document_number']) &&
+            $data['document_number'] !== null
+        ) {
+            $vettingType = new OnPremiseVettingType(new DocumentNumber($data['document_number']));
+        }
+
+        return $vettingType;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/SensitiveData.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/SensitiveData.php
@@ -20,12 +20,12 @@ namespace Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData;
 
 use Broadway\Serializer\Serializable as SerializableInterface;
 use Surfnet\Stepup\Identity\Value\CommonName;
-use Surfnet\Stepup\Identity\Value\DocumentNumber;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
 use Surfnet\Stepup\Identity\Value\UnknownVettingType;
 use Surfnet\Stepup\Identity\Value\VettingType;
+use Surfnet\Stepup\Identity\Value\VettingTypeFactory;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 class SensitiveData implements SerializableInterface
@@ -169,9 +169,10 @@ class SensitiveData implements SerializableInterface
                 SecondFactorIdentifierFactory::forType($self->secondFactorType, $data['second_factor_identifier']);
         }
 
-        if (isset($data['document_number'])) {
-            $self->documentNumber = new DocumentNumber($data['document_number']);
+        if (isset($data['document_number']) || isset($data['vetting_type'])) {
+            $self->vettingType = VettingTypeFactory::fromData($data);
         }
+
 
         return $self;
     }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/SensitiveData/SensitiveDataTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/SensitiveData/SensitiveDataTest.php
@@ -23,6 +23,8 @@ use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\DocumentNumber;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\GssfId;
+use Surfnet\Stepup\Identity\Value\OnPremiseVettingType;
+use Surfnet\Stepup\Identity\Value\UnknownVettingType;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
@@ -82,6 +84,17 @@ class SensitiveDataTest extends TestCase
                     ->withSecondFactorIdentifier(new YubikeyPublicId('00177273'), new SecondFactorType('yubikey'))
                     ->forget(),
                 ['SecondFactorIdentifier' => YubikeyPublicId::unknown()],
+            ],
+            'VettingType' => [
+                (new SensitiveData())
+                    ->withVettingType(new OnPremiseVettingType(new DocumentNumber("012345678"))),
+                ['VettingType' => new OnPremiseVettingType(new DocumentNumber("012345678"))],
+            ],
+            'VettingType, forgotten' => [
+                (new SensitiveData())
+                    ->withSecondFactorIdentifier(new YubikeyPublicId('00177273'), new SecondFactorType('yubikey'))
+                    ->forget(),
+                ['VettingType' => new UnknownVettingType()],
             ],
         ];
     }


### PR DESCRIPTION
There was a fix to prevent the vetting_type from going into the normal
event stream. However the vetting_type sensitive data was now being
deserialized back into the event because this logic wasn't yet moved
to the SensitiveData implementation in that fix.