### PR TITLE
Return HTTP 200 when Authz is denied

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/Identity.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/Identity.php
@@ -81,6 +81,20 @@ class Identity implements JsonSerializable
      */
     public $preferredLocale;
 
+    /**
+     * @ORM\Column(type="boolean", nullable=true)
+     *
+     * Indicator if the first vetted second factor was of the self-asserted token type
+     *
+     * Three possible values:
+     * - null: Identity does not have a vetted second factor yet
+     * - true: The Identity has registered a self-asserted second factor token
+     * - false: The first token was not self-asserted but one of the other vetting types
+     *
+     * @var mixed null|bool
+     */
+    public $possessedSelfAssertedToken;
+
     public static function create(
         string $id,
         Institution $institution,

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Response/JsonAuthorizationResponse.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Response/JsonAuthorizationResponse.php
@@ -35,7 +35,8 @@ class JsonAuthorizationResponse extends JsonResponse
         if ($errors) {
             $data['errors'] = $errors;
         }
-        parent::__construct($data, $code);
+        // Don't confuse the HTTP status code with the authorization status code
+        parent::__construct($data, 200);
     }
 
     public static function from(AuthorizationDecision $decision)

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/AuthorizationServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Authorization/Service/AuthorizationServiceTest.php
@@ -286,7 +286,6 @@ class AuthorizationServiceTest extends TestCase
         $this->assertEmpty($messages);
     }
 
-
     public function test_recovery_tokens_never_owned_a_sat_token_but_did_own_other_token_type()
     {
         $identity = new Identity();

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Response/JsonAuthorizationResponseTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Response/JsonAuthorizationResponseTest.php
@@ -33,13 +33,13 @@ class JsonAuthorizationResponseTest extends TestCase
     public function test_happy_flow_error_response() {
         $response = new JsonAuthorizationResponse(403);
         $this->assertEquals('{"code":403}',$response->getContent());
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function test_happy_flow_error_response_with_error_message() {
         $response = new JsonAuthorizationResponse(403, ['Not allowed']);
         $this->assertEquals('{"code":403,"errors":["Not allowed"]}',$response->getContent());
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function test_response_code_can_be_one_of_200_or_403() {


### PR DESCRIPTION
Semantically from an HTTP protocol an authorization decision that denies a certain action should still result in a 200 response code. The authorization code embedded in the response body is still set to 403.