### PR TITLE
Create read endpoints for Recovery Tokens

### DIFF
--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -307,7 +307,7 @@ Request parameters:
 ### Unverified Second Factors - Search Unverified Second Factors
 
 #### Request
-URL: `http://middleware.tld/unverified-second-factors?{identityId=}{&verificationNonce=}(&p=}`
+URL: `http://middleware.tld/unverified-second-factors?{identityId=}{&verificationNonce=}{&p=}`
 Method: GET
 Request parameters:
 - IdentityId: (optional) UUIDv4 of the identity to search for
@@ -363,7 +363,7 @@ Request parameters:
 ### Verified Second Factor - Search Verified Second Factors
 
 #### Request
-URL: `http://middleware.tld/verified-second-factors?{actorId=}&{identityId=}{&secondFactorId=}{&registrationCode=}(&p=}`
+URL: `http://middleware.tld/verified-second-factors?{actorId=}&{identityId=}{&secondFactorId=}{&registrationCode=}{&p=}`
 Method: GET
 Request parameters:
 - actorId: (required) UUIDv4 of the actor. When provided, the actor id can be used to determine the actor role.
@@ -373,7 +373,7 @@ Request parameters:
 - p: (optional, default 1) integer, the requested result page
 
 #### Request
-URL: `http://middleware.tld/verified-second-factors-of-identity?{identityId=}(&p=}`
+URL: `http://middleware.tld/verified-second-factors-of-identity?{identityId=}{&p=}`
 Method: GET
 Request parameters:
 - IdentityId: (optional) UUIDv4 of the identity to search for
@@ -429,7 +429,7 @@ Request parameters:
 ### Vetted Second Factor - Search Vetted Second Factors
 
 #### Request
-URL: `http://middleware.tld/vetted-second-factors?{identityId=}(&p=}`
+URL: `http://middleware.tld/vetted-second-factors?{identityId=}{&p=}`
 Method: GET
 Request parameters:
 - identityId: (optional) UUIDv4 of the identity to search for
@@ -454,7 +454,57 @@ Request parameters:
 }
 ```
 
+### Recovery Token - Single Recovery Token
 
+#### Request
+URL: `http://middleware.tld/recovery_token/{recoveryTokenIdId}`
+Method: GET
+Request parameters:
+- recoveryTokenIdId: (required) UUIDv4 of the Recovery Token to get
+
+#### Response
+`200 OK`
+```json
+{
+    "id": "c732d0ac-9f61-4ae1-924e-40d5172fca86",
+    "type": "safe-store",
+    "recovery_token_identifier": "$2a$12$R9h/cIPz0gi.URNNX3kh2OPST9/PgBkqquzi.Ss7KIUgO2t0jWMUW"
+}
+```
+
+### Recovery Token - Search Recovery Tokens
+
+#### Request
+URL: `http://middleware.tld/recovery_tokens?{identityId=}{type=}{&p=}`
+Method: GET
+Request parameters:
+- identityId: (optional) UUIDv4 of the identity to search for
+- type: (optional) UUIDv4 of the identity to search for
+- p: (optional, default 1) integer, the requested result page
+
+#### Response
+`200 OK`
+```json
+{
+    "collection": {
+        "total_items": 2,
+        "page": 1,
+        "page_size": 25
+    },
+    "items": [
+        {
+            "id": "c732d0ac-9f61-4ae1-924e-40d5172fca86",
+            "type": "yubikey",
+            "second_factor_identifier": "$2a$12$R9h/cIPz0gi.URNNX3kh2OPST9/PgBkqquzi.Ss7KIUgO2t0jWMUW"
+        },
+        {
+          "id": "d925d0df-8f61-8ef1-924e-40d5172fca86",
+          "type": "sms",
+          "second_factor_identifier": "+31 (0) 610101010"
+        }
+    ]
+}
+```
 
 ## Registration Authorities
 
@@ -638,7 +688,7 @@ Request parameters:
 ### Registration Authority Candidate - Search RaCandidate
 
 #### Request
-URL: `http://middleware.tld/ra-candidate?institution={&commonName=}{&email=}{&secondFactorTypes=}{&raInstitution}(&p=}`
+URL: `http://middleware.tld/ra-candidate?institution={&commonName=}{&email=}{&secondFactorTypes=}{&raInstitution}{&p=}`
 Method: GET
 Request parameters:
 - institution: (required) string, the institution as scope determination

--- a/docs/postman/3.json
+++ b/docs/postman/3.json
@@ -343,6 +343,80 @@
 			"response": []
 		},
 		{
+			"name": "/recovery_tokens",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "http://middleware.stepup.example.com/recovery_tokens?identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1",
+					"protocol": "http",
+					"host": [
+						"middleware",
+						"stepup",
+						"example",
+						"com"
+					],
+					"path": [
+						"recovery_tokens"
+					],
+					"query": [
+						{
+							"key": "identityId",
+							"value": "8b5cdd14-74b1-43a2-a806-c171728b1bf1"
+						}
+					]
+				},
+				"description": "- `identityId` optional get param\n- `verificationNonce` optional get param\n- `p` page"
+			},
+			"response": []
+		},
+		{
+			"name": "/recovery_token",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "http://middleware.stepup.example.com/recovery_tokens?identityId=8b5cdd14-74b1-43a2-a806-c171728b1bf1",
+					"protocol": "http",
+					"host": [
+						"middleware",
+						"stepup",
+						"example",
+						"com"
+					],
+					"path": [
+						"recovery_tokens"
+					],
+					"query": [
+						{
+							"key": "identityId",
+							"value": "8b5cdd14-74b1-43a2-a806-c171728b1bf1"
+						}
+					]
+				},
+				"description": "- `identityId` optional get param\n- `verificationNonce` optional get param\n- `p` page"
+			},
+			"response": []
+		}
+		{
 			"name": "/vetted-second-factor/{secondFactorId} copy",
 			"request": {
 				"method": "GET",

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RecoveryTokenController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RecoveryTokenController.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
+
+use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
+use Surfnet\StepupMiddleware\ApiBundle\Exception\NotFoundException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RecoveryTokenService;
+use Surfnet\StepupMiddleware\ApiBundle\Response\JsonCollectionResponse;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Exposes the Recovery Tokens projection through the
+ * Middleware Identity (read) API
+ */
+class RecoveryTokenController extends Controller
+{
+    /**
+     * @var RecoveryTokenService
+     */
+    private $service;
+
+    public function __construct(RecoveryTokenService $recoveryTokenServiceService)
+    {
+        $this->service = $recoveryTokenServiceService;
+    }
+
+    public function getAction($id)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS', 'ROLE_READ']);
+        try {
+            $recoveryToken = $this->service->get(new RecoveryTokenId($id));
+        } catch (NotFoundException $e) {
+            throw new NotFoundHttpException(sprintf("Recovery token '%s' does not exist", $id), $e);
+        }
+        return new JsonResponse($recoveryToken);
+    }
+
+    public function collectionAction(Request $request)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS', 'ROLE_READ']);
+
+        $query = new RecoveryTokenQuery();
+        $query->identityId = $request->get('identityId');
+        $query->type = $request->get('type');
+        $query->pageNumber = (int) $request->get('p', 1);
+
+        $paginator = $this->service->search($query);
+
+        return JsonCollectionResponse::fromPaginator($paginator);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Exception/NotFoundException.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Exception/NotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Exception;
+
+class NotFoundException extends RuntimeException
+{
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RecoveryTokenQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RecoveryTokenQuery.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
+
+use Surfnet\Stepup\Identity\Value\IdentityId;
+
+class RecoveryTokenQuery extends AbstractQuery
+{
+    /**
+     * @var IdentityId
+     */
+    public $identityId;
+
+    /**
+     * @var string|null
+     */
+    public $type;
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RecoveryTokenRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RecoveryTokenRepository.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RecoveryToken;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
 
 class RecoveryTokenRepository extends ServiceEntityRepository
 {
@@ -40,5 +41,23 @@ class RecoveryTokenRepository extends ServiceEntityRepository
     {
         $this->getEntityManager()->remove($recoveryToken);
         $this->getEntityManager()->flush();
+    }
+
+    public function createSearchQuery(RecoveryTokenQuery $query)
+    {
+        $queryBuilder = $this->createQueryBuilder('rt');
+
+        if ($query->identityId) {
+            $queryBuilder
+                ->andWhere('rt.identityId = :identityId')
+                ->setParameter('identityId', $query->identityId);
+        }
+        if ($query->type) {
+            $queryBuilder
+                ->andWhere('rt.type = :type')
+                ->setParameter('type', $query->type);
+        }
+
+        return $queryBuilder->getQuery();
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Service;
+
+use Pagerfanta\Pagerfanta;
+use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
+use Surfnet\StepupMiddleware\ApiBundle\Exception\NotFoundException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RecoveryToken;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RecoveryTokenRepository;
+
+class RecoveryTokenService extends AbstractSearchService
+{
+    /**
+     * @var RecoveryTokenRepository
+     */
+    private $recoveryTokenRepository;
+
+    public function __construct(RecoveryTokenRepository $recoveryTokenRepository)
+    {
+        $this->recoveryTokenRepository = $recoveryTokenRepository;
+    }
+
+    public function search(RecoveryTokenQuery $query): Pagerfanta
+    {
+        $doctrineQuery = $this->recoveryTokenRepository->createSearchQuery($query);
+
+        return $this->createPaginatorFrom($doctrineQuery, $query);
+    }
+
+    public function get(RecoveryTokenId $id): RecoveryToken
+    {
+        $recoveryToken = $this->recoveryTokenRepository->find($id);
+        if (!$recoveryToken) {
+            throw new NotFoundException(sprintf('Unable to find Recovery Token with id %s', $id));
+        }
+        return $recoveryToken;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -99,6 +99,20 @@ vetted_second_factor:
     methods:  [GET]
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
+recovery_token:
+    path: /recovery_token/{id}
+    defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\RecoveryTokenController::getAction }
+    methods:  [GET]
+    requirements:
+        id: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
+recovery_tokens:
+    path: /recovery_tokens
+    defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\RecoveryTokenController::collectionAction }
+    methods:  [GET]
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 ra_second_factors:
     path:     /ra-second-factors
     defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\RaSecondFactorController::collectionAction }


### PR DESCRIPTION
A singular retrieve and search endpoint was added to the API. A new
controller was created that bundles the Recovery Token logic.

See Task 7 of https://www.pivotaltracker.com/story/show/181934073