### PR TITLE
Process self asserted vetting commands

### DIFF
--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -85,20 +85,39 @@ Example of possible error messages. These may differ in the real world, but give
 }
 ```
 
-#### Response
+### Allowed to create and delete recovery tokens?
+
+- URL: `http://middleware.tld/authorization/may-register-recovery-tokens/{identityId}`
+- Method: GET
+- Request parameters:
+    - identityId: (required) UUIDv4 of the identity to assert the authorization for
+
+### Response
 `200 OK`
 ```json
-[
-    {
-        "name": "SURFnet"
-    },
-    {
-        "name": "Ibuildings"
-    }
-]
+{   
+    "code": 200
+}
 ```
 
+`403 Forbidden`
+
+Example of possible error messages. These may differ in the real world, but give a grasp on what they should look like.
+
+```json
+{   
+  "code": 403,
+  "errors": [
+    "Not permitted: institution does not allow self-asserted tokens.",
+    "Not permitted: no previous self asserted token was registered."
+  ]
+}
+```
+
+
 ## Command API
+
+For documentation of the commands that can be handled with the Command API. Please consult [this document](MiddlewareAPICommands.md).
 
 ### Request
 URL: `http://middleware.tld/command/`

--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -307,7 +307,7 @@ Request parameters:
 ### Unverified Second Factors - Search Unverified Second Factors
 
 #### Request
-URL: `http://middleware.tld/unverified-second-factors?{identityId=}{&verificationNonce=}(&p=}`
+URL: `http://middleware.tld/unverified-second-factors?{identityId=}{&verificationNonce=}{&p=}`
 Method: GET
 Request parameters:
 - IdentityId: (optional) UUIDv4 of the identity to search for
@@ -363,7 +363,7 @@ Request parameters:
 ### Verified Second Factor - Search Verified Second Factors
 
 #### Request
-URL: `http://middleware.tld/verified-second-factors?{actorId=}&{identityId=}{&secondFactorId=}{&registrationCode=}(&p=}`
+URL: `http://middleware.tld/verified-second-factors?{actorId=}&{identityId=}{&secondFactorId=}{&registrationCode=}{&p=}`
 Method: GET
 Request parameters:
 - actorId: (required) UUIDv4 of the actor. When provided, the actor id can be used to determine the actor role.
@@ -373,7 +373,7 @@ Request parameters:
 - p: (optional, default 1) integer, the requested result page
 
 #### Request
-URL: `http://middleware.tld/verified-second-factors-of-identity?{identityId=}(&p=}`
+URL: `http://middleware.tld/verified-second-factors-of-identity?{identityId=}{&p=}`
 Method: GET
 Request parameters:
 - IdentityId: (optional) UUIDv4 of the identity to search for
@@ -429,7 +429,7 @@ Request parameters:
 ### Vetted Second Factor - Search Vetted Second Factors
 
 #### Request
-URL: `http://middleware.tld/vetted-second-factors?{identityId=}(&p=}`
+URL: `http://middleware.tld/vetted-second-factors?{identityId=}{&p=}`
 Method: GET
 Request parameters:
 - identityId: (optional) UUIDv4 of the identity to search for
@@ -454,7 +454,57 @@ Request parameters:
 }
 ```
 
+### Recovery Token - Single Recovery Token
 
+#### Request
+URL: `http://middleware.tld/recovery_token/{recoveryTokenIdId}`
+Method: GET
+Request parameters:
+- recoveryTokenIdId: (required) UUIDv4 of the Recovery Token to get
+
+#### Response
+`200 OK`
+```json
+{
+    "id": "c732d0ac-9f61-4ae1-924e-40d5172fca86",
+    "type": "safe-store",
+    "recovery_token_identifier": "$2a$12$R9h/cIPz0gi.URNNX3kh2OPST9/PgBkqquzi.Ss7KIUgO2t0jWMUW"
+}
+```
+
+### Recovery Token - Search Recovery Tokens
+
+#### Request
+URL: `http://middleware.tld/recovery_tokens?{identityId=}{type=}{&p=}`
+Method: GET
+Request parameters:
+- identityId: (optional) UUIDv4 of the identity to search for
+- type: (optional) UUIDv4 of the identity to search for
+- p: (optional, default 1) integer, the requested result page
+
+#### Response
+`200 OK`
+```json
+{
+    "collection": {
+        "total_items": 2,
+        "page": 1,
+        "page_size": 25
+    },
+    "items": [
+        {
+            "id": "c732d0ac-9f61-4ae1-924e-40d5172fca86",
+            "type": "yubikey",
+            "second_factor_identifier": "$2a$12$R9h/cIPz0gi.URNNX3kh2OPST9/PgBkqquzi.Ss7KIUgO2t0jWMUW"
+        },
+        {
+          "id": "d925d0df-8f61-8ef1-924e-40d5172fca86",
+          "type": "sms",
+          "second_factor_identifier": "+31 (0) 610101010"
+        }
+    ]
+}
+```
 
 ## Registration Authorities
 
@@ -638,7 +688,7 @@ Request parameters:
 ### Registration Authority Candidate - Search RaCandidate
 
 #### Request
-URL: `http://middleware.tld/ra-candidate?institution={&commonName=}{&email=}{&secondFactorTypes=}{&raInstitution}(&p=}`
+URL: `http://middleware.tld/ra-candidate?institution={&commonName=}{&email=}{&secondFactorTypes=}{&raInstitution}{&p=}`
 Method: GET
 Request parameters:
 - institution: (required) string, the institution as scope determination

--- a/docs/MiddlewareAPICommands.md
+++ b/docs/MiddlewareAPICommands.md
@@ -1,0 +1,109 @@
+# Middleware APIs Commands
+
+## Identity context
+
+### AccreditIdentityCommand
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+|`role`|yes|`string`|The rolename the Identity is accredited with, possible options `[ra, raa]`|
+|`contactInformation`|yes|`string`|Contact information of the Identity|
+|`raInstitution`|yes|`string`|UUID of the RA Institution the Identity is accredited a role at.|
+
+### AddToWhitelistCommand
+- Management command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`institutionsToBeAdded`|yes|`array` of `string`|A list of Institutions to be added to the whitelist|
+
+### AmendRegistrationAuthorityInformationCommand
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`contactInformation`|yes|`string`|Contact information of the Identity|
+|`raInstitution`|yes|`string`|UUID of the RA Institution the Identity is amending information at.|
+
+### AppointRoleCommand
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`role`|yes|`string`|The rolename the Identity is accredited with, possible options `[ra, raa]`|
+|`raInstitution`|yes|`string`|UUID of the RA Institution the Identity is appointed a role at.|
+
+### BootstrapIdentityWithYubikeySecondFactorCommand
+Used to bootstrap SRAA users
+
+- Admin command, fired from command line using Symfony console command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`nameId`|yes|`string`|The nameId of the Identity|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+|`email`|yes|`string`, `email`|Email address of the Identity|
+|`commanName`|yes|`string`|Common name of the Identity|
+|`preferredLocale`|yes|`string`|Preferred locale of the Identity. Possible options `[nl, en]`|
+|`secondFactorId`|yes|`string`|UUID of the second factor token of the Identity|
+|`yubikeyPublicId`|yes|`string`|The public id of the yubikey the Identity is going to use|
+
+### CreateIdentityCommand
+- SelfService command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`id`|yes|`string`|UUID of the Identity|
+|`nameId`|yes|`string`|The nameId of the Identity|
+|`email`|yes|`string`, `email`|Email address of the Identity|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+|`commanName`|yes|`string`|Common name of the Identity|
+|`preferredLocale`|yes|`string`|Preferred locale of the Identity. Possible options `[nl, en]`|
+
+### ExpressLocalePreferenceCommand
+- SelfService command
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`preferredLocale`|yes|`string`|Preferred locale of the Identity. Possible options `[nl, en]`|
+
+### ForgetIdentityCommand
+
+- Deprovision command
+- Management command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`nameId`|yes|`string`|NameId of the Identity to be forgotten|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+
+### MigrateVettedSecondFactorCommand
+
+- Admin command, fired from command line using Symfony console command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`sourceIdentityId`|yes|`string`|UUID of the Identity the tokens are copied from|
+|`targetIdentityId`|yes|`string`|UUID of the Identity the tokens are copied to|
+|`sourceSecondFactorId`|yes|`string`|The source second factor UUID that is to be moved|
+|`targetSecondFactorId`|yes|`string`|The new destination second factor UUID|
+
+
+### PromiseSafeStoreSecretTokenPossessionCommand
+- SelfService command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`recoveryTokenId`|yes|`string`|The ID of the recovery code to create|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`recoveryTokenType`|yes|`string`|The recovery token type, defaults to 'safe-store'|
+|`secret`|yes|`string`|The unhashed safe-store password|

--- a/docs/postman/3.json
+++ b/docs/postman/3.json
@@ -343,6 +343,80 @@
 			"response": []
 		},
 		{
+			"name": "/recovery_tokens",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "http://middleware.stepup.example.com/recovery_tokens?identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1",
+					"protocol": "http",
+					"host": [
+						"middleware",
+						"stepup",
+						"example",
+						"com"
+					],
+					"path": [
+						"recovery_tokens"
+					],
+					"query": [
+						{
+							"key": "identityId",
+							"value": "8b5cdd14-74b1-43a2-a806-c171728b1bf1"
+						}
+					]
+				},
+				"description": "- `identityId` optional get param\n- `verificationNonce` optional get param\n- `p` page"
+			},
+			"response": []
+		},
+		{
+			"name": "/recovery_token",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "http://middleware.stepup.example.com/recovery_tokens?identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1",
+					"protocol": "http",
+					"host": [
+						"middleware",
+						"stepup",
+						"example",
+						"com"
+					],
+					"path": [
+						"recovery_tokens"
+					],
+					"query": [
+						{
+							"key": "identityId",
+							"value": "8b5cdd14-74b1-43a2-a806-c171728b1bf1"
+						}
+					]
+				},
+				"description": "- `identityId` optional get param\n- `verificationNonce` optional get param\n- `p` page"
+			},
+			"response": []
+		}
+		{
 			"name": "/vetted-second-factor/{secondFactorId} copy",
 			"request": {
 				"method": "GET",

--- a/docs/postman/3.json
+++ b/docs/postman/3.json
@@ -977,6 +977,38 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "/authorization/may-register-recovery-tokens",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "http://middleware.stepup.example.com/authorization/may-register-recovery-tokens/2fb0b832-653f-408a-812d-9c84f82fcf02",
+					"protocol": "http",
+					"host": [
+						"middleware",
+						"stepup",
+						"example",
+						"com"
+					],
+					"path": [
+						"authorization",
+						"may-register-recovery-tokens",
+						"2fb0b832-653f-408a-812d-9c84f82fcf02"
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"auth": {

--- a/src/Surfnet/Migrations/Version20220628091800.php
+++ b/src/Surfnet/Migrations/Version20220628091800.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220628091800 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE identity_self_asserted_token_options (identity_id VARCHAR(36) NOT NULL, possessed_token TINYINT(1) NOT NULL, possessed_self_asserted_token TINYINT(1) NOT NULL, PRIMARY KEY(identity_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE identity_self_asserted_token_options');
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Api/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Api/Identity.php
@@ -212,6 +212,12 @@ interface Identity extends AggregateRoot
         SecondFactorTypeService $secondFactorTypeService
     ): void;
 
+    public function registerSelfAssertedSecondFactor(
+        SecondFactorIdentifier $secondFactorIdentifier,
+        SecondFactorTypeService $secondFactorTypeService,
+        RecoveryTokenId $recoveryTokenId
+    ): void;
+
     /**
      * Migrate a token from the source identity to the target identity
      */

--- a/src/Surfnet/Stepup/Identity/Entity/RecoveryTokenCollection.php
+++ b/src/Surfnet/Stepup/Identity/Entity/RecoveryTokenCollection.php
@@ -18,8 +18,10 @@
 
 namespace Surfnet\Stepup\Identity\Entity;
 
+use Surfnet\Stepup\Exception\DomainException;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenType;
+use function array_key_exists;
 
 final class RecoveryTokenCollection
 {
@@ -35,6 +37,9 @@ final class RecoveryTokenCollection
 
     public function get(RecoveryTokenId $id): RecoveryToken
     {
+        if (!array_key_exists((string)$id, $this->recoveryTokens)) {
+            throw new DomainException(sprintf('Unable to find recovery token with id %s', $id));
+        }
         return $this->recoveryTokens[(string)$id];
     }
 

--- a/src/Surfnet/Stepup/Identity/Value/SelfAssertedRegistrationVettingType.php
+++ b/src/Surfnet/Stepup/Identity/Value/SelfAssertedRegistrationVettingType.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+class SelfAssertedRegistrationVettingType implements VettingType
+{
+    /**
+     * @var string
+     */
+    protected $type;
+
+    protected $authoringRecoveryToken;
+
+    public function __construct(RecoveryTokenId $recoveryTokenId)
+    {
+        $this->type = VettingType::TYPE_SELF_ASSERTED_REGISTRATION;
+        $this->authoringRecoveryToken = $recoveryTokenId;
+    }
+
+    public static function deserialize($data)
+    {
+        $recoveryTokenId = new RecoveryTokenId($data['recovery_token_id']);
+        return new self($recoveryTokenId);
+    }
+
+    public function auditLog(): string
+    {
+        return sprintf(' (self asserted registration using recovery token: %s)', $this->authoringRecoveryToken);
+    }
+
+    public function authoringRecoveryToken(): RecoveryTokenId
+    {
+        return $this->authoringRecoveryToken;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->type(),
+            'recovery_token_id' => (string)$this->authoringRecoveryToken,
+        ];
+    }
+
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function __toString(): string
+    {
+        return $this->type();
+    }
+
+    public function getDocumentNumber(): ?DocumentNumber
+    {
+        return null;
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Value/VettingType.php
+++ b/src/Surfnet/Stepup/Identity/Value/VettingType.php
@@ -24,6 +24,7 @@ interface VettingType extends JsonSerializable
 {
     public const TYPE_ON_PREMISE = 'on-premise';
     public const TYPE_SELF_VET = 'self-vet';
+    public const TYPE_SELF_ASSERTED_REGISTRATION = 'self-asserted-registration';
 
     public function auditLog(): string;
 

--- a/src/Surfnet/Stepup/Identity/Value/VettingTypeFactory.php
+++ b/src/Surfnet/Stepup/Identity/Value/VettingTypeFactory.php
@@ -31,6 +31,9 @@ final class VettingTypeFactory
                 case VettingType::TYPE_ON_PREMISE:
                     $vettingType = OnPremiseVettingType::deserialize($data['vetting_type']);
                     break;
+                case VettingType::TYPE_SELF_ASSERTED_REGISTRATION:
+                    $vettingType = SelfAssertedRegistrationVettingType::deserialize($data['vetting_type']);
+                    break;
             }
         }
         // BC fix for older events without a vetting type, they default back to ON_PREMISE.

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/AuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/AuthorizationService.php
@@ -74,8 +74,52 @@ class AuthorizationService
             return $this->deny(sprintf('Institution "%s", does not allow self-asserted tokens', (string) $identity->institution));
         }
 
-        if ($this->secondFactorService->hasVettedByIdentity($identityId)) {
+        $hasVettedSecondFactorToken = $this->secondFactorService->hasVettedByIdentity($identityId);
+
+        $options = $this->identityService->getSelfAssertedTokenRegistrationOptions(
+            $identity,
+            $hasVettedSecondFactorToken
+        );
+
+        if ($hasVettedSecondFactorToken) {
             return $this->deny('Identity already has a vetted second factor');
+        }
+
+        // Only allow self-asserted token (SAT) if the user does not have a token yet, or the first
+        // registered token was a SAT.
+        $hadOtherTokenType = $options->possessedSelfAssertedToken === false && $options->possessedToken === true;
+        if ($hadOtherTokenType) {
+            return $this->deny('Identity never possessed a self-asserted token, but did/does possess one of the other types');
+        }
+
+        return $this->allow();
+    }
+
+    public function assertRecoveryTokensAreAllowed(IdentityId $identityId): AuthorizationDecision
+    {
+        $identity = $this->identityService->find((string)$identityId);
+        if (!$identity) {
+            return $this->deny('Identity not found');
+        }
+
+        $institution = new Institution((string)$identity->institution);
+        $institutionConfiguration = $this->institutionConfigurationService
+            ->findInstitutionConfigurationOptionsFor($institution);
+        if (!$institutionConfiguration) {
+            return $this->deny('Institution configuration could not be found, unable to ascertain if self-asserted tokens feature is enabled');
+        }
+
+        if (!$institutionConfiguration->selfAssertedTokensOption->isEnabled()) {
+            return $this->deny(sprintf('Institution "%s", does not allow self-asserted tokens', (string) $identity->institution));
+        }
+
+        // Only allow CRUD actions on recovery tokens when the identity previously registered a SAT
+        $options = $this->identityService->getSelfAssertedTokenRegistrationOptions(
+            $identity,
+            $this->secondFactorService->hasVettedByIdentity($identityId)
+        );
+        if ($options->possessedSelfAssertedToken === false) {
+            return $this->deny('Identity never possessed a self-asserted token, deny access to recovery token CRUD actions');
         }
 
         return $this->allow();

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php
@@ -25,11 +25,11 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\WhitelistService;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\Command;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\RaExecutable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfAsserted;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\CreateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ExpressLocalePreferenceCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsSecondFactorCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\SelfVetSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\UpdateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\VetSecondFactorCommand;
 
@@ -103,7 +103,8 @@ class CommandAuthorizationService
                 return true;
             }
 
-            if ($command instanceof SelfVetSecondFactorCommand) {
+            // Self Asserted token registration is allowed for SelfServiceExecutable commands
+            if ($command instanceof SelfAsserted) {
                 return true;
             }
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/AuthorizationController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/AuthorizationController.php
@@ -43,4 +43,10 @@ class AuthorizationController extends AbstractController
         $decision = $this->authorizationService->assertRegistrationOfSelfAssertedTokensIsAllowed(new IdentityId($identityId));
         return JsonAuthorizationResponse::from($decision);
     }
+
+    public function mayRegisterRecoveryTokensAction(string $identityId)
+    {
+        $decision = $this->authorizationService->assertRecoveryTokensAreAllowed(new IdentityId($identityId));
+        return JsonAuthorizationResponse::from($decision);
+    }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RecoveryTokenController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RecoveryTokenController.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
+
+use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
+use Surfnet\StepupMiddleware\ApiBundle\Exception\NotFoundException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RecoveryTokenService;
+use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Exposes the Recovery Tokens projection through the
+ * Middleware Identity (read) API
+ */
+class RecoveryTokenController extends Controller
+{
+    /**
+     * @var RecoveryTokenService
+     */
+    private $service;
+
+    public function __construct(RecoveryTokenService $recoveryTokenServiceService)
+    {
+        $this->service = $recoveryTokenServiceService;
+    }
+
+    public function getAction($id)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS', 'ROLE_READ']);
+        try {
+            $recoveryToken = $this->service->get(new RecoveryTokenId($id));
+        } catch (NotFoundException $e) {
+            throw new NotFoundHttpException(sprintf("Recovery token '%s' does not exist", $id), $e);
+        }
+        return new JsonResponse($recoveryToken);
+    }
+
+    public function collectionAction(Request $request)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS', 'ROLE_READ']);
+
+        $query = new RecoveryTokenQuery();
+        $query->identityId = $request->get('identityId');
+        $query->type = $request->get('type');
+        $query->pageNumber = (int) $request->get('p', 1);
+
+        $paginator = $this->service->search($query);
+
+        return JsonCollectionResponse::fromPaginator($paginator);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Exception/NotFoundException.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Exception/NotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Exception;
+
+class NotFoundException extends RuntimeException
+{
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/Identity.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/Identity.php
@@ -25,7 +25,6 @@ use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\NameId;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\InvalidArgumentException;
 
 /**
  * @ORM\Entity(repositoryClass="Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository")
@@ -83,17 +82,13 @@ class Identity implements JsonSerializable
     public $preferredLocale;
 
     public static function create(
-        $id,
+        string $id,
         Institution $institution,
         NameId $nameId,
         Email $email,
         CommonName $commonName,
         Locale $preferredLocale
     ) {
-        if (!is_string($id)) {
-            throw InvalidArgumentException::invalidType('string', 'id', $id);
-        }
-
         $identity = new self();
 
         $identity->id = $id;
@@ -102,19 +97,18 @@ class Identity implements JsonSerializable
         $identity->email = $email;
         $identity->commonName = $commonName;
         $identity->preferredLocale = $preferredLocale;
-
         return $identity;
     }
 
     public function jsonSerialize()
     {
         return [
-            'id'                        => $this->id,
-            'name_id'                   => $this->nameId,
-            'institution'               => $this->institution,
-            'email'                     => $this->email,
-            'common_name'               => $this->commonName,
-            'preferred_locale'          => $this->preferredLocale,
+            'id' => $this->id,
+            'name_id' => $this->nameId,
+            'institution' => $this->institution,
+            'email' => $this->email,
+            'common_name' => $this->commonName,
+            'preferred_locale' => $this->preferredLocale,
         ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/IdentitySelfAssertedTokenOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/IdentitySelfAssertedTokenOptions.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JsonSerializable;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+
+/**
+ * @ORM\Entity(repositoryClass="Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentitySelfAssertedTokenOptionsRepository")
+ */
+class IdentitySelfAssertedTokenOptions implements JsonSerializable
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(length=36)
+     *
+     * @var IdentityId
+     */
+    public $identityId;
+
+    /**
+     * @ORM\Column(type="boolean")
+     *
+     * In order to determine if the user is allowed to register
+     * a self-asserted token. One of the conditions is that there should
+     * be no previous token registration in his name. Regardless of type.
+     *
+     * @var bool
+     */
+    public $possessedToken = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     *
+     * Indicator if Identity is allowed to work with Recovery Tokens
+     *
+     * Satisfies business rule:
+     * Limit a user to only add/modify/see recovery methods in the overview
+     * screen when they have previously had an active self-asserted token
+     *
+     * @var bool
+     */
+    public $possessedSelfAssertedToken;
+
+    public static function create(
+        IdentityId $identityId,
+        bool $possessedToken,
+        bool $possessedSelfAssertedToken
+    ) {
+        $identitySelfAssertedTokenOptions = new self();
+
+        $identitySelfAssertedTokenOptions->identityId = $identityId;
+        $identitySelfAssertedTokenOptions->possessedToken = $possessedToken;
+        $identitySelfAssertedTokenOptions->possessedSelfAssertedToken = $possessedSelfAssertedToken;
+        return $identitySelfAssertedTokenOptions;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'identity_id' => (string) $this->identityId,
+            'possessed_self_asserted_token' => $this->possessedSelfAssertedToken,
+            'possessed_token' => $this->possessedToken,
+        ];
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
@@ -24,6 +24,9 @@ use Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\IdentityRenamedEvent;
 use Surfnet\Stepup\Identity\Event\LocalePreferenceExpressedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
+use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository;
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentitySelfAssertedTokenOptionsProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentitySelfAssertedTokenOptionsProjector.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Projector;
+
+use Broadway\ReadModel\Projector;
+use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\VettingType;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\IdentitySelfAssertedTokenOptions;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentitySelfAssertedTokenOptionsRepository;
+
+class IdentitySelfAssertedTokenOptionsProjector extends Projector
+{
+    /**
+     * @var IdentitySelfAssertedTokenOptionsRepository
+     */
+    private $repository;
+
+    public function __construct(IdentitySelfAssertedTokenOptionsRepository $identitySelfAssertedTokenOptionsRepository)
+    {
+        $this->repository = $identitySelfAssertedTokenOptionsRepository;
+    }
+
+    /**
+     * Identity is created, we also create a set of
+     * IdentitySelfAssertedTokenOptions.
+     */
+    public function applyIdentityCreatedEvent(IdentityCreatedEvent $event)
+    {
+        $identitySelfAssertedTokenOptions = IdentitySelfAssertedTokenOptions::create(
+            $event->identityId,
+            false,
+            false
+        );
+        $this->repository->save($identitySelfAssertedTokenOptions);
+    }
+
+    public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $this->determinePossessionOfToken($event->vettingType, $event->identityId);
+    }
+
+    public function applySecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
+    {
+        $this->determinePossessionOfToken($event->vettingType, $event->identityId);
+    }
+
+    private function determinePossessionOfToken(VettingType $vettingType, IdentityId $identityId): void
+    {
+        $isSelfAssertedToken = $vettingType->type() === VettingType::TYPE_SELF_ASSERTED_REGISTRATION;
+        $identitySelfAssertedTokenOptions = $this->repository->find($identityId);
+        // Scenario 1: A new token is registered, we have no sat options yet,
+        // create them. These are identities from the pre SAT era.
+        if (!$identitySelfAssertedTokenOptions) {
+            $identitySelfAssertedTokenOptions = IdentitySelfAssertedTokenOptions::create(
+                $identityId,
+                true,
+                $isSelfAssertedToken
+            );
+            $this->repository->save($identitySelfAssertedTokenOptions);
+            return;
+        }
+        // Scenario 2: handle vetting of an Identity with IdentitySelfAssertedTokenOptions
+        if ($vettingType->type() === VettingType::TYPE_SELF_ASSERTED_REGISTRATION) {
+            $identitySelfAssertedTokenOptions->possessedSelfAssertedToken = true;
+        }
+        $identitySelfAssertedTokenOptions->possessedToken = true;
+        $this->repository->save($identitySelfAssertedTokenOptions);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RecoveryTokenQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RecoveryTokenQuery.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
+
+use Surfnet\Stepup\Identity\Value\IdentityId;
+
+class RecoveryTokenQuery extends AbstractQuery
+{
+    /**
+     * @var IdentityId
+     */
+    public $identityId;
+
+    /**
+     * @var string|null
+     */
+    public $type;
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentitySelfAssertedTokenOptionsRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentitySelfAssertedTokenOptionsRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\IdentitySelfAssertedTokenOptions;
+
+class IdentitySelfAssertedTokenOptionsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry, InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter)
+    {
+        parent::__construct($registry, IdentitySelfAssertedTokenOptions::class);
+        $this->authorizationRepositoryFilter = $authorizationRepositoryFilter;
+    }
+
+    public function find($id, $lockMode = null, $lockVersion = null)
+    {
+        return parent::find($id);
+    }
+
+    public function save(IdentitySelfAssertedTokenOptions $options)
+    {
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist($options);
+        $entityManager->flush();
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RecoveryTokenRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RecoveryTokenRepository.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RecoveryToken;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
 
 class RecoveryTokenRepository extends ServiceEntityRepository
 {
@@ -40,5 +41,23 @@ class RecoveryTokenRepository extends ServiceEntityRepository
     {
         $this->getEntityManager()->remove($recoveryToken);
         $this->getEntityManager()->flush();
+    }
+
+    public function createSearchQuery(RecoveryTokenQuery $query)
+    {
+        $queryBuilder = $this->createQueryBuilder('rt');
+
+        if ($query->identityId) {
+            $queryBuilder
+                ->andWhere('rt.identityId = :identityId')
+                ->setParameter('identityId', $query->identityId);
+        }
+        if ($query->type) {
+            $queryBuilder
+                ->andWhere('rt.type = :type')
+                ->setParameter('type', $query->type);
+        }
+
+        return $queryBuilder->getQuery();
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Service;
+
+use Pagerfanta\Pagerfanta;
+use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
+use Surfnet\StepupMiddleware\ApiBundle\Exception\NotFoundException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RecoveryToken;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RecoveryTokenRepository;
+
+class RecoveryTokenService extends AbstractSearchService
+{
+    /**
+     * @var RecoveryTokenRepository
+     */
+    private $recoveryTokenRepository;
+
+    public function __construct(RecoveryTokenRepository $recoveryTokenRepository)
+    {
+        $this->recoveryTokenRepository = $recoveryTokenRepository;
+    }
+
+    public function search(RecoveryTokenQuery $query): Pagerfanta
+    {
+        $doctrineQuery = $this->recoveryTokenRepository->createSearchQuery($query);
+
+        return $this->createPaginatorFrom($doctrineQuery, $query);
+    }
+
+    public function get(RecoveryTokenId $id): RecoveryToken
+    {
+        $recoveryToken = $this->recoveryTokenRepository->find($id);
+        if (!$recoveryToken) {
+            throw new NotFoundException(sprintf('Unable to find Recovery Token with id %s', $id));
+        }
+        return $recoveryToken;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
@@ -5,6 +5,12 @@ services:
             - "@surfnet_stepup_middleware_api.repository.identity"
         tags: [{ name: event_bus.event_listener, disable_for_replay: false }]
 
+    surfnet_stepup_middleware_api.projector.identity_self_asserted_token_options:
+        class: Surfnet\StepupMiddleware\ApiBundle\Identity\Projector\IdentitySelfAssertedTokenOptionsProjector
+        arguments:
+            - "@surfnet_stepup_middleware_api.repository.identity_self_asserted_token_options"
+        tags: [{ name: event_bus.event_listener, disable_for_replay: false }]
+
     surfnet_stepup_middleware_api.projector.institution_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Projector\InstitutionListingProjector
         arguments:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -12,6 +12,14 @@ authorization_self_asserted_tokens:
         identityId: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
+authorization_recovery_tokens:
+    path: /authorization/may-register-recovery-tokens/{identityId}
+    defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\AuthorizationController::mayRegisterRecoveryTokensAction }
+    methods: [ GET ]
+    requirements:
+        identityId: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 deprovision_dry_run:
     path: /deprovision/{collabPersonId}/dry-run
     requirements:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -99,6 +99,20 @@ vetted_second_factor:
     methods:  [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
+recovery_token:
+    path: /recovery_token/{id}
+    defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\RecoveryTokenController::getAction }
+    methods:  [GET]
+    requirements:
+        id: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
+recovery_tokens:
+    path: /recovery_tokens
+    defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\RecoveryTokenController::collectionAction }
+    methods:  [GET]
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 ra_second_factors:
     path:     /ra-second-factors
     defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\RaSecondFactorController::collectionAction }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -27,6 +27,7 @@ services:
     surfnet_stepup_middleware_api.repository.institution_authorization: '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionAuthorizationRepository'
     surfnet_stepup_middleware_api.repository.ra_location: '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\RaLocationRepository'
     surfnet_stepup_middleware_api.repository.identity: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository'
+    surfnet_stepup_middleware_api.repository.identity_self_asserted_token_options: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentitySelfAssertedTokenOptionsRepository'
     surfnet_stepup_middleware_api.repository.institution_listing: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\InstitutionListingRepository'
     surfnet_stepup_middleware_api.repository.ra_candidate: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository'
     surfnet_stepup_middleware_api.repository.ra_listing: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaListingRepository'
@@ -93,6 +94,7 @@ services:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService
         arguments:
             - "@surfnet_stepup_middleware_api.repository.identity"
+            - "@surfnet_stepup_middleware_api.repository.identity_self_asserted_token_options"
             - "@surfnet_stepup_middleware_api.repository.ra_listing"
             - "@surfnet_stepup_middleware_api.repository.sraa"
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
@@ -35,11 +35,11 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\WhitelistService;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RegistrationAuthorityCredentials;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\Command;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\RaExecutable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfAsserted;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\CreateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ExpressLocalePreferenceCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsSecondFactorCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\SelfVetSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\UpdateIdentityCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\VetSecondFactorCommand;
 
@@ -109,7 +109,7 @@ class CommandAuthorizationServiceTest extends TestCase
 
     /**
      * @test
-     * @dataProvider availableCommands-
+     * @dataProvider availableCommands
      *
      * @param mixed $value
      */
@@ -137,7 +137,7 @@ class CommandAuthorizationServiceTest extends TestCase
 
     /**
      * @test
-     * @dataProvider availableCommands-
+     * @dataProvider availableCommands
      *
      * @param mixed $value
      */
@@ -172,7 +172,7 @@ class CommandAuthorizationServiceTest extends TestCase
 
     /**
      * @test
-     * @dataProvider availableCommands-
+     * @dataProvider availableCommands
      *
      * @param mixed $value
      */
@@ -234,7 +234,7 @@ class CommandAuthorizationServiceTest extends TestCase
 
     /**
      * @test
-     * @dataProvider availableCommands-
+     * @dataProvider availableCommands
      *
      * @param mixed $value
      */
@@ -324,7 +324,7 @@ class CommandAuthorizationServiceTest extends TestCase
             // These commands should always be allowed to be executed
             if ($command instanceof CreateIdentityCommand ||
                 $command instanceof UpdateIdentityCommand ||
-                $command instanceof SelfVetSecondFactorCommand
+                $command instanceof SelfAsserted
             ) {
                 $this->assertTrue($this->service->maySelfServiceCommandBeExecutedOnBehalfOf($command, $actorId));
                 return;
@@ -427,6 +427,7 @@ class CommandAuthorizationServiceTest extends TestCase
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProvePhoneRecoveryTokenPossessionCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProveU2fDevicePossessionCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProveYubikeyPossessionCommand',
+            'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RegisterSelfAsseredtSecondFactorCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RemoveFromWhitelistCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ReplaceWhitelistCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RetractRegistrationAuthorityCommand',

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
@@ -427,7 +427,7 @@ class CommandAuthorizationServiceTest extends TestCase
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProvePhoneRecoveryTokenPossessionCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProveU2fDevicePossessionCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProveYubikeyPossessionCommand',
-            'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RegisterSelfAsseredtSecondFactorCommand',
+            'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RegisterSelfAssertedSecondFactorCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RemoveFromWhitelistCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ReplaceWhitelistCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RetractRegistrationAuthorityCommand',

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Command/SelfAsserted.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Command/SelfAsserted.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Command;
+
+/**
+ * Marker interface used to indicate that the command is a self asserted token registration.
+ * For example a self-vet (vet using on of your existing tokens). Or self-asserted token
+ * registration are of this type.
+ */
+interface SelfAsserted
+{
+}

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RegisterSelfAsseredtSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RegisterSelfAsseredtSecondFactorCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2021 SURF bv
+ * Copyright 2022 SURF bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,11 @@
 namespace Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command;
 
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\AbstractCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\RaExecutable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfAsserted;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class SelfVetSecondFactorCommand extends AbstractCommand implements SelfServiceExecutable, SelfAsserted
+class RegisterSelfAsseredtSecondFactorCommand extends AbstractCommand implements SelfServiceExecutable, SelfAsserted
 {
     /**
      * The ID of an existing identity.
@@ -58,7 +57,7 @@ class SelfVetSecondFactorCommand extends AbstractCommand implements SelfServiceE
      *
      * @var string
      */
-    public $registrationCode;
+    public $secondFactorIdentifier;
 
     /**
      * @Assert\NotBlank()
@@ -66,7 +65,7 @@ class SelfVetSecondFactorCommand extends AbstractCommand implements SelfServiceE
      *
      * @var string
      */
-    public $authoringSecondFactorIdentifier;
+    public $authoringRecoveryTokenId;
 
     public function getIdentityId()
     {

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RegisterSelfAssertedSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RegisterSelfAssertedSecondFactorCommand.php
@@ -23,7 +23,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfAsserted;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class RegisterSelfAsseredtSecondFactorCommand extends AbstractCommand implements SelfServiceExecutable, SelfAsserted
+class RegisterSelfAssertedSecondFactorCommand extends AbstractCommand implements SelfServiceExecutable, SelfAsserted
 {
     /**
      * The ID of an existing identity.

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RevokeRegistrantsRecoveryTokenCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RevokeRegistrantsRecoveryTokenCommand.php
@@ -62,6 +62,9 @@ class RevokeRegistrantsRecoveryTokenCommand extends AbstractCommand implements R
      */
     public function getRaInstitution()
     {
+        // Returning null as opposed to having the institution on this command was done
+        // because the RA (actor) institution can be loaded from the authorityId
+        // See: src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php:163
         return null;
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RevokeRegistrantsSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RevokeRegistrantsSecondFactorCommand.php
@@ -62,6 +62,9 @@ class RevokeRegistrantsSecondFactorCommand extends AbstractCommand implements Ra
      */
     public function getRaInstitution()
     {
+        // Returning null as opposed to having the institution on this command was done
+        // because the RA (actor) institution can be loaded from the authorityId
+        // See: src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php:163
         return null;
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/VetSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/VetSecondFactorCommand.php
@@ -101,6 +101,9 @@ class VetSecondFactorCommand extends AbstractCommand implements RaExecutable
      */
     public function getRaInstitution()
     {
+        // Returning null as opposed to having the institution on this command was done
+        // because the RA (actor) institution can be loaded from the authorityId
+        // See: src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/CommandAuthorizationService.php:163
         return null;
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
@@ -64,7 +64,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhonePo
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhoneRecoveryTokenPossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProveU2fDevicePossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProveYubikeyPossessionCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAsseredtSecondFactorCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAssertedSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsRecoveryTokenCommand;
@@ -390,7 +390,7 @@ class IdentityCommandHandler extends SimpleCommandHandler
         $this->eventSourcedRepository->save($registrant);
     }
 
-    public function handleRegisterSelfAsseredtSecondFactorCommand(RegisterSelfAsseredtSecondFactorCommand $command)
+    public function handleRegisterSelfAssertedSecondFactorCommand(RegisterSelfAssertedSecondFactorCommand $command)
     {
         /** @var IdentityApi $identity */
         $identity = $this->eventSourcedRepository->load(new IdentityId($command->identityId));

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
@@ -64,6 +64,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhonePo
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhoneRecoveryTokenPossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProveU2fDevicePossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProveYubikeyPossessionCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAsseredtSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsRecoveryTokenCommand;
@@ -387,6 +388,24 @@ class IdentityCommandHandler extends SimpleCommandHandler
 
         $this->eventSourcedRepository->save($authority);
         $this->eventSourcedRepository->save($registrant);
+    }
+
+    public function handleRegisterSelfAsseredtSecondFactorCommand(RegisterSelfAsseredtSecondFactorCommand $command)
+    {
+        /** @var IdentityApi $identity */
+        $identity = $this->eventSourcedRepository->load(new IdentityId($command->identityId));
+        $secondFactorIdentifier = SecondFactorIdentifierFactory::forType(
+            new SecondFactorType($command->secondFactorType),
+            $command->secondFactorIdentifier
+        );
+
+        $identity->registerSelfAssertedSecondFactor(
+            $secondFactorIdentifier,
+            $this->secondFactorTypeService,
+            new RecoveryTokenId($command->authoringRecoveryTokenId)
+        );
+
+        $this->eventSourcedRepository->save($identity);
     }
 
     public function handleSelfVetSecondFactorCommand(SelfVetSecondFactorCommand $command)

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
@@ -25,20 +25,25 @@ use Broadway\EventStore\EventStore as EventStoreInterface;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
 use Surfnet\Stepup\Configuration\Value\SelfAssertedTokensOption;
+use Surfnet\Stepup\DateTime\DateTime;
 use Surfnet\Stepup\Exception\DomainException;
 use Surfnet\Stepup\Helper\RecoveryTokenSecretHelper;
 use Surfnet\Stepup\Helper\SecondFactorProvePossessionHelper;
 use Surfnet\Stepup\Helper\UserDataFilterInterface;
 use Surfnet\Stepup\Identity\Entity\ConfigurableSettings;
 use Surfnet\Stepup\Identity\Event\CompliedWithRecoveryCodeRevocationEvent;
+use Surfnet\Stepup\Identity\Event\EmailVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
 use Surfnet\Stepup\Identity\Event\PhoneRecoveryTokenPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\RecoveryTokenRevokedEvent;
 use Surfnet\Stepup\Identity\Event\SafeStoreSecretRecoveryTokenPossessionPromisedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
+use Surfnet\Stepup\Identity\Event\YubikeyPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent;
 use Surfnet\Stepup\Identity\EventSourcing\IdentityRepository;
 use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\EmailVerificationWindow;
 use Surfnet\Stepup\Identity\Value\HashedSecret;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\Institution;
@@ -49,10 +54,13 @@ use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenType;
 use Surfnet\Stepup\Identity\Value\SafeStore;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
+use Surfnet\Stepup\Identity\Value\SelfAssertedRegistrationVettingType;
+use Surfnet\Stepup\Identity\Value\TimeFrame;
 use Surfnet\Stepup\Identity\Value\UnhashedSecret;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
+use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Entity\InstitutionConfigurationOptions;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\AllowedSecondFactorListService;
 use Surfnet\StepupMiddleware\ApiBundle\Configuration\Service\InstitutionConfigurationOptionsService;
@@ -60,6 +68,7 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\RuntimeException;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\PromiseSafeStoreSecretTokenPossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhoneRecoveryTokenPossessionCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAsseredtSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\CommandHandler\IdentityCommandHandler;
@@ -131,6 +140,11 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
      * @var RecoveryTokenSecretHelper|m\MockInterface
      */
     private $recoveryTokenSecretHelper;
+
+    /**
+     * @var NameId
+     */
+    private $nameId;
 
     public function setUp(): void
     {
@@ -487,6 +501,151 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
      * @group command-handler
      * @runInSeparateProcess
      */
+    public function test_a_token_can_be_registered_self_asserted()
+    {
+        $recoveryTokenId = new RecoveryTokenId(self::uuid());
+        $secret = m::mock(HashedSecret::class);
+
+        $confMock = m::mock(InstitutionConfigurationOptions::class);
+        $confMock->selfAssertedTokensOption = new SelfAssertedTokensOption(true);
+        $this->configService->shouldReceive('findInstitutionConfigurationOptionsFor')->andReturn($confMock);
+
+        $command = new RegisterSelfAsseredtSecondFactorCommand();
+        $command->authoringRecoveryTokenId = (string)$recoveryTokenId;
+        $command->secondFactorType = 'yubikey';
+        $command->secondFactorId = 'SFID';
+        $command->secondFactorIdentifier = '00028278';
+        $command->identityId = (string)$this->id;
+
+        $secondFactorId = new SecondFactorId($command->secondFactorId);
+        $yubikeyPublicId = new YubikeyPublicId($command->secondFactorIdentifier);
+
+        $expectedVettingType = new SelfAssertedRegistrationVettingType($recoveryTokenId);
+
+        $this->scenario
+
+            ->withAggregateId($this->id)
+            ->given([
+                $this->buildIdentityCreatedEvent(),
+                new YubikeyPossessionProvenEvent(
+                    $this->id,
+                    $this->institution,
+                    $secondFactorId,
+                    $yubikeyPublicId,
+                    true,
+                    EmailVerificationWindow::createFromTimeFrameStartingAt(
+                        TimeFrame::ofSeconds(static::$window),
+                        DateTime::now()
+                    ),
+                    'nonce',
+                    $this->commonName,
+                    $this->email,
+                    new Locale('en_GB')
+                ),
+                new EmailVerifiedEvent(
+                    $this->id,
+                    $this->institution,
+                    $secondFactorId,
+                    new SecondFactorType('yubikey'),
+                    $yubikeyPublicId,
+                    DateTime::now(),
+                    'REGCODE',
+                    $this->commonName,
+                    $this->email,
+                    new Locale('en_GB')
+                ),
+                new SafeStoreSecretRecoveryTokenPossessionPromisedEvent(
+                    $this->id,
+                    $this->institution,
+                    $recoveryTokenId,
+                    new SafeStore($secret),
+                    $this->commonName,
+                    $this->email,
+                    $this->preferredLocale
+                )
+            ])
+            ->when($command)
+            ->then([
+                new SecondFactorVettedWithoutTokenProofOfPossession(
+                    $this->id,
+                    $this->nameId,
+                    $this->institution,
+                    $secondFactorId,
+                    new SecondFactorType($command->secondFactorType),
+                    $yubikeyPublicId,
+                    $this->commonName,
+                    $this->email,
+                    $this->preferredLocale,
+                    $expectedVettingType
+                )
+            ]);
+    }
+
+    /**
+     * @group command-handler
+     * @runInSeparateProcess
+     */
+    public function test_self_asserted_token_registration_requires_possession_of_recovery_token()
+    {
+        $madeUpRecoveryTokenId = new RecoveryTokenId(self::uuid());
+
+        $confMock = m::mock(InstitutionConfigurationOptions::class);
+        $confMock->selfAssertedTokensOption = new SelfAssertedTokensOption(true);
+        $this->configService->shouldReceive('findInstitutionConfigurationOptionsFor')->andReturn($confMock);
+
+        $command = new RegisterSelfAsseredtSecondFactorCommand();
+        $command->authoringRecoveryTokenId = (string)$madeUpRecoveryTokenId;
+        $command->secondFactorType = 'yubikey';
+        $command->secondFactorId = 'SFID';
+        $command->secondFactorIdentifier = '00028278';
+        $command->identityId = (string)$this->id;
+
+        $secondFactorId = new SecondFactorId($command->secondFactorId);
+        $yubikeyPublicId = new YubikeyPublicId($command->secondFactorIdentifier);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('A recovery token is required to perform a self-asserted token registration');
+        $this->scenario
+
+            ->withAggregateId($this->id)
+            ->given([
+                $this->buildIdentityCreatedEvent(),
+                new YubikeyPossessionProvenEvent(
+                    $this->id,
+                    $this->institution,
+                    $secondFactorId,
+                    $yubikeyPublicId,
+                    true,
+                    EmailVerificationWindow::createFromTimeFrameStartingAt(
+                        TimeFrame::ofSeconds(static::$window),
+                        DateTime::now()
+                    ),
+                    'nonce',
+                    $this->commonName,
+                    $this->email,
+                    new Locale('en_GB')
+                ),
+                new EmailVerifiedEvent(
+                    $this->id,
+                    $this->institution,
+                    $secondFactorId,
+                    new SecondFactorType('yubikey'),
+                    $yubikeyPublicId,
+                    DateTime::now(),
+                    'REGCODE',
+                    $this->commonName,
+                    $this->email,
+                    new Locale('en_GB')
+                )
+            ])
+        ->when($command);
+
+    }
+
+    /**
+     * @group command-handler
+     * @runInSeparateProcess
+     */
     public function test_a_safe_store_secret_recovery_code_possession_can_be_revoked()
     {
         $recoveryTokenId = new RecoveryTokenId(self::uuid());
@@ -559,12 +718,12 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
 
     private function buildIdentityCreatedEvent()
     {
-        $nameId = new NameId(md5(__METHOD__));
+        $this->nameId = new NameId(md5(__METHOD__));
 
         return new IdentityCreatedEvent(
             $this->id,
             $this->institution,
-            $nameId,
+            $this->nameId,
             $this->commonName,
             $this->email,
             $this->preferredLocale

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
@@ -68,7 +68,7 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\RuntimeException;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\PromiseSafeStoreSecretTokenPossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhoneRecoveryTokenPossessionCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAsseredtSecondFactorCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAssertedSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\CommandHandler\IdentityCommandHandler;
@@ -510,7 +510,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
         $confMock->selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $this->configService->shouldReceive('findInstitutionConfigurationOptionsFor')->andReturn($confMock);
 
-        $command = new RegisterSelfAsseredtSecondFactorCommand();
+        $command = new RegisterSelfAssertedSecondFactorCommand();
         $command->authoringRecoveryTokenId = (string)$recoveryTokenId;
         $command->secondFactorType = 'yubikey';
         $command->secondFactorId = 'SFID';
@@ -593,7 +593,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
         $confMock->selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $this->configService->shouldReceive('findInstitutionConfigurationOptionsFor')->andReturn($confMock);
 
-        $command = new RegisterSelfAsseredtSecondFactorCommand();
+        $command = new RegisterSelfAssertedSecondFactorCommand();
         $command->authoringRecoveryTokenId = (string)$madeUpRecoveryTokenId;
         $command->secondFactorType = 'yubikey';
         $command->secondFactorId = 'SFID';


### PR DESCRIPTION
A new vetting type was introduced to allow for self-asseted token registration.

A rogue commit was added relating to #358 adding comments to the 'null' actor institution situation.

Task 6 of https://www.pivotaltracker.com/story/show/181934073