### PR TITLE
Add Recovery token events to audit log

### DIFF
--- a/src/Surfnet/Migrations/Version20220713123209.php
+++ b/src/Surfnet/Migrations/Version20220713123209.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Surfnet\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220713123209 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE audit_log ADD recovery_token_identifier VARCHAR(255) DEFAULT NULL, ADD recovery_token_type VARCHAR(36) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE audit_log DROP recovery_token_identifier, DROP recovery_token_type');
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Event/PhoneRecoveryTokenPossessionProvenEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/PhoneRecoveryTokenPossessionProvenEvent.php
@@ -96,6 +96,8 @@ class PhoneRecoveryTokenPossessionProvenEvent extends IdentityEvent implements F
         $metadata = new Metadata();
         $metadata->identityId = $this->identityId;
         $metadata->identityInstitution = $this->identityInstitution;
+        $metadata->recoveryTokenId = (string) $this->phoneNumber;
+        $metadata->recoveryTokenType = RecoveryTokenType::TYPE_SMS;
         return $metadata;
     }
 

--- a/src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
@@ -98,6 +98,9 @@ class SafeStoreSecretRecoveryTokenPossessionPromisedEvent extends IdentityEvent 
         $metadata = new Metadata();
         $metadata->identityId = $this->identityId;
         $metadata->identityInstitution = $this->identityInstitution;
+        // In the audit log we do not show the secret (hashed)
+        $metadata->recoveryTokenId = (string) SafeStore::hidden();
+        $metadata->recoveryTokenType = RecoveryTokenType::TYPE_SAFE_STORE;
         return $metadata;
     }
 

--- a/src/Surfnet/Stepup/Identity/Value/HiddenSecret.php
+++ b/src/Surfnet/Stepup/Identity/Value/HiddenSecret.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Value;
+
+/**
+ * We do not show the value of the safe-store secret. This
+ * would be a password hash. Instead we can show a placeholder text
+ *
+ * This is used for display of the secret in the audit log.
+ */
+class HiddenSecret implements Secret
+{
+    private const HIDDEN_TEXT = 'SECRET-HIDDEN';
+
+    public function getSecret(): string
+    {
+        return self::HIDDEN_TEXT;
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Value/SafeStore.php
+++ b/src/Surfnet/Stepup/Identity/Value/SafeStore.php
@@ -36,6 +36,11 @@ class SafeStore implements RecoveryTokenIdentifier
         return new self(new ForgottenSecret());
     }
 
+    public static function hidden()
+    {
+        return new self(new HiddenSecret());
+    }
+
     public function getValue()
     {
         return $this->secret->getSecret();

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Entity/AuditLogEntry.php
@@ -76,6 +76,10 @@ class AuditLogEntry implements JsonSerializable
         'Surfnet\Stepup\Identity\Event\AppointedAsRaForInstitutionEvent'                  => 'appointed_as_ra',
         'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent'               => 'retracted_as_ra',
         'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent' => 'retracted_as_ra',
+        'Surfnet\Stepup\Identity\Event\SafeStoreSecretRecoveryTokenPossessionPromisedEvent' => 'recovery_token_possession_promised',
+        'Surfnet\Stepup\Identity\Event\RecoveryTokenRevokedEvent' => 'recovery_token_revoked',
+        'Surfnet\Stepup\Identity\Event\PhoneRecoveryTokenPossessionProvenEvent' => 'recovery_token_possession_proven',
+        'Surfnet\Stepup\Identity\Event\CompliedWithRecoveryCodeRevocationEvent' => 'recovery_token_revoked',
     ];
 
     /**
@@ -154,6 +158,20 @@ class AuditLogEntry implements JsonSerializable
     public $secondFactorType;
 
     /**
+     * @ORM\Column(length=255, nullable=true)
+     *
+     * @var string
+     */
+    public $recoveryTokenIdentifier;
+
+    /**
+     * @ORM\Column(length=36, nullable=true)
+     *
+     * @var string|null
+     */
+    public $recoveryTokenType;
+
+    /**
      * @ORM\Column(length=255)
      *
      * @var string
@@ -179,6 +197,8 @@ class AuditLogEntry implements JsonSerializable
             'second_factor_id' => $this->secondFactorId,
             'second_factor_type' => $this->secondFactorType ? (string)$this->secondFactorType : null,
             'second_factor_identifier' => $this->secondFactorIdentifier,
+            'recovery_token_type' => $this->recoveryTokenType,
+            'recovery_token_identifier' => $this->recoveryTokenIdentifier,
             'action' => $this->mapEventToAction($this->event),
             'recorded_on' => (string) $this->recordedOn,
         ];

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RecoveryTokenProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/RecoveryTokenProjector.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Projector;
 
 use Broadway\ReadModel\Projector;
 use Surfnet\Stepup\Identity\Event\CompliedWithRecoveryCodeRevocationEvent;
+use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\PhoneRecoveryTokenPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\RecoveryTokenRevokedEvent;
 use Surfnet\Stepup\Identity\Event\SafeStoreSecretRecoveryTokenPossessionPromisedEvent;
@@ -86,5 +87,14 @@ class RecoveryTokenProjector extends Projector
         $token = $this->recoveryTokenRepository->find((string)$event->recoveryTokenId);
         $token->status = RecoveryTokenStatus::revoked();
         $this->recoveryTokenRepository->save($token);
+    }
+
+    /**
+     * When Identity is forgotten, the recovery token projections for this identity
+     * are removed from the recovery_tokens table.
+     */
+    protected function applyIdentityForgottenEvent(IdentityForgottenEvent $event)
+    {
+        $this->recoveryTokenRepository->removeByIdentity($event->identityId);
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/AuditLogRepository.php
@@ -66,6 +66,10 @@ class AuditLogRepository extends ServiceEntityRepository
         'Surfnet\Stepup\Identity\Event\AppointedAsRaEvent',
         'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedEvent',
         'Surfnet\Stepup\Identity\Event\RegistrationAuthorityRetractedForInstitutionEvent',
+        'Surfnet\Stepup\Identity\Event\SafeStoreSecretRecoveryTokenPossessionPromisedEvent',
+        'Surfnet\Stepup\Identity\Event\RecoveryTokenRevokedEvent',
+        'Surfnet\Stepup\Identity\Event\PhoneRecoveryTokenPossessionProvenEvent',
+        'Surfnet\Stepup\Identity\Event\CompliedWithRecoveryCodeRevocationEvent',
     ];
 
     /**
@@ -88,6 +92,8 @@ class AuditLogRepository extends ServiceEntityRepository
         switch ($query->orderBy) {
             case 'secondFactorType':
             case 'secondFactorIdentifier':
+            case 'recoveryTokenType':
+            case 'recoveryTokenIdentifier':
             case 'recordedOn':
             case 'actorCommonName':
             case 'actorInstitution':

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RecoveryTokenRepository.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Repository/RecoveryTokenRepository.php
@@ -21,13 +21,14 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Query;
+use Surfnet\Stepup\Identity\Value\IdentityId;
 use Surfnet\StepupMiddleware\ApiBundle\Authorization\Filter\InstitutionAuthorizationRepositoryFilter;
 use Surfnet\StepupMiddleware\ApiBundle\Doctrine\Type\RecoveryTokenStatusType;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\RuntimeException;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RecoveryToken;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RecoveryTokenStatus;
-use function sprintf;
 
 class RecoveryTokenRepository extends ServiceEntityRepository
 {
@@ -138,7 +139,7 @@ class RecoveryTokenRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery();
     }
 
-    public function createOptionsQuery(RecoveryTokenQuery $query)
+    public function createOptionsQuery(RecoveryTokenQuery $query): Query
     {
         $queryBuilder = $this->createQueryBuilder('sf')
             ->select('sf.institution')
@@ -155,5 +156,15 @@ class RecoveryTokenRepository extends ServiceEntityRepository
             );
         }
         return $queryBuilder->getQuery();
+    }
+
+    public function removeByIdentity(IdentityId $identityId): void
+    {
+        $this->getEntityManager()->createQueryBuilder()
+            ->delete($this->_entityName, 'rt')
+            ->where('rt.identityId = :identityId')
+            ->setParameter('identityId', $identityId->getIdentityId())
+            ->getQuery()
+            ->execute();
     }
 }

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/SensitiveData.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/SensitiveData/SensitiveData.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData;
 
 use Broadway\Serializer\Serializable as SerializableInterface;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
 use Surfnet\Stepup\Identity\Value\CommonName;
 use Surfnet\Stepup\Identity\Value\Email;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenIdentifier;
@@ -164,9 +165,15 @@ class SensitiveData implements SerializableInterface
         return $this->secondFactorIdentifier ?: SecondFactorIdentifierFactory::unknownForType($this->secondFactorType);
     }
 
-    public function getRecoveryTokenIdentifier(): RecoveryTokenIdentifier
+    public function getRecoveryTokenIdentifier(): ?RecoveryTokenIdentifier
     {
-        return $this->recoveryTokenIdentifier ?: RecoveryTokenIdentifierFactory::unknownForType($this->recoveryTokenType);
+        if ($this->recoveryTokenIdentifier) {
+            return $this->recoveryTokenIdentifier;
+        }
+        if ($this->recoveryTokenType) {
+            return RecoveryTokenIdentifierFactory::unknownForType($this->recoveryTokenType);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Two new columns are added in the audit log projection
The entity, repository and projections have been updated accordingly.

The events added the RT data to their audit log supply methods.
See: https://www.pivotaltracker.com/story/show/181934078

By accident, this PR also contains an update to support deprovisioning of recovery tokens
See: https://www.pivotaltracker.com/story/show/182168991