### PR TITLE
Create the self-asserted tokens feature toggle

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -102,6 +102,9 @@ doctrine:
             stepup_self_vet_option:
                 class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\SelfVetOptionType
                 commented: false
+            stepup_self_asserted_tokens_option:
+                class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\SelfAssertedTokensOptionType
+                commented: false
             stepup_institution_role:
                 class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\InstitutionRoleType
                 commented: false

--- a/config/packages/events.yaml
+++ b/config/packages/events.yaml
@@ -13,6 +13,8 @@ parameters:
         - Surfnet\Stepup\Configuration\Event\RaLocationRelocatedEvent
         - Surfnet\Stepup\Configuration\Event\RaLocationRemovedEvent
         - Surfnet\Stepup\Configuration\Event\RaLocationRenamedEvent
+        - Surfnet\Stepup\Configuration\Event\SelfAssertedTokensOptionChangedEvent
+        - Surfnet\Stepup\Configuration\Event\SelfVetOptionChangedEvent
         - Surfnet\Stepup\Configuration\Event\ServiceProvidersUpdatedEvent
         - Surfnet\Stepup\Configuration\Event\ShowRaaContactInformationOptionChangedEvent
         - Surfnet\Stepup\Configuration\Event\SraaUpdatedEvent

--- a/src/Surfnet/Migrations/Version20220519134637.php
+++ b/src/Surfnet/Migrations/Version20220519134637.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the self_asserted_tokens_option to the institution_configuration_options projection
+ */
+final class Version20220519134637 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('ALTER TABLE institution_configuration_options ADD self_asserted_tokens_option INT DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->addSql('ALTER TABLE institution_configuration_options DROP self_asserted_tokens_option');
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/Event/NewInstitutionConfigurationCreatedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/NewInstitutionConfigurationCreatedEvent.php
@@ -22,11 +22,16 @@ use Broadway\Serializer\Serializable as SerializableInterface;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
 use Surfnet\Stepup\Configuration\Value\VerifyEmailOption;
 
+/**
+ * When the institution configuration contains a new institution, this event is used
+ * to record that institution into the institution configuration.
+ */
 class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
 {
     /**
@@ -63,6 +68,11 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
      */
     public $selfVetOption;
 
+    /**
+     * @var SelfAssertedTokensOption
+     */
+    public $selfAssertedTokensOption;
+
     public function __construct(
         InstitutionConfigurationId $institutionConfigurationId,
         Institution $institution,
@@ -70,7 +80,8 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
         ShowRaaContactInformationOption $showRaaContactInformationOption,
         VerifyEmailOption $verifyEmailOption,
         NumberOfTokensPerIdentityOption $numberOfTokensPerIdentityOption,
-        SelfVetOption $selfVetOption
+        SelfVetOption $selfVetOption,
+        SelfAssertedTokensOption $selfAssertedTokensOption
     ) {
         $this->institutionConfigurationId      = $institutionConfigurationId;
         $this->institution                     = $institution;
@@ -79,6 +90,7 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
         $this->verifyEmailOption               = $verifyEmailOption;
         $this->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption;
         $this->selfVetOption = $selfVetOption;
+        $this->selfAssertedTokensOption = $selfAssertedTokensOption;
     }
 
     public static function deserialize(array $data)
@@ -93,6 +105,10 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
         if (!isset($data['self_vet_option'])) {
             $data['self_vet_option'] = false;
         }
+        // If self asserted tokens option is not yet present, default to false
+        if (!isset($data['self_asserted_tokens_option'])) {
+            $data['self_asserted_tokens_option'] = false;
+        }
         return new self(
             new InstitutionConfigurationId($data['institution_configuration_id']),
             new Institution($data['institution']),
@@ -100,7 +116,8 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
             new ShowRaaContactInformationOption($data['show_raa_contact_information_option']),
             new VerifyEmailOption($data['verify_email_option']),
             new NumberOfTokensPerIdentityOption($data['number_of_tokens_per_identity_option']),
-            new SelfVetOption($data['self_vet_option'])
+            new SelfVetOption($data['self_vet_option']),
+            new SelfAssertedTokensOption($data['self_asserted_tokens_option'])
         );
     }
 
@@ -114,6 +131,7 @@ class NewInstitutionConfigurationCreatedEvent implements SerializableInterface
             'verify_email_option'                 => $this->verifyEmailOption->isEnabled(),
             'number_of_tokens_per_identity_option' => $this->numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity(),
             'self_vet_option' => $this->selfVetOption->isEnabled(),
+            'self_asserted_tokens_option' => $this->selfAssertedTokensOption->isEnabled(),
         ];
     }
 }

--- a/src/Surfnet/Stepup/Configuration/Event/SelfAssertedTokensOptionChangedEvent.php
+++ b/src/Surfnet/Stepup/Configuration/Event/SelfAssertedTokensOptionChangedEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright 2022 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Event;
+
+use Broadway\Serializer\Serializable as SerializableInterface;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
+
+final class SelfAssertedTokensOptionChangedEvent implements SerializableInterface
+{
+    /**
+     * @var InstitutionConfigurationId
+     */
+    public $institutionConfigurationId;
+
+    /**
+     * @var Institution
+     */
+    public $institution;
+
+    /**
+     * @var SelfAssertedTokensOption
+     */
+    public $selfAssertedTokensOption;
+
+    public function __construct(
+        InstitutionConfigurationId $institutionConfigurationId,
+        Institution $institution,
+        SelfAssertedTokensOption $selfVetOption
+    ) {
+        $this->institutionConfigurationId = $institutionConfigurationId;
+        $this->institution = $institution;
+        $this->selfAssertedTokensOption = $selfVetOption;
+    }
+
+    public static function deserialize(array $data)
+    {
+        return new self(
+            new InstitutionConfigurationId($data['institution_configuration_id']),
+            new Institution($data['institution']),
+            new SelfAssertedTokensOption($data['self_asserted_tokens_option'])
+        );
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'institution_configuration_id' => $this->institutionConfigurationId->getInstitutionConfigurationId(),
+            'institution' => $this->institution->getInstitution(),
+            'self_asserted_tokens_option' => $this->selfAssertedTokensOption->isEnabled(),
+        ];
+    }
+}

--- a/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
+++ b/src/Surfnet/Stepup/Configuration/InstitutionConfiguration.php
@@ -31,6 +31,7 @@ use Surfnet\Stepup\Configuration\Event\RaLocationRelocatedEvent;
 use Surfnet\Stepup\Configuration\Event\RaLocationRemovedEvent;
 use Surfnet\Stepup\Configuration\Event\RaLocationRenamedEvent;
 use Surfnet\Stepup\Configuration\Event\SelectRaaOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\SelfAssertedTokensOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\SelfVetOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\ShowRaaContactInformationOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\UseRaaOptionChangedEvent;
@@ -48,6 +49,7 @@ use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationList;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -112,6 +114,11 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
     private $selfVetOption;
 
     /**
+     * @var SelfAssertedTokensOption
+     */
+    private $selfAssertedTokensOption;
+
+    /**
      * @var InstitutionAuthorizationOption
      */
     private $useRaOption;
@@ -153,7 +160,8 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
                 ShowRaaContactInformationOption::getDefault(),
                 VerifyEmailOption::getDefault(),
                 NumberOfTokensPerIdentityOption::getDefault(),
-                SelfVetOption::getDefault()
+                SelfVetOption::getDefault(),
+                SelfAssertedTokensOption::getDefault()
             )
         );
         $institutionConfiguration->apply(new AllowedSecondFactorListUpdatedEvent(
@@ -204,7 +212,8 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
                 ShowRaaContactInformationOption::getDefault(),
                 VerifyEmailOption::getDefault(),
                 NumberOfTokensPerIdentityOption::getDefault(),
-                SelfVetOption::getDefault()
+                SelfVetOption::getDefault(),
+                SelfAssertedTokensOption::getDefault()
             )
         );
         $this->apply(new AllowedSecondFactorListUpdatedEvent(
@@ -313,6 +322,21 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
                 $this->institutionConfigurationId,
                 $this->institution,
                 $selfVetOption
+            )
+        );
+    }
+
+    public function configureSelfAssertedTokensOption(SelfAssertedTokensOption $selfAssertedTokensOption)
+    {
+        if ($this->selfAssertedTokensOption->equals($selfAssertedTokensOption)) {
+            return;
+        }
+
+        $this->apply(
+            new SelfAssertedTokensOptionChangedEvent(
+                $this->institutionConfigurationId,
+                $this->institution,
+                $selfAssertedTokensOption
             )
         );
     }
@@ -521,6 +545,7 @@ class InstitutionConfiguration extends EventSourcedAggregateRoot implements Inst
         $this->showRaaContactInformationOption = $event->showRaaContactInformationOption;
         $this->verifyEmailOption               = $event->verifyEmailOption;
         $this->selfVetOption = $event->selfVetOption;
+        $this->selfAssertedTokensOption = $event->selfAssertedTokensOption;
         $this->numberOfTokensPerIdentityOption = $event->numberOfTokensPerIdentityOption;
         $this->raLocations                     = new RaLocationList([]);
         $this->isMarkedAsDestroyed             = false;

--- a/src/Surfnet/Stepup/Configuration/Value/SelfAssertedTokensOption.php
+++ b/src/Surfnet/Stepup/Configuration/Value/SelfAssertedTokensOption.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2022 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Configuration\Value;
+
+use JsonSerializable;
+
+final class SelfAssertedTokensOption implements JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $allowed;
+
+    public static function getDefault()
+    {
+        return new self(false);
+    }
+
+    public function __construct(bool $selfAssertedTokensAllowed)
+    {
+        $this->allowed = $selfAssertedTokensAllowed;
+    }
+
+    public function equals(SelfAssertedTokensOption $other): bool
+    {
+        return $this->allowed === $other->allowed;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->allowed;
+    }
+
+    public function jsonSerialize(): bool
+    {
+        return $this->allowed;
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Configuration/Event/EventSerializationAndDeserializationTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/Event/EventSerializationAndDeserializationTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\Stepup\Tests\Configuration\Event;
 
 use Broadway\Serializer\Serializable as SerializableInterface;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Rhumsaa\Uuid\Uuid;
 use Surfnet\Stepup\Configuration\Configuration;
 use Surfnet\Stepup\Configuration\Event\AllowedSecondFactorListUpdatedEvent;
@@ -48,6 +48,7 @@ use Surfnet\Stepup\Configuration\Value\Location;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -127,7 +128,8 @@ class EventSerializationAndDeserializationTest extends TestCase
                     new ShowRaaContactInformationOption(true),
                     new VerifyEmailOption(true),
                     new NumberOfTokensPerIdentityOption(0),
-                    new SelfVetOption(true)
+                    new SelfVetOption(true),
+                    new SelfAssertedTokensOption(true)
                 )
             ],
             'UseRaLocationsOptionChangedEvent' => [

--- a/src/Surfnet/Stepup/Tests/Configuration/InstitutionConfigurationTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/InstitutionConfigurationTest.php
@@ -33,6 +33,7 @@ use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
 use Surfnet\Stepup\Configuration\Value\InstitutionRole;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -52,6 +53,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedUseRaLocationsOption = new UseRaLocationsOption(false);
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
@@ -72,7 +74,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -108,6 +111,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $useRaLocationsOption       = new UseRaLocationsOption(false);
         $verifyEmailOption          = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedShowRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
@@ -128,7 +132,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $expectedShowRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -165,6 +170,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $theSameUseRaLocationsOption = $originalUseRaLocationsOption;
 
@@ -178,7 +184,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($theSameUseRaLocationsOption) {
@@ -200,6 +207,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $verifyEmailOption                       = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = new SelfVetOption(false);
+        $selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $sameShowRaaContactInformationOption = $originalShowRaaContactInformationOption;
 
         $this->scenario
@@ -212,7 +220,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $originalShowRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($sameShowRaaContactInformationOption) {
@@ -233,6 +242,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = new SelfVetOption(false);
+        $selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedUseRaLocationsOption = new UseRaLocationsOption(false);
 
@@ -246,7 +256,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($expectedUseRaLocationsOption) {
@@ -273,6 +284,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $originalShowRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption                       = new VerifyEmailOption(true);
         $selfVetOption = new SelfVetOption(false);
+        $selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedShowRaaContactInformationOption = new ShowRaaContactInformationOption(false);
 
@@ -286,7 +298,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                     $originalShowRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when(function (InstitutionConfiguration $institutionConfiguration) use ($expectedShowRaaContactInformationOption) {
@@ -312,6 +325,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = new SelfVetOption(false);
+        $selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedUseRaLocationsOption = new UseRaLocationsOption(false);
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
@@ -352,7 +366,8 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
                         $showRaaContactInformationOption,
                         $verifyEmailOption,
                         $numberOfTokensPerIdentityOption,
-                        $selfVetOption
+                        $selfVetOption,
+                        $selfAssertedTokensOption
                     ),
                     new AllowedSecondFactorListUpdatedEvent(
                         $institutionConfigurationId,

--- a/src/Surfnet/Stepup/Tests/Configuration/InstitutionConfigurationTest.php
+++ b/src/Surfnet/Stepup/Tests/Configuration/InstitutionConfigurationTest.php
@@ -325,7 +325,7 @@ class InstitutionConfigurationTest extends AggregateRootScenarioTestCase
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = new SelfVetOption(false);
-        $selfAssertedTokensOption = new SelfAssertedTokensOption(true);
+        $selfAssertedTokensOption = new SelfAssertedTokensOption(false);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $expectedUseRaLocationsOption = new UseRaLocationsOption(false);
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Entity/InstitutionConfigurationOptions.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -70,6 +71,13 @@ class InstitutionConfigurationOptions
     public $selfVetOption;
 
     /**
+     * @ORM\Column(type="stepup_self_asserted_tokens_option", options={"default" : 0})
+     *
+     * @var SelfAssertedTokensOption
+     */
+    public $selfAssertedTokensOption;
+
+    /**
      * @ORM\Column(type="stepup_number_of_tokens_per_identity_option", options={"default" : 0})
      *
      * @var NumberOfTokensPerIdentityOption
@@ -82,7 +90,8 @@ class InstitutionConfigurationOptions
         ShowRaaContactInformationOption $showRaaContactInformationOption,
         VerifyEmailOption $verifyEmailOption,
         NumberOfTokensPerIdentityOption $numberOfTokensPerIdentityOption,
-        SelfVetOption $selfVetOption
+        SelfVetOption $selfVetOption,
+        SelfAssertedTokensOption $selfAssertedTokensOption
     ) {
         $options = new self;
 
@@ -92,6 +101,7 @@ class InstitutionConfigurationOptions
         $options->verifyEmailOption               = $verifyEmailOption;
         $options->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption;
         $options->selfVetOption = $selfVetOption;
+        $options->selfAssertedTokensOption = $selfAssertedTokensOption;
 
         return $options;
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/InstitutionConfigurationOptionsProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Configuration/Projector/InstitutionConfigurationOptionsProjector.php
@@ -22,6 +22,7 @@ use Broadway\ReadModel\Projector;
 use Surfnet\Stepup\Configuration\Event\InstitutionConfigurationRemovedEvent;
 use Surfnet\Stepup\Configuration\Event\NewInstitutionConfigurationCreatedEvent;
 use Surfnet\Stepup\Configuration\Event\NumberOfTokensPerIdentityOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Event\SelfAssertedTokensOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\SelfVetOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\ShowRaaContactInformationOptionChangedEvent;
 use Surfnet\Stepup\Configuration\Event\UseRaLocationsOptionChangedEvent;
@@ -58,7 +59,8 @@ final class InstitutionConfigurationOptionsProjector extends Projector
             $event->showRaaContactInformationOption,
             $event->verifyEmailOption,
             $event->numberOfTokensPerIdentityOption,
-            $event->selfVetOption
+            $event->selfVetOption,
+            $event->selfAssertedTokensOption
         );
 
         $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
@@ -100,6 +102,14 @@ final class InstitutionConfigurationOptionsProjector extends Projector
     {
         $institutionConfigurationOptions = $this->institutionConfigurationOptionsRepository->findConfigurationOptionsFor($event->institution);
         $institutionConfigurationOptions->selfVetOption = $event->selfVetOption;
+
+        $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
+    }
+
+    public function applySelfAssertedTokensOptionChangedEvent(SelfAssertedTokensOptionChangedEvent $event)
+    {
+        $institutionConfigurationOptions = $this->institutionConfigurationOptionsRepository->findConfigurationOptionsFor($event->institution);
+        $institutionConfigurationOptions->selfAssertedTokensOption = $event->selfAssertedTokensOption;
 
         $this->institutionConfigurationOptionsRepository->save($institutionConfigurationOptions);
     }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/InstitutionConfigurationOptionsController.php
@@ -88,6 +88,7 @@ final class InstitutionConfigurationOptionsController extends Controller
             'show_raa_contact_information' => $institutionConfigurationOptions->showRaaContactInformationOption,
             'verify_email'                 => $institutionConfigurationOptions->verifyEmailOption,
             'self_vet' => $institutionConfigurationOptions->selfVetOption,
+            'allow_self_asserted_tokens' => $institutionConfigurationOptions->selfAssertedTokensOption,
             'number_of_tokens_per_identity' => $numberOfTokensPerIdentity,
             'allowed_second_factors'       => $allowedSecondFactorList,
             'use_ra' => $institutionConfigurationOptionsMap->getAuthorizationOptionsByRole(InstitutionRole::useRa())->jsonSerialize(),

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/SelfAssertedTokensOptionType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/SelfAssertedTokensOptionType.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
+use TypeError;
+
+/**
+ * Custom Type for the SelfAssertedTokens options Value Object
+ */
+class SelfAssertedTokensOptionType extends Type
+{
+    const NAME = 'stepup_self_asserted_tokens_option';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getIntegerTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        if (!$value instanceof SelfAssertedTokensOption) {
+            throw new ConversionException(
+                sprintf(
+                    "Encountered illegal self vet option %s '%s', expected a 
+                    SelfAssertedTokensOption instance",
+                    is_object($value) ? get_class($value) : gettype($value),
+                    is_scalar($value) ? (string) $value : ''
+                )
+            );
+        }
+
+        return (int) $value->isEnabled();
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        try {
+            $selfAssertedTokensOption = new SelfAssertedTokensOption((bool) $value);
+        } catch (TypeError $e) {
+            // get nice standard message, so we can throw it keeping the exception chain
+            $doctrineExceptionMessage = ConversionException::conversionFailed(
+                $value,
+                $this->getName()
+            )->getMessage();
+
+            throw new ConversionException($doctrineExceptionMessage, 0, $e);
+        }
+
+        return $selfAssertedTokensOption;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/ReconfigureInstitutionConfigurationOptionsCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/Command/ReconfigureInstitutionConfigurationOptionsCommand.php
@@ -61,6 +61,13 @@ final class ReconfigureInstitutionConfigurationOptionsCommand extends AbstractCo
     public $selfVetOption;
 
     /**
+     * @Assert\Type(type="boolean")
+     *
+     * @var bool
+     */
+    public $selfAssertedTokensOption;
+
+    /**
      * @Assert\Type(type="integer")
      *
      * @var int

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/CommandHandler/InstitutionConfigurationCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Configuration/CommandHandler/InstitutionConfigurationCommandHandler.php
@@ -31,6 +31,7 @@ use Surfnet\Stepup\Configuration\Value\Location;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -97,6 +98,9 @@ class InstitutionConfigurationCommandHandler extends SimpleCommandHandler
         );
         $institutionConfiguration->configureSelfVetOption(
             new SelfVetOption((bool)$command->selfVetOption)
+        );
+        $institutionConfiguration->configureSelfAssertedTokensOption(
+            new SelfAssertedTokensOption((bool)$command->selfAssertedTokensOption)
         );
         $institutionConfiguration->configureNumberOfTokensPerIdentityOption(
             new NumberOfTokensPerIdentityOption($command->numberOfTokensPerIdentityOption)

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
@@ -47,6 +47,7 @@ use Surfnet\Stepup\Configuration\Value\Location;
 use Surfnet\Stepup\Configuration\Value\NumberOfTokensPerIdentityOption;
 use Surfnet\Stepup\Configuration\Value\RaLocationId;
 use Surfnet\Stepup\Configuration\Value\RaLocationName;
+use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
 use Surfnet\Stepup\Configuration\Value\SelfVetOption;
 use Surfnet\Stepup\Configuration\Value\ShowRaaContactInformationOption;
 use Surfnet\Stepup\Configuration\Value\UseRaLocationsOption;
@@ -81,6 +82,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $numberOfTokensPerIdentityOption        = new NumberOfTokensPerIdentityOption(0);
         $defaultAllowedSecondFactorList         = AllowedSecondFactorList::blank();
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
         $selectRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::selectRaa());
@@ -96,7 +98,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $defaultShowRaaContactInformationOption,
                     $defaultVerifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -140,6 +143,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
         $selectRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::selectRaa());
@@ -154,7 +158,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new UseRaOptionChangedEvent(
                     $institutionConfigurationId,
@@ -188,6 +193,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(1);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $defaultAllowedSecondFactorList  = AllowedSecondFactorList::blank();
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
@@ -215,7 +221,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -255,6 +262,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
 
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
@@ -286,7 +294,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -332,6 +341,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
         $selectRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::selectRaa());
@@ -359,7 +369,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -405,6 +416,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
 
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
@@ -437,7 +449,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new AllowedSecondFactorListUpdatedEvent(
                     $institutionConfigurationId,
@@ -489,6 +502,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
         $selectRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::selectRaa());
@@ -514,7 +528,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new UseRaOptionChangedEvent(
                     $institutionConfigurationId,
@@ -561,6 +576,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
 
         $this->scenario
             ->withAggregateId($institutionConfigurationId)
@@ -572,7 +588,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
             ])
             ->when($command)
@@ -610,6 +627,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -622,7 +640,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -657,6 +676,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -669,7 +689,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -712,6 +733,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -724,7 +746,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when($command);
@@ -752,6 +775,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -764,7 +788,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when($command);
@@ -792,6 +817,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -804,7 +830,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -847,6 +874,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -859,7 +887,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -894,6 +923,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $verifyEmailOption               = new VerifyEmailOption(true);
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $newSelfVetOption = new SelfVetOption(true);
         $useRaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRa());
         $useRaaOption = InstitutionAuthorizationOption::getDefault(InstitutionRole::useRaa());
@@ -919,7 +949,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 
             ])
@@ -973,6 +1004,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -985,7 +1017,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when($command);
@@ -1011,6 +1044,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -1023,7 +1057,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 )
             ])
             ->when($command);
@@ -1046,6 +1081,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -1058,7 +1094,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                     $showRaaContactInformationOption,
                     $verifyEmailOption,
                     $numberOfTokensPerIdentityOption,
-                    $selfVetOption
+                    $selfVetOption,
+                    $selfAssertedTokensOption
                 ),
                 new RaLocationAddedEvent(
                     $institutionConfigurationId,
@@ -1094,6 +1131,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $showRaaContactInformationOption = new ShowRaaContactInformationOption(true);
         $verifyEmailOption               = new VerifyEmailOption(true);
         $selfVetOption = SelfVetOption::getDefault();
+        $selfAssertedTokensOption = SelfAssertedTokensOption::getDefault();
         $numberOfTokensPerIdentityOption = new NumberOfTokensPerIdentityOption(0);
 
         $this->scenario
@@ -1107,7 +1145,8 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
                         $showRaaContactInformationOption,
                         $verifyEmailOption,
                         $numberOfTokensPerIdentityOption,
-                        $selfVetOption
+                        $selfVetOption,
+                        $selfAssertedTokensOption
                     )
                 ]
             )

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Configuration/CommandHandler/InstitutionConfigurationCommandHandlerTest.php
@@ -205,6 +205,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->selfVetOption = $selfVetOption->isEnabled();
+        $command->allowedSecondFactors = $selfAssertedTokensOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         $command->useRaOption = $useRaOption->jsonSerialize();
         $command->useRaaOption = $useRaaOption->jsonSerialize();
@@ -278,6 +279,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->selfVetOption = $selfVetOption->isEnabled();
+        $command->allowedSecondFactors = $selfAssertedTokensOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         $command->useRaOption = $useRaOption->jsonSerialize();
         $command->useRaaOption = $useRaaOption->jsonSerialize();
@@ -356,6 +358,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->useRaLocationsOption            = $useRaLocationsOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->selfVetOption = $selfVetOption->isEnabled();
+        $command->allowedSecondFactors = $selfAssertedTokensOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         $command->allowedSecondFactors            = [];
 
@@ -436,6 +439,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->selfVetOption = $selfVetOption->isEnabled();
+        $command->allowedSecondFactors = $selfAssertedTokensOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         $command->allowedSecondFactors = $secondFactorsToAllow;
 
@@ -515,6 +519,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->selfVetOption = $selfVetOption->isEnabled();
+        $command->allowedSecondFactors = $selfAssertedTokensOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         $command->allowedSecondFactors = $secondFactorsToAllow;
 
@@ -936,6 +941,7 @@ class InstitutionConfigurationCommandHandlerTest extends CommandHandlerTest
         $command->showRaaContactInformationOption = $showRaaContactInformationOption->isEnabled();
         $command->verifyEmailOption               = $verifyEmailOption->isEnabled();
         $command->selfVetOption = $newSelfVetOption->isEnabled();
+        $command->allowedSecondFactors = $selfAssertedTokensOption->isEnabled();
         $command->numberOfTokensPerIdentityOption = $numberOfTokensPerIdentityOption->getNumberOfTokensPerIdentity();
         $command->allowedSecondFactors = [];
 

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Controller/InstitutionConfigurationController.php
@@ -123,6 +123,7 @@ final class InstitutionConfigurationController extends AbstractController
                 'show_raa_contact_information' => $options->showRaaContactInformationOption,
                 'verify_email' => $options->verifyEmailOption,
                 'self_vet' => $options->selfVetOption,
+                'allow_self_asserted_tokens' => $options->selfAssertedTokensOption,
                 'number_of_tokens_per_identity' => $numberOfTokensPerIdentity,
                 'allowed_second_factors' => $allowedSecondFactorMap->getAllowedSecondFactorListFor(
                     $options->institution
@@ -168,6 +169,7 @@ final class InstitutionConfigurationController extends AbstractController
             $command->numberOfTokensPerIdentityOption = $options['number_of_tokens_per_identity'];
             $command->allowedSecondFactors            = $options['allowed_second_factors'];
             $command->selfVetOption = $options['self_vet'];
+            $command->selfAssertedTokensOption = $options['allow_self_asserted_tokens'];
 
             // The useRa, useRaa and selectRaa options are optional
             $command->useRaOption = isset($options['use_ra']) ? $options['use_ra'] : null;

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/greater_thant_zero_number_of_tokens_per_identity_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/greater_thant_zero_number_of_tokens_per_identity_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => -1,
             'allowed_second_factors' => [],
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_allow_self_asserted_tokens_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_allow_self_asserted_tokens_option.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2016 SURFnet B.V.
+ * Copyright 2022 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
-            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 1,
+            'allowed_second_factors' => [],
         ]
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_self_vet_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_self_vet_option.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2016 SURFnet B.V.
+ * Copyright 2022 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ return [
             'use_ra_locations' => true,
             'show_raa_contact_information' => true,
             'verify_email' => false,
-            'self_vet' => false,
             'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 1,
+            'allowed_second_factors' => [],
         ]
     ]
 ];

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_show_raa_contact_information_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_show_raa_contact_information_option.php
@@ -24,6 +24,7 @@ return [
             'use_ra_locations' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 2,
             'allowed_second_factors' => [],
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_use_ra_locations_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/missing_use_ra_locations_option.php
@@ -24,6 +24,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 1,
             'allowed_second_factors' => [],
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_array_allowed_second_factors_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_array_allowed_second_factors_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 3,
             'allowed_second_factors' => false,
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_array_use_raa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_array_use_raa.php
@@ -25,6 +25,7 @@ return [
             "show_raa_contact_information" => true,
             "verify_email" => true,
             'self_vet' => true,
+            'allow_self_asserted_tokens' => true,
             "allowed_second_factors" => [],
             "number_of_tokens_per_identity" => 2,
             "use_ra" => [],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_boolean_show_raa_contact_information_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_boolean_show_raa_contact_information_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 1,
             'allowed_second_factors' => [],
         ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_boolean_use_ra_locations_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_boolean_use_ra_locations_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => 1,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 2,
             'allowed_second_factors' => [],
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_integer_ii_number_of_tokens_per_identity_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_integer_ii_number_of_tokens_per_identity_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 3.1415,
             'allowed_second_factors' => [],
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_integer_number_of_tokens_per_identity_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_integer_number_of_tokens_per_identity_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => true,
             'allowed_second_factors' => [],
         ]

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_strings_allowed_second_factors_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_strings_allowed_second_factors_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 3,
             'allowed_second_factors' => [
                 1,

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_valid_second_factor_types_allowed_second_factors_option.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_valid_second_factor_types_allowed_second_factors_option.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 4,
             'allowed_second_factors' => [
                 'faux_second_factor'

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_whitelisted_institution_use_raa.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/not_whitelisted_institution_use_raa.php
@@ -25,6 +25,7 @@ return [
             "show_raa_contact_information" => true,
             "verify_email" => true,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             "allowed_second_factors" => [],
             "number_of_tokens_per_identity" => 2,
             "use_ra" => ["surfnet.nl"],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/with_error_in_second_institution.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/with_error_in_second_institution.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 1,
             'allowed_second_factors' => [],
         ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/with_extra_options.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/Fixtures/invalid_reconfigure_institution_request/with_extra_options.php
@@ -25,6 +25,7 @@ return [
             'show_raa_contact_information' => true,
             'verify_email' => false,
             'self_vet' => false,
+            'allow_self_asserted_tokens' => false,
             'number_of_tokens_per_identity' => 2,
             'allowed_second_factors' => [],
             'extra_option' => 'cannot be handled',

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Tests/Validator/ReconfigureInstitutionRequestValidatorTest.php
@@ -20,7 +20,7 @@ namespace Surfnet\StepupMiddleware\ManagementBundle\Tests\Validator;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Mockery;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Surfnet\Stepup\Configuration\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Institution as IdentityInstitution;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
@@ -46,7 +46,7 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
                 $fixture['expectedPropertyPath'],
                 $fixture['expectErrorMessageToContain']
             ];
-        };
+        }
 
         return $dataSet;
     }
@@ -169,6 +169,7 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
                 'show_raa_contact_information' => true,
                 'verify_email'                 => false,
                 'self_vet' => false,
+                'allow_self_asserted_tokens' => false,
                 'number_of_tokens_per_identity' => 1,
                 'allowed_second_factors'       => [],
             ],
@@ -214,6 +215,7 @@ class ReconfigureInstitutionRequestValidatorTest extends TestCase
                 'show_raa_contact_information' => true,
                 'verify_email'                 => true,
                 'self_vet' => false,
+                'allow_self_asserted_tokens' => false,
                 'number_of_tokens_per_identity' => 3,
                 'allowed_second_factors'       => [],
             ],

--- a/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
+++ b/src/Surfnet/StepupMiddleware/ManagementBundle/Validator/ReconfigureInstitutionRequestValidator.php
@@ -129,6 +129,7 @@ final class ReconfigureInstitutionRequestValidator extends ConstraintValidator
             'show_raa_contact_information',
             'verify_email',
             'self_vet',
+            'allow_self_asserted_tokens',
             'number_of_tokens_per_identity',
             'allowed_second_factors',
         ];


### PR DESCRIPTION
This PR has two commits. One commit deals with the write side of things concerning the self-asserted token registration feature toggle. The other commit is focused on the read side. The Middleware API is consulted by self service and RA for guidance on which features are enabled for each insitution. Adding the 'allow self-asserted token registration' toggle to the InstitutionConfigurationController::getForInstitutionAction was part of that exercise. 

See: https://www.pivotaltracker.com/story/show/181933607
See task 1 of: https://www.pivotaltracker.com/story/show/181934073