### PR TITLE
Repair broken authz in mayRaCommandBeExecutedOnBehalfOf

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Authorization\Service;
 
 use Mockery as m;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Rhumsaa\Uuid\Uuid;
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
@@ -29,6 +29,7 @@ use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\AuthorizationContextService;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\CommandAuthorizationService;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContext;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\WhitelistService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCredentials;
@@ -211,6 +212,12 @@ class CommandAuthorizationServiceTest extends TestCase
             $role = InstitutionRole::useRaa();
             if ($command instanceof VetSecondFactorCommand || $command instanceof RevokeRegistrantsSecondFactorCommand) {
                 $role = InstitutionRole::useRa();
+                $mockInstitution = new Institution('mock institution');
+                $mockIdentity = m::mock(Identity::class);
+                $mockIdentity->institution = $mockInstitution;
+                $this->identityService->shouldReceive('find')
+                    ->with($command->identityId)
+                    ->andReturn($mockIdentity);
             }
 
             $this->authorizationContextService->shouldReceive('buildInstitutionAuthorizationContext')
@@ -369,6 +376,13 @@ class CommandAuthorizationServiceTest extends TestCase
             $role = InstitutionRole::useRaa();
             if ($command instanceof VetSecondFactorCommand || $command instanceof RevokeRegistrantsSecondFactorCommand) {
                 $role = InstitutionRole::useRa();
+
+                $mockInstitution = new Institution('mock institution');
+                $mockIdentity = m::mock(Identity::class);
+                $mockIdentity->institution = $mockInstitution;
+                $this->identityService->shouldReceive('find')
+                    ->with($command->identityId)
+                    ->andReturn($mockIdentity);
             }
 
             $this->authorizationContextService->shouldReceive('buildInstitutionAuthorizationContext')


### PR DESCRIPTION
When vetting a token, the authorization check was not sharp enough. (incomplete)
1. The actor user's institution was only used to test for which other institutions it is allowed to perform tasks for. This would work for any configuration where 'regular' use-ra(a) configuration where set for that institution. When the RA is selected for a different institution, that test would not get the authorizations for that institution but just grab those of the 'home institution' of the actor. Adding a second query to also include the 'select_raa' authorizations for that institution fixed this problem.
2. To debug and get a grasp of what is happening in the Autz service. Quite some logging was added. The Autz repo also was exteded with some additional logging.

See https://www.pivotaltracker.com/story/show/181537313