### PR TITLE
Implement RightToObtainData to all the Identity Events.

### DIFF
--- a/src/Surfnet/Stepup/Identity/Event/AppointedAsRaEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/AppointedAsRaEvent.php
@@ -22,12 +22,19 @@ use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
 /**
  * @deprecated This event is superseded by the AppointedAsRaForInstitutionEvent because an RA institution was needed
  */
-class AppointedAsRaEvent extends IdentityEvent
+class AppointedAsRaEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'institution',
+        'name_id',
+    ];
+
     /**
      * @var NameId
      */
@@ -74,5 +81,12 @@ class AppointedAsRaEvent extends IdentityEvent
             'institution'    => (string) $this->identityInstitution,
             'name_id'        => (string) $this->nameId
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/AppointedAsRaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/AppointedAsRaForInstitutionEvent.php
@@ -22,9 +22,17 @@ use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class AppointedAsRaForInstitutionEvent extends IdentityEvent
+class AppointedAsRaForInstitutionEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'institution',
+        'name_id',
+        'ra_institution'
+    ];
+
     /**
      * @var NameId
      */
@@ -81,5 +89,12 @@ class AppointedAsRaForInstitutionEvent extends IdentityEvent
             'name_id'        => (string) $this->nameId,
             'ra_institution' => (string) $this->raInstitution,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/AppointedAsRaaEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/AppointedAsRaaEvent.php
@@ -22,12 +22,19 @@ use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
 /**
  * @deprecated This event is superseded by the AppointedAsRaaForInstitutionEvent because an RA institution was needed
  */
-class AppointedAsRaaEvent extends IdentityEvent
+class AppointedAsRaaEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'institution',
+        'name_id',
+    ];
+
     /**
      * @var NameId
      */
@@ -74,5 +81,12 @@ class AppointedAsRaaEvent extends IdentityEvent
             'institution'    => (string) $this->identityInstitution,
             'name_id'        => (string) $this->nameId
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/AppointedAsRaaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/AppointedAsRaaForInstitutionEvent.php
@@ -22,9 +22,17 @@ use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class AppointedAsRaaForInstitutionEvent extends IdentityEvent
+class AppointedAsRaaForInstitutionEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'institution',
+        'name_id',
+        'ra_institution'
+    ];
+
     /**
      * @var NameId
      */
@@ -81,5 +89,12 @@ class AppointedAsRaaForInstitutionEvent extends IdentityEvent
             'name_id'        => (string) $this->nameId,
             'ra_institution' => (string) $this->raInstitution,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/CompliedWithRevocationEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/CompliedWithRevocationEvent.php
@@ -26,10 +26,19 @@ use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-abstract class CompliedWithRevocationEvent extends IdentityEvent implements Forgettable
+abstract class CompliedWithRevocationEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'second_factor_identifier',
+        'second_factor_type',
+        'authority_id',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\IdentityId
      */
@@ -115,5 +124,14 @@ abstract class CompliedWithRevocationEvent extends IdentityEvent implements Forg
     public function setSensitiveData(SensitiveData $sensitiveData)
     {
         $this->secondFactorIdentifier = $sensitiveData->getSecondFactorIdentifier();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/GssfPossessionProvenEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/GssfPossessionProvenEvent.php
@@ -30,10 +30,22 @@ use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\StepupProvider;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class GssfPossessionProvenEvent extends IdentityEvent implements Forgettable
+class GssfPossessionProvenEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'second_factor_id',
+        'stepup_provider',
+        'preferred_locale',
+        'second_factor_identifier',
+        'common_name',
+        'email',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
      */
@@ -183,5 +195,14 @@ class GssfPossessionProvenEvent extends IdentityEvent implements Forgettable
         $this->email      = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
         $this->gssfId     = $sensitiveData->getSecondFactorIdentifier();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaEvent.php
@@ -25,12 +25,22 @@ use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\RegistrationAuthorityRole;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
 /**
  * @deprecated This event is superseded by the IdentityAccreditedAsRaForInstitutionEvent because an RA institution was needed
  */
-class IdentityAccreditedAsRaEvent extends IdentityEvent
+class IdentityAccreditedAsRaEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'institution',
+        'registration_authority_role',
+        'location',
+        'contact_information',
+    ];
+
     /**
      * @var NameId
      */
@@ -106,5 +116,12 @@ class IdentityAccreditedAsRaEvent extends IdentityEvent
             'location'                    => (string) $this->location,
             'contact_information'         => (string) $this->contactInformation,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaForInstitutionEvent.php
@@ -25,9 +25,20 @@ use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\RegistrationAuthorityRole;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class IdentityAccreditedAsRaForInstitutionEvent extends IdentityEvent
+class IdentityAccreditedAsRaForInstitutionEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'institution',
+        'registration_authority_role',
+        'location',
+        'contact_information',
+        'ra_institution'
+    ];
+
     /**
      * @var NameId
      */
@@ -117,5 +128,12 @@ class IdentityAccreditedAsRaForInstitutionEvent extends IdentityEvent
             'contact_information'         => (string) $this->contactInformation,
             'ra_institution'              => (string) $this->raInstitution,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaEvent.php
@@ -25,12 +25,22 @@ use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\RegistrationAuthorityRole;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
 /**
  * @deprecated This event is superseded by the IdentityAccreditedAsRaaForInstitutionEvent because an RA institution was needed
  */
-class IdentityAccreditedAsRaaEvent extends IdentityEvent
+class IdentityAccreditedAsRaaEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'institution',
+        'registration_authority_role',
+        'location',
+        'contact_information',
+    ];
+
     /**
      * @var NameId
      */
@@ -106,5 +116,12 @@ class IdentityAccreditedAsRaaEvent extends IdentityEvent
             'location'                    => (string) $this->location,
             'contact_information'         => (string) $this->contactInformation,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityAccreditedAsRaaForInstitutionEvent.php
@@ -25,9 +25,20 @@ use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\RegistrationAuthorityRole;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class IdentityAccreditedAsRaaForInstitutionEvent extends IdentityEvent
+class IdentityAccreditedAsRaaForInstitutionEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'institution',
+        'registration_authority_role',
+        'location',
+        'contact_information',
+        'ra_institution'
+    ];
+
     /**
      * @var NameId
      */
@@ -116,5 +127,12 @@ class IdentityAccreditedAsRaaForInstitutionEvent extends IdentityEvent
             'contact_information'         => (string) $this->contactInformation,
             'ra_institution'              => (string) $this->raInstitution,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityCreatedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityCreatedEvent.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\Stepup\Identity\Event;
 
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\Email;
@@ -28,8 +29,17 @@ use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class IdentityCreatedEvent extends IdentityEvent implements Forgettable
+class IdentityCreatedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'id',
+        'institution',
+        'name_id',
+        'preferred_locale',
+        'common_name',
+        'email'
+    ];
+
     /**
      * @var NameId
      */
@@ -111,5 +121,14 @@ class IdentityCreatedEvent extends IdentityEvent implements Forgettable
     {
         $this->email      = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityEmailChangedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityEmailChangedEvent.php
@@ -23,10 +23,17 @@ use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class IdentityEmailChangedEvent extends IdentityEvent implements Forgettable
+class IdentityEmailChangedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'id',
+        'identity_institution',
+        'email'
+    ];
+
     /**
      * @var Email
      */
@@ -81,5 +88,14 @@ class IdentityEmailChangedEvent extends IdentityEvent implements Forgettable
     public function setSensitiveData(SensitiveData $sensitiveData)
     {
         $this->email = $sensitiveData->getEmail();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityForgottenEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityForgottenEvent.php
@@ -21,9 +21,15 @@ namespace Surfnet\Stepup\Identity\Event;
 use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class IdentityForgottenEvent extends IdentityEvent
+class IdentityForgottenEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'institution',
+    ];
+
     /**
      * @return Metadata
      */
@@ -46,6 +52,16 @@ class IdentityForgottenEvent extends IdentityEvent
      */
     public function serialize(): array
     {
-        return ['identity_id' => $this->identityId, 'institution' => $this->identityInstitution];
+        return [
+            'identity_id' => $this->identityId,
+            'institution' => $this->identityInstitution
+        ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/IdentityRenamedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityRenamedEvent.php
@@ -23,10 +23,17 @@ use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class IdentityRenamedEvent extends IdentityEvent implements Forgettable
+class IdentityRenamedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'id',
+        'institution',
+        'common_name',
+    ];
+
     /**
      * @var CommonName
      */
@@ -81,5 +88,14 @@ class IdentityRenamedEvent extends IdentityEvent implements Forgettable
     public function setSensitiveData(SensitiveData $sensitiveData)
     {
         $this->commonName = $sensitiveData->getCommonName();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/LocalePreferenceExpressedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/LocalePreferenceExpressedEvent.php
@@ -22,9 +22,16 @@ use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class LocalePreferenceExpressedEvent extends IdentityEvent
+class LocalePreferenceExpressedEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'id',
+        'institution',
+        'preferred_locale',
+    ];
+
     /**
      * @var Locale
      */
@@ -74,5 +81,12 @@ class LocalePreferenceExpressedEvent extends IdentityEvent
             'institution' => (string) $this->identityInstitution,
             'preferred_locale' => (string) $this->preferredLocale,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityInformationAmendedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityInformationAmendedEvent.php
@@ -24,12 +24,21 @@ use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
 /**
  * @deprecated This event is superseded by the RegistrationAuthorityInformationAmendedEvent because an RA institution was needed
  */
-class RegistrationAuthorityInformationAmendedEvent extends IdentityEvent
+class RegistrationAuthorityInformationAmendedEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'institution',
+        'location',
+        'contact_information',
+    ];
+
     /**
      * @var NameId
      */
@@ -95,5 +104,12 @@ class RegistrationAuthorityInformationAmendedEvent extends IdentityEvent
             'location'            => (string) $this->location,
             'contact_information' => (string) $this->contactInformation,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityInformationAmendedForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityInformationAmendedForInstitutionEvent.php
@@ -24,9 +24,19 @@ use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Location;
 use Surfnet\Stepup\Identity\Value\NameId;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class RegistrationAuthorityInformationAmendedForInstitutionEvent extends IdentityEvent
+class RegistrationAuthorityInformationAmendedForInstitutionEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'institution',
+        'name_id',
+        'location',
+        'contact_information',
+        'ra_institution'
+    ];
+
     /**
      * @var NameId
      */
@@ -102,5 +112,12 @@ class RegistrationAuthorityInformationAmendedForInstitutionEvent extends Identit
             'contact_information' => (string) $this->contactInformation,
             'ra_institution'      => (string) $this->raInstitution,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityRetractedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityRetractedEvent.php
@@ -25,13 +25,22 @@ use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
 /**
  * @deprecated This event is superseded by the RegistrationAuthorityRetractedForInstitutionEvent because an RA institution was needed
  */
-class RegistrationAuthorityRetractedEvent extends IdentityEvent implements Forgettable
+class RegistrationAuthorityRetractedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'name_id',
+        'common_name',
+        'email',
+    ];
+
     /**
      * @var NameId
      */
@@ -101,5 +110,14 @@ class RegistrationAuthorityRetractedEvent extends IdentityEvent implements Forge
     {
         $this->email      = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityRetractedForInstitutionEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/RegistrationAuthorityRetractedForInstitutionEvent.php
@@ -25,10 +25,20 @@ use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class RegistrationAuthorityRetractedForInstitutionEvent extends IdentityEvent implements Forgettable
+class RegistrationAuthorityRetractedForInstitutionEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'name_id',
+        'ra_institution',
+        'email',
+        'common_name',
+    ];
+
     /**
      * @var NameId
      */
@@ -110,5 +120,14 @@ class RegistrationAuthorityRetractedForInstitutionEvent extends IdentityEvent im
     {
         $this->email      = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorMigratedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorMigratedEvent.php
@@ -30,13 +30,28 @@ use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable
+class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'source_institution',
+        'target_name_id',
+        'identity_institution',
+        'second_factor_id',
+        'new_second_factor_id',
+        'second_factor_type',
+        'preferred_locale',
+        'second_factor_identifier',
+        'common_name',
+        'email',
+    ];
+
     /**
      * @var Institution
      */
@@ -170,5 +185,14 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable
         $this->secondFactorIdentifier = $sensitiveData->getSecondFactorIdentifier();
         $this->commonName = $sensitiveData->getCommonName();
         $this->email = $sensitiveData->getEmail();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorRevokedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorRevokedEvent.php
@@ -26,10 +26,19 @@ use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-abstract class SecondFactorRevokedEvent extends IdentityEvent implements Forgettable
+abstract class SecondFactorRevokedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'second_factor_id',
+        'second_factor_type',
+        'second_factor_identifier',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
      */
@@ -106,5 +115,14 @@ abstract class SecondFactorRevokedEvent extends IdentityEvent implements Forgett
     public function setSensitiveData(SensitiveData $sensitiveData)
     {
         $this->secondFactorIdentifier = $sensitiveData->getSecondFactorIdentifier();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorVettedEvent.php
@@ -32,13 +32,27 @@ use Surfnet\Stepup\Identity\Value\UnknownVettingType;
 use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class SecondFactorVettedEvent extends IdentityEvent implements Forgettable
+class SecondFactorVettedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'identity_institution',
+        'second_factor_id',
+        'second_factor_type',
+        'preferred_locale',
+        'email',
+        'common_name',
+        'second_factor_identifier',
+        'vetting_type',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\NameId
      */
@@ -164,5 +178,14 @@ class SecondFactorVettedEvent extends IdentityEvent implements Forgettable
         $this->commonName     = $sensitiveData->getCommonName();
         $this->secondFactorIdentifier = $sensitiveData->getSecondFactorIdentifier();
         $this->vettingType = $sensitiveData->getVettingType();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/U2fDevicePossessionProvenAndVerifiedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/U2fDevicePossessionProvenAndVerifiedEvent.php
@@ -29,13 +29,26 @@ use Surfnet\Stepup\Identity\Value\U2fKeyHandle;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
 /**
  * @deprecated Built in U2F support is dropped from StepUp, this Event was not removed to support event replay
  */
-class U2fDevicePossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified
+class U2fDevicePossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'second_factor_id',
+        'registration_requested_at',
+        'preferred_locale',
+        'second_factor_type',
+        'second_factor_identifier',
+        'email',
+        'common_name',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
      */
@@ -164,5 +177,14 @@ class U2fDevicePossessionProvenAndVerifiedEvent extends IdentityEvent implements
         $this->keyHandle   = $sensitiveData->getSecondFactorIdentifier();
         $this->email       = $sensitiveData->getEmail();
         $this->commonName  = $sensitiveData->getCommonName();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/VettedSecondFactorsAllRevokedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/VettedSecondFactorsAllRevokedEvent.php
@@ -21,9 +21,14 @@ namespace Surfnet\Stepup\Identity\Event;
 use Surfnet\Stepup\Identity\AuditLog\Metadata;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 
-class VettedSecondFactorsAllRevokedEvent extends IdentityEvent
+class VettedSecondFactorsAllRevokedEvent extends IdentityEvent implements RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+    ];
 
     final public function __construct(
         IdentityId $identityId,
@@ -58,5 +63,12 @@ class VettedSecondFactorsAllRevokedEvent extends IdentityEvent
             'identity_id'              => (string) $this->identityId,
             'identity_institution'     => (string) $this->identityInstitution,
         ];
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedUserData = $this->serialize();
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/YubikeyPossessionProvenAndVerifiedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/YubikeyPossessionProvenAndVerifiedEvent.php
@@ -29,10 +29,23 @@ use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-class YubikeyPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified
+class YubikeyPossessionProvenAndVerifiedEvent extends IdentityEvent implements Forgettable, PossessionProvenAndVerified, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'identity_institution',
+        'second_factor_id',
+        'registration_requested_at',
+        'preferred_locale',
+        'second_factor_identifier',
+        'second_factor_type',
+        'email',
+        'common_name',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\SecondFactorId
      */
@@ -163,5 +176,14 @@ class YubikeyPossessionProvenAndVerifiedEvent extends IdentityEvent implements F
         $this->yubikeyPublicId = $sensitiveData->getSecondFactorIdentifier();
         $this->email = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Identity/Event/YubikeySecondFactorBootstrappedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/YubikeySecondFactorBootstrappedEvent.php
@@ -29,10 +29,23 @@ use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
 
-final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent implements Forgettable
+final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
 {
+    protected static $whitelist = [
+        'identity_id',
+        'name_id',
+        'identity_institution',
+        'preferred_locale',
+        'second_factor_id',
+        'second_factor_identifier',
+        'second_factor_type',
+        'email',
+        'common_name',
+    ];
+
     /**
      * @var \Surfnet\Stepup\Identity\Value\NameId
      */
@@ -142,5 +155,14 @@ final class YubikeySecondFactorBootstrappedEvent extends IdentityEvent implement
         $this->email      = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
         $this->yubikeyPublicId = $sensitiveData->getSecondFactorIdentifier();
+    }
+
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        $serializedCombinedUserData = array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+        $whitelist = array_flip(self::$whitelist);
+        return array_intersect_key($serializedCombinedUserData, $whitelist);
     }
 }

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/AppointedAsRaaForInstitutionEventTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/AppointedAsRaaForInstitutionEventTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Tests\Configuration\Event;
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\Stepup\Identity\Event\AppointedAsRaaForInstitutionEvent;
+use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\Stepup\Identity\Value\NameId;
+
+
+class AppointedAsRaaForInstitutionEventTest extends TestCase
+{
+    public function test_if_all_whitelisted_data_is_returned()
+    {
+        $appointedAsRaaForInstitutionEvent = new AppointedAsRaaForInstitutionEvent(
+            new IdentityId("id"),
+            new Institution("HZ"),
+            new NameId("nameId"),
+            new Institution("ra")
+        );
+
+        $filteredUserData = $appointedAsRaaForInstitutionEvent->obtainUserData();
+
+        $this->assertArrayHasKey("identity_id", $filteredUserData);
+        $this->assertArrayHasKey("institution", $filteredUserData);
+        $this->assertArrayHasKey("name_id", $filteredUserData);
+        $this->assertArrayHasKey("ra_institution", $filteredUserData);
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/IdentityCreatedEventTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/IdentityCreatedEventTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Tests\Configuration\Event;
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\Stepup\Identity\Value\NameId;
+
+
+class IdentityCreatedEventTest extends TestCase
+{
+    public function test_if_all_the_expected_data_is_returned()
+    {
+        $IdentityCreatedEvent = new IdentityCreatedEvent(
+            new IdentityId("id"),
+            new Institution("HZ"),
+            new NameId("nameId"),
+            new CommonName("commonName"),
+            new Email("test@hz.nl"),
+            new Locale("nl_NL"));
+
+        $userData = $IdentityCreatedEvent->obtainUserData();
+
+        $this->assertArrayHasKey("id", $userData);
+        $this->assertArrayHasKey("institution", $userData);
+        $this->assertArrayHasKey("name_id", $userData);
+        $this->assertArrayHasKey("preferred_locale", $userData);
+        $this->assertArrayHasKey("common_name", $userData);
+        $this->assertArrayHasKey("email", $userData);
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/PhonePossessionProvenAndVerifiedEventTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/PhonePossessionProvenAndVerifiedEventTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Tests\Configuration\Event;
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\Stepup\DateTime\DateTime;
+use Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\Stepup\Identity\Value\PhoneNumber;
+use Surfnet\Stepup\Identity\Value\SecondFactorId;
+
+class PhonePossessionProvenAndVerifiedEventTest extends TestCase
+{
+    public function test_if_all_the_expected_data_is_returned()
+    {
+        $PhonePossessionProvenAndVerifiedEvent = new PhonePossessionProvenAndVerifiedEvent(
+            new IdentityId("id"),
+            new Institution("HZ"),
+            new SecondFactorId("52"),
+            new PhoneNumber("+0 (0) 000000000"),
+            new CommonName("common"),
+            new Email("test@gmail.com"),
+            new Locale("nl_NL"),
+            new DateTime(),
+            "Y3MWWNDR"
+        );
+
+        $userData = $PhonePossessionProvenAndVerifiedEvent->obtainUserData();
+
+        $this->assertArrayHasKey("identity_id", $userData);
+        $this->assertArrayHasKey("identity_institution", $userData);
+        $this->assertArrayHasKey("second_factor_id", $userData);
+        $this->assertArrayHasKey("registration_requested_at", $userData);
+        $this->assertArrayHasKey("preferred_locale", $userData);
+        $this->assertArrayHasKey("second_factor_type", $userData);
+        $this->assertArrayHasKey("second_factor_identifier", $userData);
+        $this->assertArrayHasKey("common_name", $userData);
+
+        //test if non whitelisted data is filtered out
+        $this->assertArrayNotHasKey("registration_code", $userData);
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/PhonePossessionProvenEventTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/PhonePossessionProvenEventTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Tests\Configuration\Event;
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\Stepup\DateTime\DateTime;
+use Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\EmailVerificationWindow;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\Stepup\Identity\Value\Locale;
+use Surfnet\Stepup\Identity\Value\PhoneNumber;
+use Surfnet\Stepup\Identity\Value\SecondFactorId;
+
+class PhonePossessionProvenEventTest extends TestCase
+{
+    public function test_if_all_the_expected_data_is_returned()
+    {
+        $PhonePossessionProvenEvent = new PhonePossessionProvenEvent(
+            new IdentityId("id"),
+            new Institution("Hz"),
+            new SecondFactorId("52"),
+            new PhoneNumber("+0 (0) 000000000"),
+            true,
+            emailVerificationWindow::createWindowFromTill(new DateTime(), new DateTime()),
+            "30c0fcb136bf324eea652d5b86c1a08c",
+            new CommonName("commonname"),
+            new Email("test@gmail.com"),
+            new Locale("nl_NL"));
+
+        $userData = $PhonePossessionProvenEvent->obtainUserData();
+
+        $this->assertArrayHasKey("identity_id", $userData);
+        $this->assertArrayHasKey("identity_institution", $userData);
+        $this->assertArrayHasKey("second_factor_id", $userData);
+        $this->assertArrayHasKey("preferred_locale", $userData);
+        $this->assertArrayHasKey("email", $userData);
+        //PhoneNumber converts to second_factor_type and second_factor_identifier
+        $this->assertArrayHasKey("second_factor_type", $userData);
+        $this->assertArrayHasKey("second_factor_identifier", $userData);
+        //commonName changes to common_name
+        $this->assertArrayHasKey("common_name", $userData);
+
+        //test if non whitelisted data is filtered out
+        $this->assertArrayNotHasKey("email_verification_required", $userData);
+        $this->assertArrayNotHasKey("email_verification_window", $userData);
+        $this->assertArrayNotHasKey("email_verification_nonce", $userData);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/RightToObtainDataInterface.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/RightToObtainDataInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData;
+
+interface RightToObtainDataInterface
+{
+    public function obtainUserData(): array;
+}


### PR DESCRIPTION
Gather relevant user information from EventStream, The sensitive data and non-sensitive data are combined and then held against a whitelist. The whitelisted data is returned in a JSON serializable object.

TravisCI currently fails due to a security vulnerability. this will be fixed in a future pr.
Some of the documentation is also outdated or needs some tweaking/adding. this will also be done in a future pr.

Task 3 of [#181430595](https://www.pivotaltracker.com/story/show/181430595)