### PR TITLE
Implement deprovision methods

### DIFF
--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -1,4 +1,5 @@
 parameters:
+    application_name: StepUp Middleware
     # IP addresses of any HTTP proxies that are sitting in from of the application
     # See: http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html
     trusted_proxies:   ~

--- a/src/Surfnet/Stepup/Identity/EventSourcing/IdentityRepository.php
+++ b/src/Surfnet/Stepup/Identity/EventSourcing/IdentityRepository.php
@@ -18,32 +18,76 @@
 
 namespace Surfnet\Stepup\Identity\EventSourcing;
 
+use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventBus as EventBusInterface;
 use Broadway\EventSourcing\AggregateFactory\AggregateFactory;
 use Broadway\EventSourcing\EventSourcingRepository;
 use Broadway\EventSourcing\EventStreamDecorator;
 use Broadway\EventStore\EventStore as EventStoreInterface;
+use Broadway\EventStore\EventStreamNotFoundException;
+use Broadway\Repository\AggregateNotFoundException;
+use Broadway\Serializer\Serializable;
+use Psr\Log\LoggerInterface;
+use Surfnet\Stepup\Identity\Identity;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
 
 class IdentityRepository extends EventSourcingRepository
 {
+    protected $events;
+
+    protected $logger;
+
     /**
-     * @param EventStoreInterface             $eventStore
-     * @param EventBusInterface               $eventBus
-     * @param AggregateFactory       $aggregateFactory
      * @param EventStreamDecorator[] $eventStreamDecorators
      */
     public function __construct(
         EventStoreInterface $eventStore,
         EventBusInterface $eventBus,
         AggregateFactory $aggregateFactory,
+        LoggerInterface $logger,
         array $eventStreamDecorators = []
     ) {
+        $this->events = $eventStore;
+        $this->logger = $logger;
         parent::__construct(
             $eventStore,
             $eventBus,
-            \Surfnet\Stepup\Identity\Identity::class,
+            Identity::class,
             $aggregateFactory,
             $eventStreamDecorators
         );
+    }
+
+    public function obtainInformation(IdentityId $id): array
+    {
+        try {
+            $domainEventStream = $this->events->load($id);
+            $data = [];
+            /** @var DomainMessage $domainMessage */
+            foreach ($domainEventStream as $domainMessage) {
+                $event = $domainMessage->getPayload();
+                if (!$event instanceof Serializable) {
+                    $this->logger->warning(
+                        sprintf(
+                            'Unable to serialize event type %s, unable to return user information for that event',
+                            $domainMessage->getType()
+                        )
+                    );
+                }
+                // A combination of the playhead and event name are used to index the data array
+                $index = $domainMessage->getPlayhead() . '-' . $domainMessage->getType();
+                // The data is retrieved from the payload (the event object), sensitive data is merged into it
+                $eventData = $event->serialize();
+                if ($event instanceof Forgettable) {
+                    $eventData += $event->getSensitiveData()->serialize();
+                }
+
+                $data[$index] = $eventData;
+            }
+            return $data;
+        } catch (EventStreamNotFoundException $e) {
+            throw AggregateNotFoundException::create($id, $e);
+        }
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/DeprovisionController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/DeprovisionController.php
@@ -18,20 +18,46 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
+use Surfnet\StepupMiddleware\ApiBundle\Service\DeprovisionServiceInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class DeprovisionController extends AbstractController
 {
-    public function deprovisionAction()
+    private $deprovisionService;
+
+    private $applicationName;
+
+    public function __construct(DeprovisionServiceInterface $deprovisionService, string $applicationName)
     {
-        $this->denyAccessUnlessGranted(['ROLE_DEPROVISION']);
-        return new JsonResponse();
+        $this->deprovisionService = $deprovisionService;
+        $this->applicationName = $applicationName;
     }
 
-    public function dryRunAction()
+    public function deprovisionAction(string $collabPersonId): JsonResponse
     {
         $this->denyAccessUnlessGranted(['ROLE_DEPROVISION']);
-        return new JsonResponse();
+
+        $userData = $this->deprovisionService->readUserData($collabPersonId);
+        if (!empty($userData)) {
+            $this->deprovisionService->deprovision($collabPersonId);
+        }
+        return new JsonResponse($this->formatResponse('OK', $userData));
+    }
+
+    public function dryRunAction(string $collabPersonId): JsonResponse
+    {
+        $this->denyAccessUnlessGranted(['ROLE_DEPROVISION']);
+        $userData = $this->deprovisionService->readUserData($collabPersonId);
+        return new JsonResponse($this->formatResponse('OK', $userData));
+    }
+
+    private function formatResponse(string $status, array $userData): array
+    {
+        return [
+            'status'  => $status,
+            'name'    => $this->applicationName,
+            'data'    => $userData,
+        ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Exception/UserNotFoundException.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Exception/UserNotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Exception;
+
+class UserNotFoundException extends RuntimeException
+{
+
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaListingProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaListingProjector.php
@@ -151,7 +151,7 @@ class RaListingProjector extends Projector
 
     protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)
     {
-        $this->raListingRepository->removeByIdentityId($event->identityId);
+        $this->raListingRepository->removeByIdentityId($event->identityId, $event->identityInstitution);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaListingRepository.php
@@ -237,13 +237,14 @@ class RaListingRepository extends ServiceEntityRepository
      * @param IdentityId $identityId
      * @return void
      */
-    public function removeByIdentityId(IdentityId $identityId)
+    public function removeByIdentityId(IdentityId $identityId, Institution $institution)
     {
         $this->getEntityManager()->createQueryBuilder()
             ->delete($this->_entityName, 'ral')
             ->where('ral.identityId = :identityId')
             ->andWhere('ral.raInstitution = :institution')
             ->setParameter('identityId', $identityId->getIdentityId())
+            ->setParameter('institution', $institution->getInstitution())
             ->getQuery()
             ->execute();
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -14,6 +14,12 @@ services:
         autowire: true
         tags: ['controller.service_arguments']
 
+    Surfnet\StepupMiddleware\ApiBundle\Controller\DeprovisionController:
+        arguments:
+            $deprovisionService: '@Surfnet\StepupMiddleware\ApiBundle\Service\DeprovisionService'
+            $applicationName: '%application_name%'
+        tags: [ 'controller.service_arguments' ]
+
     # Repositories
     surfnet_stepup_middleware_api.repository.configured_institution: '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\ConfiguredInstitutionRepository'
     surfnet_stepup_middleware_api.repository.institution_configuration_options: '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionConfigurationOptionsRepository'
@@ -157,3 +163,10 @@ services:
             - '@surfnet_stepup_middleware_api.service.identity'
             - '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\ConfiguredInstitutionRepository'
             - '@surfnet_stepup_middleware_api.repository.authorization'
+
+    Surfnet\StepupMiddleware\ApiBundle\Service\DeprovisionService:
+        arguments:
+            $pipeline: '@surfnet_stepup_middleware_command_handling.pipeline.transaction_aware_pipeline'
+            $eventSourcingRepository: '@surfnet_stepup.repository.identity'
+            $apiRepository: '@surfnet_stepup_middleware_api.repository.identity'
+            $logger: '@logger'

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionService.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Service;
+
+
+use Psr\Log\LoggerInterface;
+use Surfnet\Stepup\Identity\EventSourcing\IdentityRepository;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\StepupMiddleware\ApiBundle\Exception\UserNotFoundException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as ApiIdentityRepository;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Pipeline\Pipeline;
+
+class DeprovisionService implements DeprovisionServiceInterface
+{
+    /**
+     * @var Pipeline
+     */
+    private $pipeline;
+
+    /**
+     * @var IdentityRepository
+     */
+    private $eventSourcingRepository;
+
+    /**
+     * @var ApiIdentityRepository
+     */
+    private $apiRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param Pipeline $pipeline
+     * @param IdentityRepository $repository
+     */
+    public function __construct(
+        Pipeline $pipeline,
+        IdentityRepository $eventSourcingRepository,
+        ApiIdentityRepository $apiRepository,
+        LoggerInterface $logger
+    ) {
+        $this->pipeline = $pipeline;
+        $this->eventSourcingRepository = $eventSourcingRepository;
+        $this->apiRepository = $apiRepository;
+        $this->logger = $logger;
+    }
+
+    public function readUserData(string $collabPersonId): array
+    {
+        try {
+            $identityId = $this->getIdentityIdByNameId($collabPersonId);
+            return $this->eventSourcingRepository->obtainInformation($identityId);
+        } catch (UserNotFoundException $e) {
+            $this->logger->notice(
+                sprintf(
+                    'User identified by: %s was not found. Unable to provide deprovision data.',
+                    $collabPersonId
+                )
+            );
+            return [];
+        }
+    }
+
+    public function deprovision(string $collabPersonId)
+    {
+    }
+
+    private function getIdentityIdByNameId(string $collabPersonId): IdentityId
+    {
+        $user = $this->apiRepository->findOneByNameId($collabPersonId);
+        if (!$user) {
+            throw new UserNotFoundException();
+        }
+        return new IdentityId($user->id);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionServiceInterface.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Service;
+
+interface DeprovisionServiceInterface
+{
+    public function readUserData(string $collabPersonId): array;
+
+    public function deprovision(string $collabPersonId);
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionServiceInterface.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionServiceInterface.php
@@ -20,7 +20,18 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Service;
 
 interface DeprovisionServiceInterface
 {
+    /**
+     * Returns all data we know for the specified user. The
+     * Identity events for the user are loaded and returned in
+     * a portable format (JSON encodable arrays)
+     */
     public function readUserData(string $collabPersonId): array;
 
-    public function deprovision(string $collabPersonId);
+    /**
+     * The deprovision method applies the right to be forgotten
+     * command on the pipeline. As this is a command, it does not
+     * return any data. And as such, this method does not return
+     * any user data either.
+     */
+    public function deprovision(string $collabPersonId): void;
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/DeprovisionServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/DeprovisionServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Service;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Surfnet\Stepup\Identity\EventSourcing\IdentityRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as ApiIdentityRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Service\DeprovisionService;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Pipeline\Pipeline;
+
+class DeprovisionServiceTest extends TestCase
+{
+    /**
+     * @var DeprovisionService
+     */
+    private $deprovisionService;
+
+    /**
+     * @var m\LegacyMockInterface|m\MockInterface|Pipeline
+     */
+    private $pipeline;
+
+    /**
+     * @var m\LegacyMockInterface|m\MockInterface|ApiIdentityRepository
+     */
+    private $apiRepo;
+
+    /**
+     * @var m\LegacyMockInterface|m\MockInterface|IdentityRepository
+     */
+    private $eventRepo;
+
+    protected function setUp(): void
+    {
+        $this->pipeline = m::mock(Pipeline::class);
+        $this->apiRepo = m::mock(ApiIdentityRepository::class);
+        $this->eventRepo = m::mock(IdentityRepository::class);
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing(); // Not going to verify every log message at this point
+        $this->deprovisionService = new DeprovisionService($this->pipeline, $this->eventRepo, $this->apiRepo, $logger);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    public function test_it_can_be_created()
+    {
+        $this->assertInstanceOf(DeprovisionService::class, $this->deprovisionService);
+    }
+
+    /**
+     * @group api-bundle
+     */
+    public function test_it_deals_with_non_exisiting_collab_user_id()
+    {
+        $this->apiRepo
+            ->shouldReceive('findOneByNameId')
+            ->with('urn:collab:person:example.com:maynard_keenan')
+            ->once()
+            ->andReturnNull();
+        $data = $this->deprovisionService->readUserData('urn:collab:person:example.com:maynard_keenan');
+
+        $this->assertTrue(is_array($data));
+        $this->assertEmpty($data);
+    }
+
+    /**
+     * @group api-bundle
+     */
+    public function test_it_can_return_data()
+    {
+        $identity = m::mock(Identity::class);
+        $identity->id = '0bf0b464-a5de-11ec-b909-0242ac120002';
+        $this->apiRepo
+            ->shouldReceive('findOneByNameId')
+            ->with('urn:collab:person:example.com:maynard_keenan')
+            ->once()
+            ->andReturn($identity);
+
+        $this->eventRepo->shouldReceive('obtainInformation')->andReturn(['status' => 'OK', 'data' => []]);
+
+        $data = $this->deprovisionService->readUserData('urn:collab:person:example.com:maynard_keenan');
+
+        $this->assertTrue(is_array($data));
+        $this->assertEquals($data['status'], 'OK');
+    }
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Command/DeprovisionExecutable.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Command/DeprovisionExecutable.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Command;
+
+/**
+ * Marker interface used to indicate that the command may only be invoked through
+ * the deprovision/lifecycle API.
+ */
+interface DeprovisionExecutable
+{
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/ForgetIdentityCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/ForgetIdentityCommand.php
@@ -19,10 +19,11 @@
 namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command;
 
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\AbstractCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\DeprovisionExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\ManagementExecutable;
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class ForgetIdentityCommand extends AbstractCommand implements ManagementExecutable
+final class ForgetIdentityCommand extends AbstractCommand implements ManagementExecutable, DeprovisionExecutable
 {
     /**
      * @Assert\NotBlank

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Pipeline/AuthorizingStage.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Pipeline/AuthorizingStage.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Pipeline;
 
 use Psr\Log\LoggerInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\Command;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\DeprovisionExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\ManagementExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\RaExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
@@ -63,6 +64,10 @@ class AuthorizingStage implements Stage
 
         if ($command instanceof ManagementExecutable) {
             $allowedRoles[] = 'ROLE_MANAGEMENT';
+        }
+
+        if ($command instanceof DeprovisionExecutable) {
+            $allowedRoles[] = 'ROLE_DEPROVISION';
         }
 
         if (empty($allowedRoles)) {

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/event_sourcing.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/event_sourcing.yml
@@ -9,6 +9,7 @@ services:
             - "@surfnet_stepup_middleware_command_handling.event_store.sensitive_data"
             - "@surfnet_stepup_middleware_command_handling.event_bus.buffered"
             - "@surfnet_stepup.aggregate_factory.public_constructor"
+            - "@logger"
             - ["@surfnet_stepup_middleware_command_handling.metadata_enricher.actor"]
 
     surfnet_stepup_middleware_command_handling.metadata_enricher.actor:

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
@@ -23,6 +23,7 @@ use Broadway\EventHandling\EventBus as EventBusInterface;
 use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
 use Broadway\EventStore\EventStore as EventStoreInterface;
 use Mockery as m;
+use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
 use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Exception\DomainException;
@@ -98,12 +99,15 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
         $secondFactorTypeService->shouldReceive('hasEqualOrHigherLoaComparedTo')->andReturn(true);
         $secondFactorProvePossessionHelper = m::mock(SecondFactorProvePossessionHelper::class);
         $this->configService = m::mock(InstitutionConfigurationOptionsService::class);
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing();
 
         return new IdentityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
                 $eventBus,
-                $aggregateFactory
+                $aggregateFactory,
+                $logger
             ),
             $this->identityProjectionRepository,
             ConfigurableSettings::create(self::$window, ['nl_NL', 'en_GB']),

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -25,6 +25,7 @@ use Broadway\EventStore\EventStore as EventStoreInterface;
 use DateTime as CoreDateTime;
 use Hamcrest\Matchers;
 use Mockery as m;
+use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
 use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
@@ -141,12 +142,14 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $this->secondFactorProvePossessionHelper = m::mock(SecondFactorProvePossessionHelper::class);
         $this->configService = m::mock(InstitutionConfigurationOptionsService::class);
         $this->configService->shouldIgnoreMissing();
-
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing();
         return new IdentityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
                 $eventBus,
-                $aggregateFactory
+                $aggregateFactory,
+                $logger
             ),
             $this->identityProjectionRepository,
             ConfigurableSettings::create(self::$window, ['nl_NL', 'en_GB']),

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RegistrationAuthorityCommandHandlerTest.php
@@ -24,6 +24,7 @@ use Broadway\EventHandling\EventBus as EventBusInterface;
 use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
 use Broadway\EventStore\EventStore as EventStoreInterface;
 use Mockery as m;
+use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\EventSourcing\InstitutionConfigurationRepository;
 use Surfnet\Stepup\Configuration\InstitutionConfiguration;
 use Surfnet\Stepup\Identity\Event\AppointedAsRaaForInstitutionEvent;
@@ -86,11 +87,15 @@ class RegistrationAuthorityCommandHandlerTest extends CommandHandlerTest
             ->shouldReceive('load')
             ->andReturn($this->institutionConfiguration);
 
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing();
+
         return new RegistrationAuthorityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
                 $eventBus,
-                $aggregateFactory
+                $aggregateFactory,
+                $logger
             ),
             $this->institutionConfigurationRepositoryMock
         );

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RightToBeForgottenCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/RightToBeForgottenCommandHandlerTest.php
@@ -25,6 +25,7 @@ use Broadway\EventStore\EventStore as EventStoreInterface;
 use Hamcrest\Matchers;
 use Mockery as m;
 use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaEvent;
 use Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
@@ -67,11 +68,15 @@ class RightToBeForgottenCommandHandlerTest extends CommandHandlerTest
         $this->sensitiveDataService = m::mock('Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Service\SensitiveDataService');
         $this->sraaRepository = m::mock('Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\SraaRepository');
 
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing();
+
         return new RightToBeForgottenCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
                 $eventBus,
-                $aggregateFactory
+                $aggregateFactory,
+                $logger
             ),
             $this->apiIdentityRepository,
             $this->sensitiveDataService,

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -23,6 +23,7 @@ use Broadway\EventHandling\EventBus as EventBusInterface;
 use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
 use Broadway\EventStore\EventStore as EventStoreInterface;
 use Mockery as m;
+use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\EventSourcing\InstitutionConfigurationRepository;
 use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
@@ -76,12 +77,15 @@ class SecondFactorRevocationTest extends CommandHandlerTest
     protected function createCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus): CommandHandler
     {
         $aggregateFactory = new PublicConstructorAggregateFactory();
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldIgnoreMissing();
 
         return new IdentityCommandHandler(
             new IdentityRepository(
                 new IdentityIdEnforcingEventStoreDecorator($eventStore),
                 $eventBus,
-                $aggregateFactory
+                $aggregateFactory,
+                $logger
             ),
             m::mock(IdentityProjectionRepository::class),
             ConfigurableSettings::create(self::$window, []),


### PR DESCRIPTION
## Why?
In order to further automate the GDPR rules, it's beneficial to connect StepUp to the OpenConext UserLifecycle application. This automates the removal of inactive users from the platform. And allows for a practical way to retrieve all user data from the StepUp platform. And also allows for exercising the right to be forgotten.

## How?
To achieve this goal, I added a deprovision/userlifecycle endpoint to the Middleware API.

This API exposes two endpoints. One to retrieve data, and one to remove user data.

### Retrieving data
Data retrieval is done in a very practical manner. The events that are stored for the identiy that needs/wants to remove its data is collected from the event store. This data contains all relevant data for the user. Including sensitive data. That data is then serialized to JSON data and returned to the lifecycle app.

Todo: the data is now aggregated in the IdentityRepository. This is no longer the case when @VadimSchmitz work is finished on task 3 of [#181430595](https://www.pivotaltracker.com/story/show/181430595).

### Removing data
Removing user data from StepUp was already implemented into the application. One hurdle remained, that was to expose this command to the LifeCycle API.

## More info
https://www.pivotaltracker.com/story/show/181430595