### PR TITLE
Deny SAT when both RT and SAT SF are lost

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Service/RecoveryTokenService.php
@@ -21,9 +21,11 @@ namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Service;
 use Pagerfanta\Pagerfanta;
 use Surfnet\Stepup\Identity\Value\RecoveryTokenId;
 use Surfnet\StepupMiddleware\ApiBundle\Exception\NotFoundException;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\Identity;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Entity\RecoveryToken;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Query\RecoveryTokenQuery;
 use Surfnet\StepupMiddleware\ApiBundle\Identity\Repository\RecoveryTokenRepository;
+use Surfnet\StepupMiddleware\ApiBundle\Identity\Value\RecoveryTokenStatus;
 
 class RecoveryTokenService extends AbstractSearchService
 {
@@ -56,5 +58,17 @@ class RecoveryTokenService extends AbstractSearchService
     public function getFilterOptions(RecoveryTokenQuery $query)
     {
         return $this->getFilteredQueryOptions($this->recoveryTokenRepository->createOptionsQuery($query));
+    }
+
+    public function identityHasActiveRecoveryToken(Identity $identity): bool
+    {
+        $recoveryTokens = $this->recoveryTokenRepository->findBy(
+            [
+                'identityId' => $identity->id,
+                'status' => RecoveryTokenStatus::active()
+            ]
+        );
+
+        return count($recoveryTokens) > 0;
     }
 }


### PR DESCRIPTION
If a user looses both their activated token and their recovery method they cannot activate a token themselves. Allowing this would enable an attack whereby the attacker with only the first factor can delete and then add a new token to the account, upgrading it to a 2FA account. So getting out of this situation must involve an external verification step.

To do this, the user has to follow the normal service desk vetting process. I.e. register a token and then select the service desk activation method. The result is that the user will then have a normal loa2 or loa3 token. This is a higher level than the user had before, but this will work just fine. Using this process enables us to implement this scenario using the existing Stepup functionality.

The check missing in the existing authz check was to verify that the user does have an active recovery token.

https://www.pivotaltracker.com/story/show/181934196