### PR TITLE
Upgrade self-asserted tokens allowed authorization check

### DIFF
--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -100,6 +100,8 @@ Example of possible error messages. These may differ in the real world, but give
 
 ## Command API
 
+For documentation of the commands that can be handled with the Command API. Please consult [this document](MiddlewareAPICommands.md).
+
 ### Request
 URL: `http://middleware.tld/command/`
 Method: POST

--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -85,18 +85,35 @@ Example of possible error messages. These may differ in the real world, but give
 }
 ```
 
-#### Response
+### Allowed to create and delete recovery tokens?
+
+- URL: `http://middleware.tld/authorization/may-register-recovery-tokens/{identityId}`
+- Method: GET
+- Request parameters:
+    - identityId: (required) UUIDv4 of the identity to assert the authorization for
+
+### Response
 `200 OK`
 ```json
-[
-    {
-        "name": "SURFnet"
-    },
-    {
-        "name": "Ibuildings"
-    }
-]
+{   
+    "code": 200
+}
 ```
+
+`403 Forbidden`
+
+Example of possible error messages. These may differ in the real world, but give a grasp on what they should look like.
+
+```json
+{   
+  "code": 403,
+  "errors": [
+    "Not permitted: institution does not allow self-asserted tokens.",
+    "Not permitted: no previous self asserted token was registered."
+  ]
+}
+```
+
 
 ## Command API
 

--- a/docs/MiddlewareAPICommands.md
+++ b/docs/MiddlewareAPICommands.md
@@ -1,0 +1,109 @@
+# Middleware APIs Commands
+
+## Identity context
+
+### AccreditIdentityCommand
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+|`role`|yes|`string`|The rolename the Identity is accredited with, possible options `[ra, raa]`|
+|`contactInformation`|yes|`string`|Contact information of the Identity|
+|`raInstitution`|yes|`string`|UUID of the RA Institution the Identity is accredited a role at.|
+
+### AddToWhitelistCommand
+- Management command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`institutionsToBeAdded`|yes|`array` of `string`|A list of Institutions to be added to the whitelist|
+
+### AmendRegistrationAuthorityInformationCommand
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`contactInformation`|yes|`string`|Contact information of the Identity|
+|`raInstitution`|yes|`string`|UUID of the RA Institution the Identity is amending information at.|
+
+### AppointRoleCommand
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`role`|yes|`string`|The rolename the Identity is accredited with, possible options `[ra, raa]`|
+|`raInstitution`|yes|`string`|UUID of the RA Institution the Identity is appointed a role at.|
+
+### BootstrapIdentityWithYubikeySecondFactorCommand
+Used to bootstrap SRAA users
+
+- Admin command, fired from command line using Symfony console command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`nameId`|yes|`string`|The nameId of the Identity|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+|`email`|yes|`string`, `email`|Email address of the Identity|
+|`commanName`|yes|`string`|Common name of the Identity|
+|`preferredLocale`|yes|`string`|Preferred locale of the Identity. Possible options `[nl, en]`|
+|`secondFactorId`|yes|`string`|UUID of the second factor token of the Identity|
+|`yubikeyPublicId`|yes|`string`|The public id of the yubikey the Identity is going to use|
+
+### CreateIdentityCommand
+- SelfService command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`id`|yes|`string`|UUID of the Identity|
+|`nameId`|yes|`string`|The nameId of the Identity|
+|`email`|yes|`string`, `email`|Email address of the Identity|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+|`commanName`|yes|`string`|Common name of the Identity|
+|`preferredLocale`|yes|`string`|Preferred locale of the Identity. Possible options `[nl, en]`|
+
+### ExpressLocalePreferenceCommand
+- SelfService command
+- RA command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`preferredLocale`|yes|`string`|Preferred locale of the Identity. Possible options `[nl, en]`|
+
+### ForgetIdentityCommand
+
+- Deprovision command
+- Management command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`nameId`|yes|`string`|NameId of the Identity to be forgotten|
+|`institution`|yes|`string`|UUID of the Institution of the Identity|
+
+### MigrateVettedSecondFactorCommand
+
+- Admin command, fired from command line using Symfony console command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`sourceIdentityId`|yes|`string`|UUID of the Identity the tokens are copied from|
+|`targetIdentityId`|yes|`string`|UUID of the Identity the tokens are copied to|
+|`sourceSecondFactorId`|yes|`string`|The source second factor UUID that is to be moved|
+|`targetSecondFactorId`|yes|`string`|The new destination second factor UUID|
+
+
+### PromiseSafeStoreSecretTokenPossessionCommand
+- SelfService command
+
+|**Fieldname**|**Required**|**Type**|**Remarks**|
+|--|--|--|--|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`recoveryTokenId`|yes|`string`|The ID of the recovery code to create|
+|`identityId`|yes|`string`|UUID of the Identity|
+|`recoveryTokenType`|yes|`string`|The recovery token type, defaults to 'safe-store'|
+|`secret`|yes|`string`|The unhashed safe-store password|

--- a/docs/postman/3.json
+++ b/docs/postman/3.json
@@ -977,6 +977,38 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "/authorization/may-register-recovery-tokens",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "http://middleware.stepup.example.com/authorization/may-register-recovery-tokens/2fb0b832-653f-408a-812d-9c84f82fcf02",
+					"protocol": "http",
+					"host": [
+						"middleware",
+						"stepup",
+						"example",
+						"com"
+					],
+					"path": [
+						"authorization",
+						"may-register-recovery-tokens",
+						"2fb0b832-653f-408a-812d-9c84f82fcf02"
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"auth": {

--- a/src/Surfnet/Migrations/Version20220628091800.php
+++ b/src/Surfnet/Migrations/Version20220628091800.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220628091800 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE identity_self_asserted_token_options (identity_id VARCHAR(36) NOT NULL, possessed_token TINYINT(1) NOT NULL, possessed_self_asserted_token TINYINT(1) NOT NULL, PRIMARY KEY(identity_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE identity_self_asserted_token_options');
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Value/VettingTypeFactory.php
+++ b/src/Surfnet/Stepup/Identity/Value/VettingTypeFactory.php
@@ -31,6 +31,9 @@ final class VettingTypeFactory
                 case VettingType::TYPE_ON_PREMISE:
                     $vettingType = OnPremiseVettingType::deserialize($data['vetting_type']);
                     break;
+                case VettingType::TYPE_SELF_ASSERTED_REGISTRATION:
+                    $vettingType = SelfAssertedRegistrationVettingType::deserialize($data['vetting_type']);
+                    break;
             }
         }
         // BC fix for older events without a vetting type, they default back to ON_PREMISE.

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/AuthorizationService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Authorization/Service/AuthorizationService.php
@@ -78,6 +78,16 @@ class AuthorizationService
             return $this->deny('Identity already has a vetted second factor');
         }
 
+        // Only allow self-asserted token (SAT) if the user does not have a token yet, or the first
+        // registered token was a SAT.
+        $options = $this->identityService->getSelfAssertedTokenRegistrationOptions(
+            $identity,
+            $this->secondFactorService->hasVettedByIdentity($identityId)
+        );
+        if ($options->possessedSelfAssertedToken === false) {
+            return $this->deny('Identity never possessed a self-asserted token, but did/does possess one of the other types');
+        }
+
         return $this->allow();
     }
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/AuthorizationController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/AuthorizationController.php
@@ -43,4 +43,10 @@ class AuthorizationController extends AbstractController
         $decision = $this->authorizationService->assertRegistrationOfSelfAssertedTokensIsAllowed(new IdentityId($identityId));
         return JsonAuthorizationResponse::from($decision);
     }
+
+    public function mayRegisterRecoveryTokensAction(string $identityId)
+    {
+        $decision = $this->authorizationService->assertRecoveryTokensAreAllowed(new IdentityId($identityId));
+        return JsonAuthorizationResponse::from($decision);
+    }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/Identity.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/Identity.php
@@ -25,7 +25,6 @@ use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\Institution;
 use Surfnet\Stepup\Identity\Value\Locale;
 use Surfnet\Stepup\Identity\Value\NameId;
-use Surfnet\StepupMiddleware\CommandHandlingBundle\Exception\InvalidArgumentException;
 
 /**
  * @ORM\Entity(repositoryClass="Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository")
@@ -83,17 +82,13 @@ class Identity implements JsonSerializable
     public $preferredLocale;
 
     public static function create(
-        $id,
+        string $id,
         Institution $institution,
         NameId $nameId,
         Email $email,
         CommonName $commonName,
         Locale $preferredLocale
     ) {
-        if (!is_string($id)) {
-            throw InvalidArgumentException::invalidType('string', 'id', $id);
-        }
-
         $identity = new self();
 
         $identity->id = $id;
@@ -102,19 +97,18 @@ class Identity implements JsonSerializable
         $identity->email = $email;
         $identity->commonName = $commonName;
         $identity->preferredLocale = $preferredLocale;
-
         return $identity;
     }
 
     public function jsonSerialize()
     {
         return [
-            'id'                        => $this->id,
-            'name_id'                   => $this->nameId,
-            'institution'               => $this->institution,
-            'email'                     => $this->email,
-            'common_name'               => $this->commonName,
-            'preferred_locale'          => $this->preferredLocale,
+            'id' => $this->id,
+            'name_id' => $this->nameId,
+            'institution' => $this->institution,
+            'email' => $this->email,
+            'common_name' => $this->commonName,
+            'preferred_locale' => $this->preferredLocale,
         ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/IdentitySelfAssertedTokenOptions.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/IdentitySelfAssertedTokenOptions.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JsonSerializable;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+
+/**
+ * @ORM\Entity(repositoryClass="Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentitySelfAssertedTokenOptionsRepository")
+ */
+class IdentitySelfAssertedTokenOptions implements JsonSerializable
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(length=36)
+     *
+     * @var IdentityId
+     */
+    public $identityId;
+
+    /**
+     * @ORM\Column(type="boolean")
+     *
+     * In order to determine if the user is allowed to register
+     * a self-asserted token. One of the conditions is that there should
+     * be no previous token registration in his name. Regardless of type.
+     *
+     * @var bool
+     */
+    public $possessedToken = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     *
+     * Indicator if Identity is allowed to work with Recovery Tokens
+     *
+     * Satisfies business rule:
+     * Limit a user to only add/modify/see recovery methods in the overview
+     * screen when they have previously had an active self-asserted token
+     *
+     * @var bool
+     */
+    public $possessedSelfAssertedToken;
+
+    public static function create(
+        IdentityId $identityId,
+        bool $possessedToken,
+        bool $possessedSelfAssertedToken
+    ) {
+        $identitySelfAssertedTokenOptions = new self();
+
+        $identitySelfAssertedTokenOptions->identityId = $identityId;
+        $identitySelfAssertedTokenOptions->possessedToken = $possessedToken;
+        $identitySelfAssertedTokenOptions->possessedSelfAssertedToken = $possessedSelfAssertedToken;
+        return $identitySelfAssertedTokenOptions;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'identity_id' => (string) $this->identityId,
+            'possessed_self_asserted_token' => $this->possessedSelfAssertedToken,
+            'possessed_token' => $this->possessedToken,
+        ];
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
@@ -24,6 +24,9 @@ use Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\IdentityRenamedEvent;
 use Surfnet\Stepup\Identity\Event\LocalePreferenceExpressedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
+use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository;
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentitySelfAssertedTokenOptionsProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentitySelfAssertedTokenOptionsProjector.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Projector;
+
+use Broadway\ReadModel\Projector;
+use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\VettingType;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\IdentitySelfAssertedTokenOptions;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentitySelfAssertedTokenOptionsRepository;
+
+class IdentitySelfAssertedTokenOptionsProjector extends Projector
+{
+    /**
+     * @var IdentitySelfAssertedTokenOptionsRepository
+     */
+    private $repository;
+
+    public function __construct(IdentitySelfAssertedTokenOptionsRepository $identitySelfAssertedTokenOptionsRepository)
+    {
+        $this->repository = $identitySelfAssertedTokenOptionsRepository;
+    }
+
+    /**
+     * Identity is created, we also create a set of
+     * IdentitySelfAssertedTokenOptions.
+     */
+    public function applyIdentityCreatedEvent(IdentityCreatedEvent $event)
+    {
+        $identitySelfAssertedTokenOptions = IdentitySelfAssertedTokenOptions::create(
+            $event->identityId,
+            false,
+            false
+        );
+        $this->repository->save($identitySelfAssertedTokenOptions);
+    }
+
+    public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event)
+    {
+        $this->determinePossessionOfToken($event->vettingType, $event->identityId);
+    }
+
+    public function applySecondFactorVettedWithoutTokenProofOfPossession(SecondFactorVettedWithoutTokenProofOfPossession $event)
+    {
+        $this->determinePossessionOfToken($event->vettingType, $event->identityId);
+    }
+
+    private function determinePossessionOfToken(VettingType $vettingType, IdentityId $identityId): void
+    {
+        $isSelfAssertedToken = $vettingType->type() === VettingType::TYPE_SELF_ASSERTED_REGISTRATION;
+        $identitySelfAssertedTokenOptions = $this->repository->find($identityId);
+        // Scenario 1: A new token is registered, we have no sat options yet,
+        // create them. These are identities from the pre SAT era.
+        if (!$identitySelfAssertedTokenOptions) {
+            $identitySelfAssertedTokenOptions = IdentitySelfAssertedTokenOptions::create(
+                $identityId,
+                true,
+                $isSelfAssertedToken
+            );
+            $this->repository->save($identitySelfAssertedTokenOptions);
+            return;
+        }
+        // Scenario 2: handle vetting of an Identity with IdentitySelfAssertedTokenOptions
+        if ($vettingType->type() === VettingType::TYPE_SELF_ASSERTED_REGISTRATION) {
+            $identitySelfAssertedTokenOptions->possessedSelfAssertedToken = true;
+        }
+        $identitySelfAssertedTokenOptions->possessedToken = true;
+        $this->repository->save($identitySelfAssertedTokenOptions);
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentitySelfAssertedTokenOptionsRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/IdentitySelfAssertedTokenOptionsRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\IdentitySelfAssertedTokenOptions;
+
+class IdentitySelfAssertedTokenOptionsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry, InstitutionAuthorizationRepositoryFilter $authorizationRepositoryFilter)
+    {
+        parent::__construct($registry, IdentitySelfAssertedTokenOptions::class);
+        $this->authorizationRepositoryFilter = $authorizationRepositoryFilter;
+    }
+
+    public function find($id, $lockMode = null, $lockVersion = null)
+    {
+        return parent::find($id);
+    }
+
+    public function save(IdentitySelfAssertedTokenOptions $options)
+    {
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist($options);
+        $entityManager->flush();
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/projection.yml
@@ -5,6 +5,12 @@ services:
             - "@surfnet_stepup_middleware_api.repository.identity"
         tags: [{ name: event_bus.event_listener, disable_for_replay: false }]
 
+    surfnet_stepup_middleware_api.projector.identity_self_asserted_token_options:
+        class: Surfnet\StepupMiddleware\ApiBundle\Identity\Projector\IdentitySelfAssertedTokenOptionsProjector
+        arguments:
+            - "@surfnet_stepup_middleware_api.repository.identity_self_asserted_token_options"
+        tags: [{ name: event_bus.event_listener, disable_for_replay: false }]
+
     surfnet_stepup_middleware_api.projector.institution_listing:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Projector\InstitutionListingProjector
         arguments:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/routing.yml
@@ -12,6 +12,14 @@ authorization_self_asserted_tokens:
         identityId: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
 
+authorization_recovery_tokens:
+    path: /authorization/may-register-recovery-tokens/{identityId}
+    defaults: { _controller: Surfnet\StepupMiddleware\ApiBundle\Controller\AuthorizationController::mayRegisterRecoveryTokensAction }
+    methods: [ GET ]
+    requirements:
+        identityId: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    condition: "request.headers.get('Accept') matches '/^application\\\\/json($|[;,])/'"
+
 deprovision_dry_run:
     path: /deprovision/{collabPersonId}/dry-run
     requirements:

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Resources/config/services.yml
@@ -27,6 +27,7 @@ services:
     surfnet_stepup_middleware_api.repository.institution_authorization: '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\InstitutionAuthorizationRepository'
     surfnet_stepup_middleware_api.repository.ra_location: '@Surfnet\StepupMiddleware\ApiBundle\Configuration\Repository\RaLocationRepository'
     surfnet_stepup_middleware_api.repository.identity: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentityRepository'
+    surfnet_stepup_middleware_api.repository.identity_self_asserted_token_options: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\IdentitySelfAssertedTokenOptionsRepository'
     surfnet_stepup_middleware_api.repository.institution_listing: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\InstitutionListingRepository'
     surfnet_stepup_middleware_api.repository.ra_candidate: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaCandidateRepository'
     surfnet_stepup_middleware_api.repository.ra_listing: '@Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RaListingRepository'
@@ -93,6 +94,7 @@ services:
         class: Surfnet\StepupMiddleware\ApiBundle\Identity\Service\IdentityService
         arguments:
             - "@surfnet_stepup_middleware_api.repository.identity"
+            - "@surfnet_stepup_middleware_api.repository.identity_self_asserted_token_options"
             - "@surfnet_stepup_middleware_api.repository.ra_listing"
             - "@surfnet_stepup_middleware_api.repository.sraa"
 


### PR DESCRIPTION
The identity is only allowed to register a self-asserted token (SAT) when the Identity never owned a token. Or previously owned a self-asserted token.

To check this:
1. The Identity projection was updated, a new column was added projecting that property
2. The identity projector now applies the second factor vetted events, and checks if the token is of type SAT 
3. Finally the authorization endpoint now also evaluates this

As we are not able to replay the event stream on production environment, I suggest a database migration script is created that performs the check that is found in the projection before enabling the SAT feature. As all Identities that have a token prior to enabling this feature should have the `possessed_self_asserted_token` column set to `0`. Where the default value after creating the column will be `null`.

https://www.pivotaltracker.com/story/show/182192608