### PR TITLE
Do not remove the deprovisioned Identity data from the projections 

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/SecondFactorStatusType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/SecondFactorStatusType.php
@@ -67,6 +67,8 @@ class SecondFactorStatusType extends Type
             return 20;
         } elseif (SecondFactorStatus::revoked()->equals($value)) {
             return 30;
+        } elseif (SecondFactorStatus::forgotten()->equals($value)) {
+            return 40;
         }
 
         throw new ConversionException(sprintf("Encountered inconvertible second factor status '%s'", (string) $value));
@@ -88,11 +90,13 @@ class SecondFactorStatusType extends Type
             return SecondFactorStatus::vetted();
         } elseif ($value === '30') {
             return SecondFactorStatus::revoked();
+        } elseif ($value === '40') {
+            return SecondFactorStatus::forgotten();
         }
 
         throw new ConversionException(
             sprintf(
-                "Encountered illegal second factor status of type %s '%s', expected it to be one of [0,10,20,30]",
+                "Encountered illegal second factor status of type %s '%s', expected it to be one of [0,10,20,30,40]",
                 is_object($value) ? get_class($value) : gettype($value),
                 is_scalar($value) ? (string) $value : ''
             )

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/AuditLogProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/AuditLogProjector.php
@@ -138,13 +138,18 @@ class AuditLogProjector implements EventListener
 
     private function applyIdentityForgottenEvent(IdentityForgottenEvent $event)
     {
+        $entries = $this->auditLogRepository->findByIdentityId($event->identityId);
+        foreach ($entries as $auditLogEntry) {
+            $auditLogEntry->actorCommonName = CommonName::unknown();
+        }
+
         $entriesWhereActor = $this->auditLogRepository->findEntriesWhereIdentityIsActorOnly($event->identityId);
         foreach ($entriesWhereActor as $auditLogEntry) {
             $auditLogEntry->actorCommonName = CommonName::unknown();
         }
 
+        $this->auditLogRepository->saveAll($entries);
         $this->auditLogRepository->saveAll($entriesWhereActor);
-        $this->auditLogRepository->removeByIdentityId($event->identityId);
     }
 
     private function augmentActorCommonName(AuditLogEntry $entry, Metadata $auditLogMetadata): void

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
@@ -74,9 +74,4 @@ class IdentityProjector extends Projector
 
         $this->identityRepository->save($identity);
     }
-
-    protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)
-    {
-        $this->identityRepository->removeByIdentityId($event->identityId);
-    }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaSecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RaSecondFactorProjector.php
@@ -353,7 +353,7 @@ class RaSecondFactorProjector extends Projector
 
     protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)
     {
-        $this->raSecondFactorRepository->removeByIdentityId($event->identityId);
+        $this->raSecondFactorRepository->updateStatusByIdentityIdToForgotten($event->identityId);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
@@ -118,17 +118,16 @@ class AuditLogRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param IdentityId $identityId
-     * @return void
+     * @param IdentityId $actorId
+     * @return AuditLogEntry[]
      */
-    public function removeByIdentityId(IdentityId $identityId)
+    public function findByIdentityId(IdentityId $identityId)
     {
-        $this->getEntityManager()->createQueryBuilder()
-            ->delete($this->_entityName, 'al')
+        return $this->createQueryBuilder('al')
             ->where('al.identityId = :identityId')
-            ->setParameter('identityId', $identityId->getIdentityId())
+            ->setParameter('identityId', $identityId)
             ->getQuery()
-            ->execute();
+            ->getResult();
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RaSecondFactorRepository.php
@@ -215,4 +215,16 @@ class RaSecondFactorRepository extends ServiceEntityRepository
 
         $entityManager->flush();
     }
+
+    public function updateStatusByIdentityIdToForgotten(IdentityId $identityId)
+    {
+        $this->getEntityManager()->createQueryBuilder()
+            ->update($this->_entityName, 'rasf')
+            ->set('rasf.status', ":forgotten")
+            ->where('rasf.identityId = :identityId')
+            ->setParameter('identityId', $identityId->getIdentityId())
+            ->setParameter('forgotten', 40)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/SecondFactorStatus.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/SecondFactorStatus.php
@@ -45,13 +45,18 @@ final class SecondFactorStatus
         return new self('revoked');
     }
 
+    public static function forgotten()
+    {
+        return new self('forgotten');
+    }
+
     /**
      * @param string $status
      * @return bool
      */
     public static function isValidStatus($status)
     {
-        return in_array($status, ['unverified', 'verified', 'vetted', 'revoked', true]);
+        return in_array($status, ['unverified', 'verified', 'vetted', 'revoked', 'forgotten', true]);
     }
 
     /**

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/SecondFactorStatusTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/SecondFactorStatusTypeTest.php
@@ -79,6 +79,7 @@ class SecondFactorStatusTypeTest extends UnitTest
             'verified' => [SecondFactorStatus::verified(), 10],
             'vetted' => [SecondFactorStatus::vetted(), 20],
             'revoked' => [SecondFactorStatus::revoked(), 30],
+            'forgotten' => [SecondFactorStatus::forgotten(), 40],
         ];
     }
 
@@ -131,6 +132,7 @@ class SecondFactorStatusTypeTest extends UnitTest
             'verified' => ['10', SecondFactorStatus::verified()],
             'vetted' => ['20', SecondFactorStatus::vetted()],
             'revoked' => ['30', SecondFactorStatus::revoked()],
+            'forgotten' => ['40', SecondFactorStatus::forgotten()],
         ];
     }
 


### PR DESCRIPTION
First of all: the data is anonymized, all sensitive data is still removed!

The data that was previously removed from the projections is now kept for the RaSecondFactor projection, the identity projection and the Audit Log projection. This only to allow RA's to see deprovisioned data in the second factor overview.

https://www.pivotaltracker.com/story/show/181172862