### PR TITLE
Prevent composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,9 @@
         ]
     },
     "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        },
         "optimize-autoloader": true,
         "platform": {
             "php": "7.2"


### PR DESCRIPTION
symfony/flex contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/flex" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]

Newer versions of composer will throw the warning above.