### PR TITLE
Support recovery token interactions in RA

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -72,6 +72,9 @@ doctrine:
             stepup_second_factor_status:
                 class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\SecondFactorStatusType
                 commented: false
+            stepup_recovery_token_status:
+                class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\RecoveryTokenStatusType
+                commented: false
             stepup_ra_location_name:
                 class: Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\RaLocationNameType
                 commented: false

--- a/docs/MiddlewareAPI.md
+++ b/docs/MiddlewareAPI.md
@@ -499,6 +499,13 @@ Method: GET
 Request parameters:
 - identityId: (optional) UUIDv4 of the identity to search for
 - type: (optional) UUIDv4 of the identity to search for
+- email: (optional) string, the email to match against
+- institution: (optional) string, the institution to match against
+- status: (optional) string, the status to match against
+- p: (optional, default 1) integer, the requested result page
+- orderBy: (optional) string, sorting column; possible values: name, type, secondFactorId, email, institution, status
+- orderDirection: (optional, default desc) string, sorting direction; only asc or desc allowed.
+
 - p: (optional, default 1) integer, the requested result page
 
 #### Response

--- a/src/Surfnet/Migrations/Version20220711125952.php
+++ b/src/Surfnet/Migrations/Version20220711125952.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220711125952 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE recovery_token ADD institution VARCHAR(255) NOT NULL, ADD name VARCHAR(255) NOT NULL, ADD email VARCHAR(255) NOT NULL, ADD status INT NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE recovery_token DROP institution, DROP name, DROP email, DROP status');
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RecoveryTokenController.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Controller/RecoveryTokenController.php
@@ -18,7 +18,11 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Controller;
 
+use Psr\Log\LoggerInterface;
+use Surfnet\Stepup\Configuration\Value\InstitutionRole;
+use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Service\AuthorizationContextService;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\NotFoundException;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Service\RecoveryTokenService;
@@ -27,6 +31,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use function in_array;
+use function sprintf;
 
 /**
  * Exposes the Recovery Tokens projection through the
@@ -39,14 +45,31 @@ class RecoveryTokenController extends Controller
      */
     private $service;
 
-    public function __construct(RecoveryTokenService $recoveryTokenServiceService)
-    {
+    /**
+     * @var AuthorizationContextService
+     */
+    private $authorizationService;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        RecoveryTokenService $recoveryTokenServiceService,
+        AuthorizationContextService $authorizationService,
+        LoggerInterface $logger
+    ) {
         $this->service = $recoveryTokenServiceService;
+        $this->authorizationService = $authorizationService;
+        $this->logger = $logger;
     }
 
     public function getAction($id)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS', 'ROLE_READ']);
+        $this->logger->info(sprintf('Received request to get recovery token: %s', $id));
+
         try {
             $recoveryToken = $this->service->get(new RecoveryTokenId($id));
         } catch (NotFoundException $e) {
@@ -58,14 +81,34 @@ class RecoveryTokenController extends Controller
     public function collectionAction(Request $request)
     {
         $this->denyAccessUnlessGranted(['ROLE_RA', 'ROLE_SS', 'ROLE_READ']);
-
+        $this->logger->info(sprintf('Received search request for recovery tokens with params: %s', $request->getQueryString()));
         $query = new RecoveryTokenQuery();
         $query->identityId = $request->get('identityId');
         $query->type = $request->get('type');
+        $query->status = $request->get('status');
+        $query->institution = $request->get('institution');
+        $query->email = $request->get('email');
+        $query->name = $request->get('name');
         $query->pageNumber = (int) $request->get('p', 1);
+        $query->orderBy = $request->get('orderBy');
+        $query->orderDirection = $request->get('orderDirection');
 
+        $roles = $this->getUser()->getRoles();
+        // Only apply the authorization context on non self service requests
+        if (!in_array('ROLE_SS', $roles)) {
+            $actorId = $request->get('actorId', $request->get('identityId'));
+            $this->logger->info(sprintf('Executing query on behalf of %s', $actorId));
+            $actorId = new IdentityId($actorId);
+            $query->authorizationContext = $this->authorizationService->buildInstitutionAuthorizationContext(
+                $actorId,
+                new InstitutionRole(InstitutionRole::ROLE_USE_RA)
+            );
+        }
         $paginator = $this->service->search($query);
+        $this->logger->info(sprintf('Found %d results', $paginator->count()));
 
-        return JsonCollectionResponse::fromPaginator($paginator);
+        $filters = $this->service->getFilterOptions($query);
+
+        return JsonCollectionResponse::fromPaginator($paginator, $filters);
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/RecoveryTokenStatusType.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Doctrine/Type/RecoveryTokenStatusType.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RecoveryTokenStatus;
+
+/**
+ * Custom Doctrine Type for the four possible statuses a recovery token
+ */
+class RecoveryTokenStatusType extends Type
+{
+    const NAME = 'stepup_recovery_token_status';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getIntegerTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * @param mixed $value
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): int
+    {
+        if (!$value instanceof RecoveryTokenStatus) {
+            throw new ConversionException(
+                sprintf(
+                    "Encountered illegal recovery token status of type %s '%s', expected a RecoveryTokenStatus instance",
+                    is_object($value) ? get_class($value) : gettype($value),
+                    is_scalar($value) ? (string) $value : ''
+                )
+            );
+        }
+
+        if (RecoveryTokenStatus::active()->equals($value)) {
+            return 0;
+        } elseif (RecoveryTokenStatus::revoked()->equals($value)) {
+            return 10;
+        } elseif (RecoveryTokenStatus::forgotten()->equals($value)) {
+            return 20;
+        }
+
+        throw new ConversionException(sprintf("Encountered inconvertible second factor status '%s'", (string) $value));
+    }
+
+    /**
+     * @param mixed $value
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): RecoveryTokenStatus
+    {
+        if ($value === '0') {
+            return RecoveryTokenStatus::active();
+        } elseif ($value === '10') {
+            return RecoveryTokenStatus::revoked();
+        } elseif ($value === '20') {
+            return RecoveryTokenStatus::forgotten();
+        }
+
+        throw new ConversionException(
+            sprintf(
+                "Encountered illegal recovery token status of type %s '%s', expected it to be one of [0,10,20]",
+                is_object($value) ? get_class($value) : gettype($value),
+                is_scalar($value) ? (string) $value : ''
+            )
+        );
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/RecoveryToken.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/RecoveryToken.php
@@ -19,6 +19,10 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RecoveryTokenStatus;
 
 /**
  * @ORM\Entity(
@@ -55,6 +59,38 @@ class RecoveryToken implements \JsonSerializable
     public $type;
 
     /**
+     * @ORM\Column(type="stepup_recovery_token_status")
+     *
+     * @var RecoveryTokenStatus
+     */
+    public $status;
+
+    /**
+     * @ORM\Column(type="institution")
+     *
+     * @var Institution
+     */
+    public $institution;
+
+    /**
+     * The name of the registrant.
+     *
+     * @ORM\Column(type="stepup_common_name")
+     *
+     * @var CommonName
+     */
+    public $name;
+
+    /**
+     * The e-mail of the registrant.
+     *
+     * @ORM\Column(type="stepup_email")
+     *
+     * @var Email
+     */
+    public $email;
+
+    /**
      * @ORM\Column(length=255)
      *
      * @var string
@@ -66,7 +102,12 @@ class RecoveryToken implements \JsonSerializable
         return [
             'id'   => $this->id,
             'type' => $this->type,
+            'status' => (string) $this->status,
             'recovery_method_identifier' => $this->recoveryMethodIdentifier,
+            'identity_id' => $this->identityId,
+            'name' => $this->name,
+            'email' => $this->email,
+            'institution' => $this->institution,
         ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RecoveryTokenQuery.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Query/RecoveryTokenQuery.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Query;
 
 use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\StepupMiddleware\ApiBundle\Authorization\Value\InstitutionAuthorizationContextInterface;
 
 class RecoveryTokenQuery extends AbstractQuery
 {
@@ -31,4 +32,39 @@ class RecoveryTokenQuery extends AbstractQuery
      * @var string|null
      */
     public $type;
+
+    /**
+     * @var string|null
+     */
+    public $status;
+
+    /**
+     * @var string|null
+     */
+    public $institution;
+
+    /**
+     * @var string|null
+     */
+    public $name;
+
+    /**
+     * @var string|null
+     */
+    public $email;
+
+    /**
+     * @var string|null
+     */
+    public $orderBy;
+
+    /**
+     * @var string|null
+     */
+    public $orderDirection;
+
+    /**
+     * @var InstitutionAuthorizationContextInterface
+     */
+    public $authorizationContext;
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
@@ -52,4 +52,9 @@ class RecoveryTokenService extends AbstractSearchService
         }
         return $recoveryToken;
     }
+
+    public function getFilterOptions(RecoveryTokenQuery $query)
+    {
+        return $this->getFilteredQueryOptions($this->recoveryTokenRepository->createOptionsQuery($query));
+    }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/RecoveryTokenStatus.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Value/RecoveryTokenStatus.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Value;
+
+final class RecoveryTokenStatus
+{
+    /**
+     * @var string
+     */
+    private $status;
+
+    public static function active(): self
+    {
+        return new self('active');
+    }
+
+    public static function revoked(): self
+    {
+        return new self('revoked');
+    }
+
+    public static function forgotten(): self
+    {
+        return new self('forgotten');
+    }
+
+    public static function isValidStatus(string $status): bool
+    {
+        return in_array($status, ['active', 'revoked', 'forgotten']);
+    }
+
+    private function __construct(string $status)
+    {
+        $this->status = $status;
+    }
+
+    public function equals(RecoveryTokenStatus $other): bool
+    {
+        return $this->status === $other->status;
+    }
+
+    public function __toString(): string
+    {
+        return $this->status;
+    }
+}

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/RecoveryTokenStatusTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/RecoveryTokenStatusTypeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\ApiBundle\Tests\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase as UnitTest;
+use Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\RecoveryTokenStatusType;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RecoveryTokenStatus;
+
+class RecoveryTokenStatusTypeTest extends UnitTest
+{
+    /**
+     * @var \Doctrine\DBAL\Platforms\MySqlPlatform
+     */
+    private $platform;
+
+    /**
+     * Register the type, since we're forced to use the factory method.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType(RecoveryTokenStatusType::NAME, RecoveryTokenStatusType::class);
+    }
+
+    public function setUp(): void
+    {
+        $this->platform = new MySqlPlatform();
+    }
+
+    public function invalidPhpValues()
+    {
+        return [
+            'null' => [null],
+            'string' => ['string'],
+            'int' => [9],
+            'float' => [9.1],
+            'array' => [array()],
+            'object of a different type' => [new \stdClass],
+            'resource' => [fopen('php://memory', 'w')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidPhpValues
+     * @group doctrine
+     *
+     * @param mixed $value
+     */
+    public function an_invalid_php_value_is_not_accepted_in_to_sql_conversion($value)
+    {
+        $this->expectException(\Doctrine\DBAL\Types\ConversionException::class);
+
+        $type = Type::getType(RecoveryTokenStatusType::NAME);
+        $type->convertToDatabaseValue($value, $this->platform);
+    }
+
+    public function validPhpValues()
+    {
+        return [
+            'active' => [RecoveryTokenStatus::unverified(), 0],
+            'revoked' => [RecoveryTokenStatus::revoked(), 10],
+            'forgotten' => [RecoveryTokenStatus::forgotten(), 20],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider validPhpValues
+     * @group doctrine
+     *
+     * @param mixed $phpValue
+     * @param int $databaseValue
+     */
+    public function a_valid_php_value_is_converted_to_a_sql_value($phpValue, $databaseValue)
+    {
+        $type = Type::getType(RecoveryTokenStatusType::NAME);
+        $this->assertSame($databaseValue, $type->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    public function invalidDatabaseValues()
+    {
+        return [
+            'null' => [null],
+            'invalid string' => ['string'],
+            'int' => [9],
+            'float' => [9.1],
+            'array' => [array()],
+            'object of a different type' => [new \stdClass],
+            'resource' => [fopen('php://memory', 'w')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDatabaseValues
+     * @group doctrine
+     *
+     * @param mixed $input
+     */
+    public function an_invalid_database_value_causes_an_exception_upon_conversion($input)
+    {
+        $this->expectException(\Doctrine\DBAL\Types\ConversionException::class);
+
+        $type = Type::getType(RecoveryTokenStatusType::NAME);
+        $type->convertToPHPValue($input, $this->platform);
+    }
+
+    public function validDatabaseValues()
+    {
+        return [
+            'active' => ['0', RecoveryTokenStatus::active()],
+            'revoked' => ['10', RecoveryTokenStatus::revoked()],
+            'forgotten' => ['20', RecoveryTokenStatus::forgotten()],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider validDatabaseValues
+     * @group doctrine
+     *
+     * @param int $databaseValue
+     * @param mixed $phpValue
+     */
+    public function a_valid_database_value_is_converted_to_a_sql_value($databaseValue, $phpValue)
+    {
+        $type = Type::getType(RecoveryTokenStatusType::NAME);
+        $this->assertTrue($phpValue->equals($type->convertToPHPValue($databaseValue, $this->platform)));
+    }
+}


### PR DESCRIPTION
Some features where missing to achieve this most notable are:

1. Several data was missing in the recovery tokens projection. For example we need the identity name, email, and institution in  order to inform the RA on which specific Identity owns the RT.
2. The RT DTO did not return the IdentityId
3. Searching RT's was very limited. Several query parameters where added (see docs for new options)

See: https://www.pivotaltracker.com/story/show/181934078
See: https://www.pivotaltracker.com/story/show/181968091