### PR TITLE
Hash the safe-store secret

### DIFF
--- a/src/Surfnet/Stepup/Helper/RecoveryTokenSecretHelper.php
+++ b/src/Surfnet/Stepup/Helper/RecoveryTokenSecretHelper.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Helper;
+
+use Surfnet\Stepup\Identity\Value\HashedSecret;
+use Surfnet\Stepup\Identity\Value\UnhashedSecret;
+
+/**
+ * Converts the unhashed secret to a hashed version
+ *
+ * Mainly created in order to allow mocking of this feature for
+ * test purposes.
+ */
+class RecoveryTokenSecretHelper
+{
+    public function hash(UnhashedSecret $unhashedSecret): HashedSecret
+    {
+        return $unhashedSecret->hashSecret();
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
@@ -18,7 +18,9 @@
 
 namespace Surfnet\Stepup\Identity\Event;
 
+use Surfnet\Stepup\Identity\Value\HashableSecret;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
+use Surfnet\Stepup\Identity\Value\RecoveryTokenIdentifier;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenType;
 use Surfnet\Stepup\Identity\Value\SafeStore;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
@@ -54,7 +56,7 @@ class SafeStoreSecretRecoveryTokenPossessionPromisedEvent extends IdentityEvent 
     public $recoveryTokenId;
 
     /**
-     * @var \Surfnet\Stepup\Identity\Value\SafeStore
+     * @var \Surfnet\Stepup\Identity\Value\HashableSecret
      */
     public $secret;
 
@@ -77,7 +79,7 @@ class SafeStoreSecretRecoveryTokenPossessionPromisedEvent extends IdentityEvent 
         IdentityId $identityId,
         Institution $identityInstitution,
         RecoveryTokenId $recoveryTokenId,
-        SafeStore $secret,
+        RecoveryTokenIdentifier $secret,
         CommonName $commonName,
         Email $email,
         Locale $preferredLocale

--- a/src/Surfnet/Stepup/Identity/Value/ForgottenSecret.php
+++ b/src/Surfnet/Stepup/Identity/Value/ForgottenSecret.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+/**
+ * When Identity applied the right to be forgotten, this
+ * marker VO is a stand in for the forgotten secret.
+ */
+class ForgottenSecret implements Secret
+{
+    private const FORGOTTEN_TEXT = 'SECRET-FORGOTTEN-BY-USER';
+
+    public function getSecret(): string
+    {
+        return self::FORGOTTEN_TEXT;
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Value/HashableSecret.php
+++ b/src/Surfnet/Stepup/Identity/Value/HashableSecret.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+interface HashableSecret extends Secret
+{
+    /**
+     * Hash the secret set in the value objects property, and hash it.
+     * Returns a new instance.
+     */
+    public function hashSecret(): Secret;
+}

--- a/src/Surfnet/Stepup/Identity/Value/HashedSecret.php
+++ b/src/Surfnet/Stepup/Identity/Value/HashedSecret.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+/**
+ * The hashed secret, used on the safe-store recovery token type
+ */
+class HashedSecret implements Secret
+{
+    private $secret;
+
+    public function __construct(string $secret)
+    {
+        $this->secret = $secret;
+    }
+
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Value/RecoveryTokenIdentifierFactory.php
+++ b/src/Surfnet/Stepup/Identity/Value/RecoveryTokenIdentifierFactory.php
@@ -28,7 +28,7 @@ final class RecoveryTokenIdentifierFactory
             return new PhoneNumber($recoveryTokenIdentifier);
         }
         if ($type->isSafeStore()) {
-            return new SafeStore($recoveryTokenIdentifier);
+            return new SafeStore(new HashedSecret($recoveryTokenIdentifier));
         }
         throw new InvalidArgumentException(sprintf('Unsupported type given while building recovery method: "%s"', $type));
     }

--- a/src/Surfnet/Stepup/Identity/Value/SafeStore.php
+++ b/src/Surfnet/Stepup/Identity/Value/SafeStore.php
@@ -19,27 +19,26 @@
 namespace Surfnet\Stepup\Identity\Value;
 
 /**
- * Marker recovery token identifier for the SafeStore token type
+ * Recovery token identifier for the SafeStore token type
  */
-final class SafeStore implements RecoveryTokenIdentifier
+class SafeStore implements RecoveryTokenIdentifier
 {
-    private $hashedSecret;
+    /** @var Secret */
+    private $secret;
 
-
-    public function __construct(string $hashedSecret)
+    public function __construct(Secret $hashedSecret)
     {
-        $this->hashedSecret = $hashedSecret;
+        $this->secret = $hashedSecret;
     }
-
 
     public static function unknown(): self
     {
-        return new self('');
+        return new self(new ForgottenSecret());
     }
 
     public function getValue()
     {
-        return $this->hashedSecret;
+        return $this->secret->getSecret();
     }
 
     public function equals($other): bool
@@ -49,7 +48,7 @@ final class SafeStore implements RecoveryTokenIdentifier
 
     public function __toString(): string
     {
-        return $this->hashedSecret;
+        return $this->getValue();
     }
 
     public function jsonSerialize(): string

--- a/src/Surfnet/Stepup/Identity/Value/Secret.php
+++ b/src/Surfnet/Stepup/Identity/Value/Secret.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+interface Secret
+{
+    public function getSecret(): string;
+}

--- a/src/Surfnet/Stepup/Identity/Value/UnhashedSecret.php
+++ b/src/Surfnet/Stepup/Identity/Value/UnhashedSecret.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+/**
+ * Unhashed secret
+ *
+ * This VO can be used to hash the unhashed secret
+ *
+ * A HashedSecret is constructed when calling the immutable hashSecret
+ * method. This method will return an instance of HashedSecret.
+ */
+class UnhashedSecret implements HashableSecret
+{
+    /**
+     * Cost to compute the hash (10 is the default baseline value for hash_password)
+     * Increasing this value also increases the time to generate it.
+     */
+    private const COST = 14;
+
+    /**
+     * The default password_hash alog is Bcrypt, other options include:\
+     *  PASSWORD_ARGON2I and PASSWORD_ARGON2ID. More information in the PHP man pages
+     * https://www.php.net/manual/en/function.password-hash.php
+     */
+    private const ALGORITHM = PASSWORD_BCRYPT;
+
+    private $secret;
+
+    public function hashSecret(): Secret
+    {
+        $hashedSecret = password_hash(
+            $this->secret,
+            self::ALGORITHM,
+            ['cost' => self::COST]
+        );
+        return new HashedSecret($hashedSecret);
+    }
+
+    public function __construct(string $secret)
+    {
+        $this->secret = $secret;
+    }
+
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+}

--- a/src/Surfnet/Stepup/Tests/Identity/Value/RecoveryTokenIdentifierFactoryTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Value/RecoveryTokenIdentifierFactoryTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\Stepup\Tests\Identity\Value;
 
 use PHPUnit\Framework\TestCase;
+use Surfnet\Stepup\Identity\Value\HashedSecret;
 use Surfnet\Stepup\Identity\Value\PhoneNumber;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenIdentifierFactory;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenType;
@@ -36,7 +37,7 @@ final class RecoveryTokenIdentifierFactoryTest extends TestCase
             RecoveryTokenIdentifierFactory::forType(RecoveryTokenType::sms(), '+31 (0) 12345678')
         );
         $this->assertEquals(
-            new SafeStore('super-secret'),
+            new SafeStore(new HashedSecret('super-secret')),
             RecoveryTokenIdentifierFactory::forType(RecoveryTokenType::safeStore(), 'super-secret')
         );
 

--- a/src/Surfnet/Stepup/Tests/Identity/Value/SafeStoreTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Value/SafeStoreTest.php
@@ -19,9 +19,12 @@
 namespace Surfnet\Stepup\Tests\Identity\Value;
 
 use PHPUnit\Framework\TestCase as UnitTest;
+use Surfnet\Stepup\Identity\Value\HashedSecret;
 use Surfnet\Stepup\Identity\Value\PhoneNumber;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenIdentifier;
 use Surfnet\Stepup\Identity\Value\SafeStore;
+use Surfnet\Stepup\Identity\Value\UnhashedSecret;
+use function password_verify;
 
 class SafeStoreTest extends UnitTest
 {
@@ -30,7 +33,8 @@ class SafeStoreTest extends UnitTest
      */
     public function test_creation_of_safe_store()
     {
-        $instance = new SafeStore(password_hash('super-secret', PASSWORD_BCRYPT));
+        $unhashed = new UnhashedSecret('super-secret');
+        $instance = new SafeStore($unhashed->hashSecret());
         $this->assertInstanceOf(RecoveryTokenIdentifier::class, $instance);
         $this->assertTrue(password_verify('super-secret', $instance->getValue()));
     }
@@ -40,15 +44,15 @@ class SafeStoreTest extends UnitTest
      */
     public function test_equals()
     {
-        $safeStore = new SafeStore('a');
-        $safeStore2 = new SafeStore('a');
+        $safeStore = new SafeStore(new UnhashedSecret('a'));
+        $safeStore2 = new SafeStore(new UnhashedSecret('a'));
         // For now this is the case, as the safe store is a marker token type
         $this->assertTrue($safeStore->equals($safeStore2));
 
         $phone = new PhoneNumber('+30 (0) 612314353');
         $this->assertFalse($safeStore->equals($phone));
 
-        $safeStore3 = new SafeStore('b');
+        $safeStore3 = new SafeStore(new HashedSecret('$2a$12$R9h/cIPz0gi.URNNX3kh2OPST9/PgBkqquzi.Ss7KIUgO2t0jWMUW'));
         $this->assertFalse($safeStore->equals($safeStore3));
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -170,3 +170,7 @@ services:
             $eventSourcingRepository: '@surfnet_stepup.repository.identity'
             $apiRepository: '@surfnet_stepup_middleware_api.repository.identity'
             $logger: '@logger'
+
+    Surfnet\Stepup\Helper\RecoveryTokenSecretHelper:
+        class: Surfnet\Stepup\Helper\RecoveryTokenSecretHelper
+

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/command_handlers.yml
@@ -10,6 +10,7 @@ services:
             - '@Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper'
             - "@surfnet_stepup_middleware_api.service.institution_configuration_options"
             - "@surfnet_stepup.service.loa_resolution"
+            - '@Surfnet\Stepup\Helper\RecoveryTokenSecretHelper'
         tags: [{ name: command_bus.command_handler }]
 
     surfnet_stepup_middleware_command_handling.command_handler.registration_authority_command_handler:

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
@@ -27,6 +27,7 @@ use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
 use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Exception\DomainException;
+use Surfnet\Stepup\Helper\RecoveryTokenSecretHelper;
 use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Helper\UserDataFilterInterface;
 use Surfnet\Stepup\Identity\Entity\ConfigurableSettings;
@@ -83,6 +84,11 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
      */
     private $configService;
 
+    /**
+     * @var IdentityProjectionRepository|m\MockInterface
+     */
+    private $identityProjectionRepository;
+
 
     public function setUp(): void
     {
@@ -117,7 +123,8 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
             $secondFactorTypeService,
             $secondFactorProvePossessionHelper,
             $this->configService,
-            $this->loaResolutionService
+            $this->loaResolutionService,
+            m::mock(RecoveryTokenSecretHelper::class)
         );
     }
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -28,6 +28,7 @@ use Mockery as m;
 use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\Value\AllowedSecondFactorList;
 use Surfnet\Stepup\DateTime\DateTime;
+use Surfnet\Stepup\Helper\RecoveryTokenSecretHelper;
 use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Helper\UserDataFilterInterface;
 use Surfnet\Stepup\Identity\Entity\ConfigurableSettings;
@@ -159,7 +160,8 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
             $this->secondFactorTypeService,
             $this->secondFactorProvePossessionHelper,
             $this->configService,
-            $this->loaResolutionService
+            $this->loaResolutionService,
+            m::mock(RecoveryTokenSecretHelper::class)
         );
     }
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -24,8 +24,8 @@ use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
 use Broadway\EventStore\EventStore as EventStoreInterface;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
-use Surfnet\Stepup\Configuration\EventSourcing\InstitutionConfigurationRepository;
 use Surfnet\Stepup\DateTime\DateTime;
+use Surfnet\Stepup\Helper\RecoveryTokenSecretHelper;
 use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Helper\UserDataFilterInterface;
 use Surfnet\Stepup\Identity\Entity\ConfigurableSettings;
@@ -95,7 +95,8 @@ class SecondFactorRevocationTest extends CommandHandlerTest
             m::mock(SecondFactorTypeService::class)->shouldIgnoreMissing(),
             m::mock(SecondFactorProvePossessionHelper::class)->shouldIgnoreMissing(),
             m::mock(InstitutionConfigurationOptionsService::class)->shouldIgnoreMissing(),
-            m::mock(LoaResolutionService::class)
+            m::mock(LoaResolutionService::class),
+            m::mock(RecoveryTokenSecretHelper::class)
         );
     }
 


### PR DESCRIPTION
As promised in #356, the actual hashing of the safe-store secret is now implemented.

See the three commit messages for greater detail on the context of this PR

This concludes task 4 of https://www.pivotaltracker.com/story/show/181934073
And see: https://www.pivotaltracker.com/story/show/181934021 for the design decisions regarding the hashing algorithm setup