### PR TITLE
Vetting type on vetted second factor projections

### DIFF
--- a/src/Surfnet/Migrations/Version20220704084758.php
+++ b/src/Surfnet/Migrations/Version20220704084758.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220704084758 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE vetted_second_factor ADD vetting_type VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE vetted_second_factor DROP vetting_type');
+    }
+}

--- a/src/Surfnet/Migrations/Version20220704101721.php
+++ b/src/Surfnet/Migrations/Version20220704101721.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220704101721 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $gatewaySchema = $this->getGatewaySchema();
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD vetting_type VARCHAR(255) NOT NULL', $gatewaySchema));
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $gatewaySchema = $this->getGatewaySchema();
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor DROP vetting_type', $gatewaySchema));
+    }
+
+    private function getGatewaySchema()
+    {
+        return $this->container->getParameter('database_gateway_name');
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
@@ -206,13 +206,14 @@ class VerifiedSecondFactor extends AbstractSecondFactor
     /**
      * @return VettedSecondFactor
      */
-    public function asVetted()
+    public function asVetted(VettingType $vettingType)
     {
         return VettedSecondFactor::create(
             $this->id,
             $this->identity,
             $this->type,
-            $this->secondFactorIdentifier
+            $this->secondFactorIdentifier,
+            $vettingType
         );
     }
 

--- a/src/Surfnet/Stepup/Identity/Entity/VettedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VettedSecondFactor.php
@@ -25,6 +25,7 @@ use Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
+use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 
 /**
@@ -55,23 +56,26 @@ class VettedSecondFactor extends AbstractSecondFactor
     private $secondFactorIdentifier;
 
     /**
-     * @param SecondFactorId $id
-     * @param Identity $identity
-     * @param SecondFactorType $type
-     * @param SecondFactorIdentifier $secondFactorIdentifier
+     * @var VettingType
+     */
+    private $vettingType;
+
+    /**
      * @return VettedSecondFactor
      */
     public static function create(
         SecondFactorId $id,
         Identity $identity,
         SecondFactorType $type,
-        SecondFactorIdentifier $secondFactorIdentifier
+        SecondFactorIdentifier $secondFactorIdentifier,
+        VettingType $vettingType
     ) {
         $secondFactor = new self();
         $secondFactor->id = $id;
         $secondFactor->identity = $identity;
         $secondFactor->type = $type;
         $secondFactor->secondFactorIdentifier = $secondFactorIdentifier;
+        $secondFactor->vettingType = $vettingType;
 
         return $secondFactor;
     }
@@ -113,6 +117,11 @@ class VettedSecondFactor extends AbstractSecondFactor
                 $authorityId
             )
         );
+    }
+
+    public function vettingType(): VettingType
+    {
+        return $this->vettingType;
     }
 
     protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)

--- a/src/Surfnet/Stepup/Identity/Event/SecondFactorMigratedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SecondFactorMigratedEvent.php
@@ -28,6 +28,8 @@ use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifier;
 use Surfnet\Stepup\Identity\Value\SecondFactorIdentifierFactory;
+use Surfnet\Stepup\Identity\Value\VettingType;
+use Surfnet\Stepup\Identity\Value\VettingTypeFactory;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
 use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
@@ -95,6 +97,10 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
      * @var \Surfnet\Stepup\Identity\Value\Locale
      */
     public $preferredLocale;
+    /**
+     * @var VettingType
+     */
+    public $vettingType;
 
     /**
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -108,6 +114,7 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
         SecondFactorId $newSecondFactorId,
         SecondFactorType $secondFactorType,
         SecondFactorIdentifier $secondFactorIdentifier,
+        VettingType $vettingType,
         CommonName $commonName,
         Email $email,
         Locale $preferredLocale
@@ -120,6 +127,7 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
         $this->newSecondFactorId = $newSecondFactorId;
         $this->secondFactorType = $secondFactorType;
         $this->secondFactorIdentifier = $secondFactorIdentifier;
+        $this->vettingType = $vettingType;
         $this->commonName = $commonName;
         $this->email = $email;
         $this->preferredLocale = $preferredLocale;
@@ -149,6 +157,7 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
             new SecondFactorId($data['new_second_factor_id']),
             $secondFactorType,
             SecondFactorIdentifierFactory::unknownForType($secondFactorType),
+            VettingTypeFactory::fromData($data['vetting_type']),
             CommonName::unknown(),
             Email::unknown(),
             new Locale($data['preferred_locale'])
@@ -167,6 +176,7 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
             'identity_institution' => (string)$this->identityInstitution,
             'second_factor_id' => (string)$this->secondFactorId,
             'new_second_factor_id' => (string)$this->newSecondFactorId,
+            'vetting_type' => $this->vettingType->jsonSerialize(),
             'second_factor_type' => (string) $this->secondFactorType,
             'preferred_locale' => (string) $this->preferredLocale,
         ];
@@ -177,6 +187,7 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
         return (new SensitiveData)
             ->withCommonName($this->commonName)
             ->withEmail($this->email)
+            ->withVettingType($this->vettingType)
             ->withSecondFactorIdentifier($this->secondFactorIdentifier, $this->secondFactorType);
     }
 
@@ -185,6 +196,7 @@ class SecondFactorMigratedEvent extends IdentityEvent implements Forgettable, Ri
         $this->secondFactorIdentifier = $sensitiveData->getSecondFactorIdentifier();
         $this->commonName = $sensitiveData->getCommonName();
         $this->email = $sensitiveData->getEmail();
+        $this->vettingType = $sensitiveData->getVettingType();
     }
 
     public function obtainUserData(): array

--- a/src/Surfnet/Stepup/Identity/Value/UnknownVettingType.php
+++ b/src/Surfnet/Stepup/Identity/Value/UnknownVettingType.php
@@ -27,7 +27,7 @@ class UnknownVettingType implements VettingType
 
     public function __construct()
     {
-        $this->type = 'unknown';
+        $this->type = VettingType::TYPE_UNKNOWN;
     }
 
     public function auditLog(): string

--- a/src/Surfnet/Stepup/Identity/Value/VettingType.php
+++ b/src/Surfnet/Stepup/Identity/Value/VettingType.php
@@ -25,6 +25,7 @@ interface VettingType extends JsonSerializable
     public const TYPE_ON_PREMISE = 'on-premise';
     public const TYPE_SELF_VET = 'self-vet';
     public const TYPE_SELF_ASSERTED_REGISTRATION = 'self-asserted-registration';
+    public const TYPE_UNKNOWN = 'unknown';
 
     public function auditLog(): string;
 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/VettedSecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/VettedSecondFactor.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Surfnet\Stepup\Identity\Value\VettingType;
+use function is_null;
 
 /**
  * @ORM\Entity(
@@ -27,6 +29,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Table(
  *      indexes={
  *          @ORM\Index(name="idx_vetted_second_factor_type", columns={"type"}),
+ *          @ORM\Index(name="idx_vetted_second_factor_vetting_type", columns={"vetting_type"}),
  *     }
  * )
  */
@@ -64,6 +67,12 @@ class VettedSecondFactor implements \JsonSerializable
     public $secondFactorIdentifier;
 
     /**
+     * @ORM\Column(length=255, nullable=true)
+     * @var string
+     */
+    public $vettingType;
+
+    /**
      * @param VettedSecondFactor $vettedSecondFactor
      * @return bool
      */
@@ -72,12 +81,21 @@ class VettedSecondFactor implements \JsonSerializable
         return $vettedSecondFactor->type == $this->type && $vettedSecondFactor->secondFactorIdentifier == $this->secondFactorIdentifier;
     }
 
+    public function vettingType(): string
+    {
+        if (is_null($this->vettingType)) {
+            return VettingType::TYPE_ON_PREMISE;
+        }
+        return $this->vettingType;
+    }
+
     public function jsonSerialize()
     {
         return [
             'id'   => $this->id,
             'type' => $this->type,
             'second_factor_identifier' => $this->secondFactorIdentifier,
+            'vetting_type' => $this->vettingType,
         ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
@@ -50,6 +50,7 @@ use Surfnet\Stepup\Identity\Value\NameId;
 use Surfnet\Stepup\Identity\Value\OnPremiseVettingType;
 use Surfnet\Stepup\Identity\Value\SecondFactorId;
 use Surfnet\Stepup\Identity\Value\TimeFrame;
+use Surfnet\Stepup\Identity\Value\UnknownVettingType;
 use Surfnet\Stepup\Identity\Value\YubikeyPublicId;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
@@ -204,6 +205,7 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
                     $targetRegistrantSecFacId,
                     new SecondFactorType('yubikey'),
                     $sourceYubikeySecFacId,
+                    new UnknownVettingType(),
                     $targetRegistrantCommonName,
                     $targetRegistrantEmail,
                     new Locale('en_GB')
@@ -271,6 +273,7 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
                     $targetRegistrantSecFacId,
                     new SecondFactorType('yubikey'),
                     $sourceYubikeySecFacId,
+                    new UnknownVettingType(),
                     $targetRegistrantCommonName,
                     $targetRegistrantEmail,
                     new Locale('en_GB')

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
@@ -95,6 +95,13 @@ class SecondFactor
      */
     private $secondFactorIdentifier;
 
+    /**
+     * @var string
+     *
+     * @ORM\Column(length=255)
+     */
+    private $vettingType;
+
     public function __construct(
         $identityId,
         $nameId,
@@ -102,7 +109,8 @@ class SecondFactor
         $displayLocale,
         $secondFactorId,
         $secondFactorIdentifier,
-        $secondFactorType
+        $secondFactorType,
+        $vettingType
     ) {
         $this->id                     = (string) Uuid::uuid4();
         $this->identityId             = $identityId;
@@ -112,5 +120,6 @@ class SecondFactor
         $this->secondFactorId         = $secondFactorId;
         $this->secondFactorIdentifier = $secondFactorIdentifier;
         $this->secondFactorType       = $secondFactorType;
+        $this->vettingType = $vettingType;
     }
 }

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/SecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/SecondFactorProjector.php
@@ -27,6 +27,7 @@ use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\VettedSecondFactorRevokedEvent;
 use Surfnet\Stepup\Identity\Event\YubikeySecondFactorBootstrappedEvent;
+use Surfnet\Stepup\Identity\Value\VettingType;
 use Surfnet\StepupMiddleware\GatewayBundle\Entity\SecondFactor;
 use Surfnet\StepupMiddleware\GatewayBundle\Exception\RuntimeException;
 use Surfnet\StepupMiddleware\GatewayBundle\Repository\SecondFactorRepository;
@@ -56,7 +57,8 @@ class SecondFactorProjector extends Projector
                 (string) $event->preferredLocale,
                 (string) $event->secondFactorId,
                 (string) $event->yubikeyPublicId,
-                'yubikey'
+                'yubikey',
+                VettingType::TYPE_UNKNOWN
             )
         );
     }
@@ -71,7 +73,8 @@ class SecondFactorProjector extends Projector
                 (string) $event->preferredLocale,
                 (string) $event->newSecondFactorId,
                 $event->secondFactorIdentifier,
-                $event->secondFactorType
+                $event->secondFactorType,
+                $event->vettingType->type()
             )
         );
     }
@@ -86,7 +89,8 @@ class SecondFactorProjector extends Projector
                 (string) $event->preferredLocale,
                 (string) $event->secondFactorId,
                 $event->secondFactorIdentifier,
-                $event->secondFactorType
+                $event->secondFactorType,
+                $event->vettingType->type()
             )
         );
     }
@@ -101,7 +105,8 @@ class SecondFactorProjector extends Projector
                 (string) $event->preferredLocale,
                 (string) $event->secondFactorId,
                 $event->secondFactorIdentifier,
-                $event->secondFactorType
+                $event->secondFactorType,
+                $event->vettingType->type()
             )
         );
     }


### PR DESCRIPTION
The vetting type is set on both the Gateway and Middleware Second Factor projections (for vetted second factors)

The vetting type is a relevant projection as it is used to determine the registration level of assurance (loa) of a second factor token.