### PR TITLE
Replace deprecated Swiftmailer with Symfony mailer

### DIFF
--- a/.env
+++ b/.env
@@ -31,10 +31,3 @@
 ###> symfony/mailer ###
 # MAILER_DSN=smtp://localhost
 ###< symfony/mailer ###
-
-###> symfony/swiftmailer-bundle ###
-# For Gmail as a transport, use: "gmail://username:password@localhost"
-# For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
-# Delivery is disabled by default via "null://localhost"
-#MAILER_URL=null://localhost
-###< symfony/swiftmailer-bundle ###

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,7 +2,7 @@ name: test-integration
 on:
   pull_request:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop, feature/*, bugfix/* ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "symfony/maker-bundle": "^1.19",
         "symfony/monolog-bundle": "^3.5",
         "symfony/security-bundle": "4.4.*",
-        "symfony/swiftmailer-bundle": "^3.4",
         "symfony/translation": "4.4.*",
         "symfony/twig-bundle": "4.4.*",
         "symfony/validator": "4.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -5378,16 +5378,16 @@
         },
         {
             "name": "symfony/mailer",
-            "version": "v4.4.38",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "cb843f81cbe16bfd2e17e23d619adb2dddfd0bde"
+                "reference": "62d909879078b31f338b26a2701c8f8802343769"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/cb843f81cbe16bfd2e17e23d619adb2dddfd0bde",
-                "reference": "cb843f81cbe16bfd2e17e23d619adb2dddfd0bde",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/62d909879078b31f338b26a2701c8f8802343769",
+                "reference": "62d909879078b31f338b26a2701c8f8802343769",
                 "shasum": ""
             },
             "require": {
@@ -5452,7 +5452,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T07:51:37+00:00"
+            "time": "2022-04-27T04:12:05+00:00"
         },
         {
             "name": "symfony/maker-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c4acf27e0ff60e0bf5b27ec7aa682f3",
+    "content-hash": "58e427fcea761527d90d77c1acb63ba2",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -3567,78 +3567,6 @@
             "time": "2022-02-10T11:54:37+00:00"
         },
         {
-            "name": "swiftmailer/swiftmailer",
-            "version": "v6.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8a5d5072dca8f48460fce2f4131fcc495eec654c",
-                "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c",
-                "shasum": ""
-            },
-            "require": {
-                "egulias/email-validator": "^2.0|^3.1",
-                "php": ">=7.0.0",
-                "symfony/polyfill-iconv": "^1.0",
-                "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "symfony/phpunit-bridge": "^4.4|^5.4"
-            },
-            "suggest": {
-                "ext-intl": "Needed to support internationalized email addresses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.2-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "lib/swift_required.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Corbyn"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Swiftmailer, free feature-rich PHP mailer",
-            "homepage": "https://swiftmailer.symfony.com",
-            "keywords": [
-                "email",
-                "mail",
-                "mailer"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/swiftmailer/swiftmailer",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": "symfony/mailer",
-            "time": "2021-10-18T15:26:12+00:00"
-        },
-        {
             "name": "symfony/asset",
             "version": "v4.4.37",
             "source": {
@@ -3874,16 +3802,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.4.37",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "e8c2d2c951ddedecb6d28954d336cb7d2e852d0e"
+                "reference": "9d031eb2d4292aed117b0f7fafd5c436dcf3dfd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/e8c2d2c951ddedecb6d28954d336cb7d2e852d0e",
-                "reference": "e8c2d2c951ddedecb6d28954d336cb7d2e852d0e",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9d031eb2d4292aed117b0f7fafd5c436dcf3dfd7",
+                "reference": "9d031eb2d4292aed117b0f7fafd5c436dcf3dfd7",
                 "shasum": ""
             },
             "require": {
@@ -3945,7 +3873,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-03T09:46:22+00:00"
+            "time": "2022-04-12T15:19:55+00:00"
         },
         {
             "name": "symfony/console",
@@ -4036,16 +3964,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.37",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470"
+                "reference": "6637e62480b60817b9a6984154a533e8e64c6bd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5de6c6e7f52b364840e53851c126be4d71e60470",
-                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/6637e62480b60817b9a6984154a533e8e64c6bd5",
+                "reference": "6637e62480b60817b9a6984154a533e8e64c6bd5",
                 "shasum": ""
             },
             "require": {
@@ -4097,20 +4025,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:41:36+00:00"
+            "time": "2022-04-12T15:19:55+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v4.4.39",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "5d0fbcdb9317864b2bd9e49d570d88ae512cadf3"
+                "reference": "74c7f55de0eced4d3c9654809b1871870386a577"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5d0fbcdb9317864b2bd9e49d570d88ae512cadf3",
-                "reference": "5d0fbcdb9317864b2bd9e49d570d88ae512cadf3",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/74c7f55de0eced4d3c9654809b1871870386a577",
+                "reference": "74c7f55de0eced4d3c9654809b1871870386a577",
                 "shasum": ""
             },
             "require": {
@@ -4180,7 +4108,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-02T12:36:39+00:00"
+            "time": "2022-04-12T15:19:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4355,16 +4283,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v4.4.37",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8d80ad881e1ce17979547873d093e3c987a6a629"
+                "reference": "529feb0e03133dbd5fd3707200147cc4903206da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8d80ad881e1ce17979547873d093e3c987a6a629",
-                "reference": "8d80ad881e1ce17979547873d093e3c987a6a629",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/529feb0e03133dbd5fd3707200147cc4903206da",
+                "reference": "529feb0e03133dbd5fd3707200147cc4903206da",
                 "shasum": ""
             },
             "require": {
@@ -4416,7 +4344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:41:36+00:00"
+            "time": "2022-04-12T15:19:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -4501,16 +4429,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v1.1.11",
+            "version": "v1.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "01e9a4efac0ee33a05dfdf93b346f62e7d0e998c"
+                "reference": "1d5cd762abaa6b2a4169d3e77610193a7157129e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/01e9a4efac0ee33a05dfdf93b346f62e7d0e998c",
-                "reference": "01e9a4efac0ee33a05dfdf93b346f62e7d0e998c",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/1d5cd762abaa6b2a4169d3e77610193a7157129e",
+                "reference": "1d5cd762abaa6b2a4169d3e77610193a7157129e",
                 "shasum": ""
             },
             "require": {
@@ -4573,7 +4501,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T15:25:38+00:00"
+            "time": "2022-01-02T09:41:36+00:00"
         },
         {
             "name": "symfony/expression-language",
@@ -5055,16 +4983,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v1.1.11",
+            "version": "v1.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "8a497ee1712c2507eaccd31aca00dd603f93d25d"
+                "reference": "89e01dc0f8677ee843b7c46f12624cac7fe4292b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/8a497ee1712c2507eaccd31aca00dd603f93d25d",
-                "reference": "8a497ee1712c2507eaccd31aca00dd603f93d25d",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/89e01dc0f8677ee843b7c46f12624cac7fe4292b",
+                "reference": "89e01dc0f8677ee843b7c46f12624cac7fe4292b",
                 "shasum": ""
             },
             "require": {
@@ -5126,20 +5054,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-06T10:00:00+00:00"
+            "time": "2022-03-08T18:43:16+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.4.39",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "60e8e42a4579551e5ec887d04380e2ab9e4cc314"
+                "reference": "27441220aebeb096b4eb8267acaaa7feb5e4266c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/60e8e42a4579551e5ec887d04380e2ab9e4cc314",
-                "reference": "60e8e42a4579551e5ec887d04380e2ab9e4cc314",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/27441220aebeb096b4eb8267acaaa7feb5e4266c",
+                "reference": "27441220aebeb096b4eb8267acaaa7feb5e4266c",
                 "shasum": ""
             },
             "require": {
@@ -5191,20 +5119,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-04T07:06:13+00:00"
+            "time": "2022-04-21T07:22:34+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.4.39",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "19d1cacefe81cb448227cc4d5909fb36e2e23081"
+                "reference": "7f8ce5bffc3939c63b7da32de5a546c98eb67698"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/19d1cacefe81cb448227cc4d5909fb36e2e23081",
-                "reference": "19d1cacefe81cb448227cc4d5909fb36e2e23081",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7f8ce5bffc3939c63b7da32de5a546c98eb67698",
+                "reference": "7f8ce5bffc3939c63b7da32de5a546c98eb67698",
                 "shasum": ""
             },
             "require": {
@@ -5292,7 +5220,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-05T21:04:55+00:00"
+            "time": "2022-04-27T17:13:11+00:00"
         },
         {
             "name": "symfony/inflector",
@@ -5612,16 +5540,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v4.4.37",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "a4fb074827e59a80bc3c5df4657fa782bac7cdab"
+                "reference": "5b05a62a714bb7e8ba1ce7412f7442debe67c291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/a4fb074827e59a80bc3c5df4657fa782bac7cdab",
-                "reference": "a4fb074827e59a80bc3c5df4657fa782bac7cdab",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/5b05a62a714bb7e8ba1ce7412f7442debe67c291",
+                "reference": "5b05a62a714bb7e8ba1ce7412f7442debe67c291",
                 "shasum": ""
             },
             "require": {
@@ -5681,7 +5609,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:41:36+00:00"
+            "time": "2022-04-12T15:19:55+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
@@ -5979,86 +5907,6 @@
                 }
             ],
             "time": "2021-10-20T20:35:02+00:00"
-        },
-        {
-            "name": "symfony/polyfill-iconv",
-            "version": "v1.25.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "f1aed619e28cb077fc83fac8c4c0383578356e40"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/f1aed619e28cb077fc83fac8c4c0383578356e40",
-                "reference": "f1aed619e28cb077fc83fac8c4c0383578356e40",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-iconv": "*"
-            },
-            "suggest": {
-                "ext-iconv": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Iconv\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Iconv extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "iconv",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-04T09:04:05+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -7244,16 +7092,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.11",
+            "version": "v1.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "633df678bec3452e04a7b0337c9bcfe7354124b3"
+                "reference": "eedb374f02031714a48848758a27812f3eca317a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/633df678bec3452e04a7b0337c9bcfe7354124b3",
-                "reference": "633df678bec3452e04a7b0337c9bcfe7354124b3",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/eedb374f02031714a48848758a27812f3eca317a",
+                "reference": "eedb374f02031714a48848758a27812f3eca317a",
                 "shasum": ""
             },
             "require": {
@@ -7316,84 +7164,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T13:32:43+00:00"
-        },
-        {
-            "name": "symfony/swiftmailer-bundle",
-            "version": "v3.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/swiftmailer-bundle.git",
-                "reference": "9daab339f226ac958192bf89836cb3378cc0e652"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/9daab339f226ac958192bf89836cb3378cc0e652",
-                "reference": "9daab339f226ac958192bf89836cb3378cc0e652",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "swiftmailer/swiftmailer": "^6.1.3",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/http-kernel": "^4.4|^5.0"
-            },
-            "conflict": {
-                "twig/twig": "<1.41|>=2.0,<2.10"
-            },
-            "require-dev": {
-                "symfony/console": "^4.4|^5.0",
-                "symfony/framework-bundle": "^4.4|^5.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0",
-                "symfony/yaml": "^4.4|^5.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Bundle\\SwiftmailerBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony SwiftmailerBundle",
-            "homepage": "http://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": "symfony/mailer",
-            "time": "2022-02-06T08:03:40+00:00"
+            "time": "2022-03-09T13:39:03+00:00"
         },
         {
             "name": "symfony/templating",
@@ -7925,16 +7696,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.4.39",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "35237c5e5dcb6593a46a860ba5b29c1d4683d80e"
+                "reference": "58eb36075c04aaf92a7a9f38ee9a8b97e24eb481"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/35237c5e5dcb6593a46a860ba5b29c1d4683d80e",
-                "reference": "35237c5e5dcb6593a46a860ba5b29c1d4683d80e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/58eb36075c04aaf92a7a9f38ee9a8b97e24eb481",
+                "reference": "58eb36075c04aaf92a7a9f38ee9a8b97e24eb481",
                 "shasum": ""
             },
             "require": {
@@ -8007,7 +7778,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T10:38:15+00:00"
+            "time": "2022-04-25T21:15:06+00:00"
         },
         {
             "name": "symfony/var-exporter",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -11,7 +11,6 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
-    Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
     Liip\TestFixturesBundle\LiipTestFixturesBundle::class => ['dev' => true, 'test' => true, 'smoketest' => true, 'smoketest_event_replay' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],

--- a/config/packages/dev/mailer.yaml
+++ b/config/packages/dev/mailer.yaml
@@ -1,0 +1,3 @@
+framework:
+    mailer:
+        dsn: "%mailer_transport%://%mailer_user%:%mailer_password%@%mailer_host%:1025"

--- a/config/packages/dev/swiftmailer.yaml
+++ b/config/packages/dev/swiftmailer.yaml
@@ -1,5 +1,0 @@
-# See https://symfony.com/doc/current/email/dev_environment.html
-swiftmailer:
-    # send all emails to a specific address
-    #delivery_addresses: ['me@example.com']
-    port: 1025

--- a/config/packages/dev_event_replay/swiftmailer.yaml
+++ b/config/packages/dev_event_replay/swiftmailer.yaml
@@ -1,5 +1,0 @@
-# See https://symfony.com/doc/current/email/dev_environment.html
-swiftmailer:
-    # send all emails to a specific address
-    #delivery_addresses: ['me@example.com']
-    port: 1025

--- a/config/packages/prod_event_replay/swiftmailer.yaml
+++ b/config/packages/prod_event_replay/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    disable_delivery: true

--- a/config/packages/smoketest/swiftmailer.yaml
+++ b/config/packages/smoketest/swiftmailer.yaml
@@ -1,5 +1,0 @@
-# See https://symfony.com/doc/current/email/dev_environment.html
-swiftmailer:
-    # send all emails to a specific address
-    #delivery_addresses: ['me@example.com']
-    port: 1025

--- a/config/packages/smoketest_event_replay/swiftmailer.yaml
+++ b/config/packages/smoketest_event_replay/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    disable_delivery: true

--- a/config/packages/swiftmailer.yaml
+++ b/config/packages/swiftmailer.yaml
@@ -1,6 +1,0 @@
-swiftmailer:
-    transport: "%mailer_transport%"
-    host:      "%mailer_host%"
-    username:  "%mailer_user%"
-    password:  "%mailer_password%"
-    spool:     { type: memory }

--- a/config/packages/test/mailer.yaml
+++ b/config/packages/test/mailer.yaml
@@ -1,5 +1,3 @@
-# See https://symfony.com/doc/current/email/dev_environment.html
-swiftmailer:
-  # send all emails to a specific address
-  #delivery_addresses: ['me@example.com']
-  port: 1025
+framework:
+  mailer:
+    dsn: "%mailer_transport%://%mailer_user%:%mailer_password%@%mailer_host%"

--- a/config/packages/test/swiftmailer.yaml
+++ b/config/packages/test/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    disable_delivery: true

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/DependencyInjection/SurfnetStepupMiddlewareCommandHandlingExtension.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/DependencyInjection/SurfnetStepupMiddlewareCommandHandlingExtension.php
@@ -47,28 +47,28 @@ class SurfnetStepupMiddlewareCommandHandlingExtension extends Extension
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.email_verification_mail')
-            ->replaceArgument(4, $config['self_service_email_verification_url_template'])
-            ->replaceArgument(6, $config['email_fallback_locale'])
-            ->replaceArgument(7, $config['self_service_url']);
+            ->replaceArgument(3, $config['self_service_email_verification_url_template'])
+            ->replaceArgument(5, $config['email_fallback_locale'])
+            ->replaceArgument(6, $config['self_service_url']);
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.registration_mail')
-            ->replaceArgument(5, $config['email_fallback_locale'])
-            ->replaceArgument(6, $config['self_service_url']);
+            ->replaceArgument(4, $config['email_fallback_locale'])
+            ->replaceArgument(5, $config['self_service_url']);
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.second_factor_revocation_mail')
-            ->replaceArgument(5, $config['email_fallback_locale'])
-            ->replaceArgument(6, $config['self_service_url']);
+            ->replaceArgument(4, $config['email_fallback_locale'])
+            ->replaceArgument(5, $config['self_service_url']);
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.second_factor_vetted_mail')
-            ->replaceArgument(5, $config['email_fallback_locale'])
-            ->replaceArgument(6, $config['self_service_url']);
+            ->replaceArgument(4, $config['email_fallback_locale'])
+            ->replaceArgument(5, $config['self_service_url']);
 
         $container
             ->getDefinition('surfnet_stepup_middleware_command_handling.service.recovery_token_mail')
-            ->replaceArgument(5, $config['email_fallback_locale'])
-            ->replaceArgument(6, $config['self_service_url']);
+            ->replaceArgument(4, $config['email_fallback_locale'])
+            ->replaceArgument(5, $config['self_service_url']);
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php
@@ -21,10 +21,11 @@ namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service;
 use Assert\Assertion;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Service\EmailTemplateService;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Sender;
-use Swift_Mailer as Mailer;
-use Swift_Message as Message;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface as Mailer;
 use Symfony\Component\Translation\TranslatorInterface;
-use Twig\Environment;
+
 
 final class EmailVerificationMailService
 {
@@ -59,11 +60,6 @@ final class EmailVerificationMailService
     private $sender;
 
     /**
-     * @var Environment
-     */
-    private $twig;
-
-    /**
      * @var string
      */
     private $selfServiceUrl;
@@ -72,7 +68,7 @@ final class EmailVerificationMailService
      * @param Mailer $mailer
      * @param Sender $sender
      * @param TranslatorInterface $translator
-     * @param Environment $twig
+
      * @param string $emailVerificationUrlTemplate
      * @param EmailTemplateService $emailTemplateService
      * @param string $fallbackLocale
@@ -84,7 +80,6 @@ final class EmailVerificationMailService
         Mailer $mailer,
         Sender $sender,
         TranslatorInterface $translator,
-        Environment $twig,
         $emailVerificationUrlTemplate,
         EmailTemplateService $emailTemplateService,
         $fallbackLocale,
@@ -98,7 +93,6 @@ final class EmailVerificationMailService
         $this->mailer = $mailer;
         $this->sender = $sender;
         $this->translator = $translator;
-        $this->twig = $twig;
         $this->emailVerificationUrlTemplate = $emailVerificationUrlTemplate;
         $this->emailTemplateService = $emailTemplateService;
         $this->fallbackLocale = $fallbackLocale;
@@ -110,6 +104,7 @@ final class EmailVerificationMailService
      * @param string $commonName
      * @param string $email
      * @param string $verificationNonce
+     * @throws TransportExceptionInterface
      */
     public function sendEmailVerificationEmail(
         $locale,
@@ -140,21 +135,12 @@ final class EmailVerificationMailService
             'selfServiceUrl'   => $this->selfServiceUrl,
         ];
 
-        // Rendering file template instead of string
-        // (https://github.com/symfony/symfony/issues/10865#issuecomment-42438248)
-        $body = $this->twig->render(
-            '@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig',
-            $parameters
-        );
-
-        /** @var Message $message */
-        $message = $this->mailer->createMessage();
-        $message
-            ->setFrom($this->sender->getEmail(), $this->sender->getName())
-            ->addTo($email, $commonName)
-            ->setSubject($subject)
-            ->setBody($body, 'text/html', 'utf-8');
-
-        $this->mailer->send($message);
+        $email = (new TemplatedEmail())
+            ->from($this->sender->getEmail(), $this->sender->getName())
+            ->to($email, $commonName)
+            ->subject($subject)
+            ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
+            ->context($parameters);
+        $this->mailer->send($email);
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/EmailVerificationMailService.php
@@ -21,11 +21,11 @@ namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service;
 use Assert\Assertion;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Service\EmailTemplateService;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Sender;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface as Mailer;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Translation\TranslatorInterface;
-
 
 final class EmailVerificationMailService
 {
@@ -136,8 +136,8 @@ final class EmailVerificationMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email, $commonName)
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
@@ -27,6 +27,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Sender;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface as Mailer;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Translation\TranslatorInterface;
 
 final class RegistrationMailService
@@ -62,13 +63,6 @@ final class RegistrationMailService
     private $selfServiceUrl;
 
     /**
-     * @param Mailer $mailer
-     * @param Sender $sender
-     * @param TranslatorInterface $translator
-     * @param EmailTemplateService $emailTemplateService
-     * @param string $fallbackLocale
-     * @param $selfServiceUrl
-     *
      * @throws \Assert\AssertionFailedException
      */
     public function __construct(
@@ -76,8 +70,8 @@ final class RegistrationMailService
         Sender $sender,
         TranslatorInterface $translator,
         EmailTemplateService $emailTemplateService,
-        $fallbackLocale,
-        $selfServiceUrl
+        string $fallbackLocale,
+        string $selfServiceUrl
     ) {
         Assertion::string($fallbackLocale, 'Fallback locale "%s" expected to be string, type %s given');
 
@@ -132,7 +126,7 @@ final class RegistrationMailService
 
         $email = (new TemplatedEmail())
             ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email, $commonName)
+            ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php
@@ -30,6 +30,7 @@ use Surfnet\StepupMiddleware\MiddlewareBundle\Service\SecondFactorDisplayNameRes
 use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface as Mailer;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -73,14 +74,6 @@ final class SecondFactorRevocationMailService
     private $displayNameResolver;
 
     /**
-     * @param Mailer $mailer
-     * @param Sender $sender
-     * @param TranslatorInterface $translator
-     * @param EmailTemplateService $emailTemplateService
-     * @param string $fallbackLocale
-     * @param string $selfServiceUrl
-     * @param SecondFactorDisplayNameResolverService $displayNameResolver
-     *
      * @throws \Assert\AssertionFailedException
      */
     public function __construct(
@@ -88,8 +81,8 @@ final class SecondFactorRevocationMailService
         Sender $sender,
         TranslatorInterface $translator,
         EmailTemplateService $emailTemplateService,
-        $fallbackLocale,
-        $selfServiceUrl,
+        string $fallbackLocale,
+        string $selfServiceUrl,
         SecondFactorDisplayNameResolverService $displayNameResolver
     ) {
         Assertion::string($fallbackLocale, 'Fallback locale "%s" expected to be string, type %s given');
@@ -133,6 +126,7 @@ final class SecondFactorRevocationMailService
             $locale->getLocale(),
             $this->fallbackLocale
         );
+
         $parameters = [
             'isRevokedByRa'   => true,
             'templateString'  => $emailTemplate->htmlContent,
@@ -144,8 +138,8 @@ final class SecondFactorRevocationMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email->getEmail(), $commonName->getCommonName())
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorVettedMailService.php
@@ -26,6 +26,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Service\EmailTe
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Sender;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface as Mailer;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Translation\TranslatorInterface;
 
 final class SecondFactorVettedMailService
@@ -114,8 +115,8 @@ final class SecondFactorVettedMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email, $commonName)
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
@@ -41,7 +41,6 @@ services:
             - "@mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
-            - "@twig"
             - "" # Verification URL set in bundle extension
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
@@ -54,7 +53,6 @@ services:
             - "@mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
-            - "@twig"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
             - "" # Self service url is set in bundle extension
@@ -66,7 +64,6 @@ services:
             - "@mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
-            - "@twig"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
             - "" # Self service url is set in bundle extension
@@ -79,7 +76,6 @@ services:
             - "@mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
-            - "@twig"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
             - "" # Self service url is set in bundle extension
@@ -92,7 +88,6 @@ services:
             - "@mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
-            - "@twig"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "" # Fallback locale
             - "" # Self service url is set in bundle extension

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
@@ -35,7 +35,6 @@ services:
             - "@mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
-            - "@twig"
             - "@surfnet_stepup_middleware_management.service.email_template"
             - "@surfnet_stepup_middleware_api.service.institution_configuration_options"
             - "@surfnet_stepup_middleware_api.service.ra_listing"

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php
@@ -28,10 +28,10 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCrede
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\VerifiedTokenInformation;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Service\EmailTemplateService;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Sender;
-use Swift_Mailer as Mailer;
-use Swift_Message as Message;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface as Mailer;
 use Symfony\Component\Translation\TranslatorInterface;
-use Twig\Environment;
 
 class VerifiedSecondFactorReminderMailService
 {
@@ -49,11 +49,6 @@ class VerifiedSecondFactorReminderMailService
      * @var TranslatorInterface
      */
     private $translator;
-
-    /**
-     * @var Environment
-     */
-    private $twig;
 
     /**
      * @var EmailTemplateService
@@ -84,7 +79,6 @@ class VerifiedSecondFactorReminderMailService
      * @param Mailer $mailer
      * @param Sender $sender
      * @param TranslatorInterface $translator
-     * @param Environment $twig
      * @param EmailTemplateService $emailTemplateService
      * @param InstitutionConfigurationOptionsService $institutionConfigurationOptionsService
      * @param RaListingService $raListingService
@@ -95,7 +89,6 @@ class VerifiedSecondFactorReminderMailService
         Mailer $mailer,
         Sender $sender,
         TranslatorInterface $translator,
-        Environment $twig,
         EmailTemplateService $emailTemplateService,
         InstitutionConfigurationOptionsService $institutionConfigurationOptionsService,
         RaListingService $raListingService,
@@ -106,7 +99,6 @@ class VerifiedSecondFactorReminderMailService
         $this->mailer = $mailer;
         $this->sender = $sender;
         $this->translator = $translator;
-        $this->twig = $twig;
         $this->emailTemplateService = $emailTemplateService;
         $this->institutionConfigurationOptionsService = $institutionConfigurationOptionsService;
         $this->raListingService = $raListingService;
@@ -167,7 +159,8 @@ class VerifiedSecondFactorReminderMailService
      * @param string $email
      * @param DateTime $requestedAt
      * @param $registrationCode
-     * @return int
+     * @return void
+     * @throws TransportExceptionInterface
      */
     private function sendReminderWithInstitution(
         $locale,
@@ -199,22 +192,13 @@ class VerifiedSecondFactorReminderMailService
             'raLocations' => $raLocations,
         ];
 
-        // Rendering file template instead of string
-        // (https://github.com/symfony/symfony/issues/10865#issuecomment-42438248)
-        $body = $this->twig->render(
-            '@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig',
-            $parameters
-        );
-
-        /** @var Message $message */
-        $message = $this->mailer->createMessage();
-        $message
-            ->setFrom($this->sender->getEmail(), $this->sender->getName())
-            ->addTo($email, $commonName)
-            ->setSubject($subject)
-            ->setBody($body, 'text/html', 'utf-8');
-
-        return $this->mailer->send($message);
+        $email = (new TemplatedEmail())
+            ->from($this->sender->getEmail(), $this->sender->getName())
+            ->to($email, $commonName)
+            ->subject($subject)
+            ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
+            ->context($parameters);
+        $this->mailer->send($email);
     }
 
     private function sendReminderWithRas(
@@ -247,21 +231,12 @@ class VerifiedSecondFactorReminderMailService
             'ras' => $ras,
         ];
 
-        // Rendering file template instead of string
-        // (https://github.com/symfony/symfony/issues/10865#issuecomment-42438248)
-        $body = $this->twig->render(
-            '@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig',
-            $parameters
-        );
-
-        /** @var Message $message */
-        $message = $this->mailer->createMessage();
-        $message
-            ->setFrom($this->sender->getEmail(), $this->sender->getName())
-            ->addTo($email, $commonName)
-            ->setSubject($subject)
-            ->setBody($body, 'text/html', 'utf-8');
-
-        return $this->mailer->send($message);
+        $email = (new TemplatedEmail())
+            ->from($this->sender->getEmail(), $this->sender->getName())
+            ->to($email, $commonName)
+            ->subject($subject)
+            ->htmlTemplate('SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
+            ->context($parameters);
+        $this->mailer->send($email);
     }
 }

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php
@@ -28,11 +28,14 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCrede
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\VerifiedTokenInformation;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Configuration\Service\EmailTemplateService;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Value\Sender;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail as TemplatedEmail;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface as Mailer;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class VerifiedSecondFactorReminderMailService
 {
     /**
@@ -75,16 +78,6 @@ class VerifiedSecondFactorReminderMailService
      */
     private $fallbackLocale;
 
-    /**
-     * @param Mailer $mailer
-     * @param Sender $sender
-     * @param TranslatorInterface $translator
-     * @param EmailTemplateService $emailTemplateService
-     * @param InstitutionConfigurationOptionsService $institutionConfigurationOptionsService
-     * @param RaListingService $raListingService
-     * @param RaLocationService $raLocationService
-     * @param string $fallbackLocale
-     */
     public function __construct(
         Mailer $mailer,
         Sender $sender,
@@ -93,7 +86,7 @@ class VerifiedSecondFactorReminderMailService
         InstitutionConfigurationOptionsService $institutionConfigurationOptionsService,
         RaListingService $raListingService,
         RaLocationService $raLocationService,
-        $fallbackLocale
+        string $fallbackLocale
     ) {
         Assertion::string($fallbackLocale, 'Fallback locale "%s" expected to be string, type %s given');
         $this->mailer = $mailer;

--- a/symfony.lock
+++ b/symfony.lock
@@ -362,9 +362,6 @@
     "surfnet/stepup-saml-bundle": {
         "version": "4.1.11"
     },
-    "swiftmailer/swiftmailer": {
-        "version": "v6.2.3"
-    },
     "symfony/asset": {
         "version": "v4.4.9"
     },
@@ -542,9 +539,6 @@
     "symfony/polyfill-ctype": {
         "version": "v1.17.0"
     },
-    "symfony/polyfill-iconv": {
-        "version": "v1.17.0"
-    },
     "symfony/polyfill-intl-icu": {
         "version": "v1.17.0"
     },
@@ -624,20 +618,6 @@
     },
     "symfony/stopwatch": {
         "version": "v4.4.10"
-    },
-    "symfony/swiftmailer-bundle": {
-        "version": "2.5",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "2.5",
-            "ref": "ae4d22af30bbd484506bc1817c5a3ef72c855b93"
-        },
-        "files": [
-            "config/packages/dev/swiftmailer.yaml",
-            "config/packages/swiftmailer.yaml",
-            "config/packages/test/swiftmailer.yaml"
-        ]
     },
     "symfony/templating": {
         "version": "v4.4.9"


### PR DESCRIPTION
All mail services that used the deprecated Swiftmailer are not using Symfony mailer.

https://www.pivotaltracker.com/story/show/179976844