### PR TITLE
Rename typo in RegisterSelfAsseredtSecondFactorCommand

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/CommandAuthorizationServiceTest.php
@@ -427,7 +427,7 @@ class CommandAuthorizationServiceTest extends TestCase
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProvePhoneRecoveryTokenPossessionCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProveU2fDevicePossessionCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ProveYubikeyPossessionCommand',
-            'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RegisterSelfAsseredtSecondFactorCommand',
+            'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RegisterSelfAssertedSecondFactorCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RemoveFromWhitelistCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\ReplaceWhitelistCommand',
             'Surfnet\\StepupMiddleware\\CommandHandlingBundle\\Identity\\Command\\RetractRegistrationAuthorityCommand',

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RegisterSelfAssertedSecondFactorCommand.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Command/RegisterSelfAssertedSecondFactorCommand.php
@@ -23,7 +23,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfAsserted;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Command\SelfServiceExecutable;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class RegisterSelfAsseredtSecondFactorCommand extends AbstractCommand implements SelfServiceExecutable, SelfAsserted
+class RegisterSelfAssertedSecondFactorCommand extends AbstractCommand implements SelfServiceExecutable, SelfAsserted
 {
     /**
      * The ID of an existing identity.

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
@@ -64,7 +64,7 @@ use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhonePo
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhoneRecoveryTokenPossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProveU2fDevicePossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProveYubikeyPossessionCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAsseredtSecondFactorCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAssertedSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsRecoveryTokenCommand;
@@ -390,7 +390,7 @@ class IdentityCommandHandler extends SimpleCommandHandler
         $this->eventSourcedRepository->save($registrant);
     }
 
-    public function handleRegisterSelfAsseredtSecondFactorCommand(RegisterSelfAsseredtSecondFactorCommand $command)
+    public function handleRegisterSelfAssertedSecondFactorCommand(RegisterSelfAssertedSecondFactorCommand $command)
     {
         /** @var IdentityApi $identity */
         $identity = $this->eventSourcedRepository->load(new IdentityId($command->identityId));

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
@@ -68,7 +68,7 @@ use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository as
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\RuntimeException;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\PromiseSafeStoreSecretTokenPossessionCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\ProvePhoneRecoveryTokenPossessionCommand;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAsseredtSecondFactorCommand;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RegisterSelfAssertedSecondFactorCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeOwnRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Command\RevokeRegistrantsRecoveryTokenCommand;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\CommandHandler\IdentityCommandHandler;
@@ -510,7 +510,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
         $confMock->selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $this->configService->shouldReceive('findInstitutionConfigurationOptionsFor')->andReturn($confMock);
 
-        $command = new RegisterSelfAsseredtSecondFactorCommand();
+        $command = new RegisterSelfAssertedSecondFactorCommand();
         $command->authoringRecoveryTokenId = (string)$recoveryTokenId;
         $command->secondFactorType = 'yubikey';
         $command->secondFactorId = 'SFID';
@@ -593,7 +593,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
         $confMock->selfAssertedTokensOption = new SelfAssertedTokensOption(true);
         $this->configService->shouldReceive('findInstitutionConfigurationOptionsFor')->andReturn($confMock);
 
-        $command = new RegisterSelfAsseredtSecondFactorCommand();
+        $command = new RegisterSelfAssertedSecondFactorCommand();
         $command->authoringRecoveryTokenId = (string)$madeUpRecoveryTokenId;
         $command->secondFactorType = 'yubikey';
         $command->secondFactorId = 'SFID';


### PR DESCRIPTION
A typo had snuck into the RegisterSelfAsser~edt~tedSecondFactorCommand
