### PR TITLE
 Improve type safety by setting sql_mode to be strict part 2

### DIFF
--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -6,6 +6,11 @@ parameters:
     database_driver:   pdo_mysql
     database_host:     10.10.0.100
     database_port:     ~
+    # Enabling the STRICT_ALL_TABLES SQL mode. To prevent 'magic' truncation problems where string
+    # values like the identity name id would be truncated after 255 characters without notice. Enabling
+    # STRICT_ALL_TABLES changes this behaviour, and raises SQLSTATE[22001] 'Bad response' when this
+    # occurs.
+    database_driver_options_1002: 'SET @@SQL_MODE = CONCAT(@@SQL_MODE, ",STRICT_ALL_TABLES")'
     # The database server version is used in the dbal configuration and is required to prevent issues when the database
     # connection is booted. See https://github.com/doctrine/DoctrineBundle/issues/351 for more details on this.
     # Also see: https://symfony.com/doc/current/reference/configuration/doctrine.html#doctrine-dbal-configuration

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -14,11 +14,8 @@ doctrine:
                 server_version: "%database_server_version%"
                 charset: utf8
                 options:
-                    # Enabling the STRICT_ALL_TABLES SQL mode. To prevent 'magic' truncation problems where string
-                    # values like the identity name id would be truncated after 255 characters without notice. Enabling
-                    # STRICT_ALL_TABLES changes this behaviour, and raises SQLSTATE[22001] 'Bad response' when this
-                    # occurs.
-                    1002: 'SET sql_mode="STRICT_ALL_TABLES"'
+                    # The 1002 constant sets the PDO MYSQL_ATTR_INIT_COMMAND for when the connection is (re)connected.
+                    1002: "%database_driver_options_1002%"
             gateway:
                 driver:   "%database_driver%"
                 host:     "%database_host%"
@@ -29,7 +26,7 @@ doctrine:
                 server_version: "%database_server_version%"
                 charset: utf8
                 options:
-                    1002: 'SET sql_mode="STRICT_ALL_TABLES"'
+                    1002: "%database_driver_options_1002%"
             deploy:
                 driver:   "%database_driver%"
                 host:     "%database_host%"
@@ -40,7 +37,7 @@ doctrine:
                 server_version: "%database_server_version%"
                 charset: utf8
                 options:
-                    1002: 'SET sql_mode="STRICT_ALL_TABLES"'
+                    1002: "%database_driver_options_1002%"
         types:
             authority_role:
                 class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\AuthorityRoleType


### PR DESCRIPTION
Merged a bit to quickly, I addressed two review points from @pmeulen 

Part one can be found here, including the feedback mentioned above here #335 