### PR TITLE
Reproduce buggy behavior in useRaa configuration

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
@@ -169,6 +169,10 @@ class CommandAuthorizationService
             // Both are only sent by the RA where the minimal role requirement is RA
             // all the other actions require RAA rights
             if ($command instanceof VetSecondFactorCommand || $command instanceof RevokeRegistrantsSecondFactorCommand) {
+                // The role should be context aware, in other words: when the user only has the RAA role, this should
+                // also resolve. It currently does not. The buildInstitutionAuthorizationContext will search for the
+                // institutions that have the role defined here. When the institution only has useRaa, it will not find
+                // the institution because we 'downgraded' it to useRa (which is not configured)
                 $this->logger->notice('VetSecondFactorCommand and RevokeRegistrantsSecondFactorCommand require a RA role');
                 $role = InstitutionRole::useRa();
                 // Use the institution of the identity (the user vetting or having his token revoked).


### PR DESCRIPTION
When an institution is configured to use RAA's from another institution,
but the useRa is not set for that same institution. And a RAA user is
made RAA for that institution. He/She is not allowed to perform RA
actions (vet second factor and revocation of a token).

This is because in the authorisation service we 'downgrade' the Vet and
Revoke actions to require the use ra role.

The succesive buildInstitutionsAuthorizationContext then searches for
the institutions that have that useRa role applied. None are found, an
authorization exception is raised.

To fix this. Either add both the useRa and useRaa actions to the authz
context. Or make the parent method more user context aware. Where we
would have to check that if the useRaa role is applied for either one of
the Vet or Revoke events, we should set the useRaa role instead of the
hard coded useRa.

See: https://www.pivotaltracker.com/story/show/180081100