### PR TITLE
Respond with OK when identity not found

### DIFF
--- a/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionService.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Service/DeprovisionService.php
@@ -71,19 +71,23 @@ class DeprovisionService implements DeprovisionServiceInterface
             return $this->eventSourcingRepository->obtainInformation(new IdentityId($identity->id));
         } catch (UserNotFoundException $e) {
             $this->logger->notice(
-                sprintf(
-                    'User identified by: %s was not found. Unable to provide deprovision data.',
-                    $collabPersonId
-                )
+                $e->getMessage()
             );
-            throw $e;
+            return [];
         }
     }
 
     public function deprovision(string $collabPersonId): void
     {
         $this->logger->debug(sprintf('Searching user identified by: %s', $collabPersonId));
-        $user = $this->getIdentityByNameId($collabPersonId);
+        try {
+            $user = $this->getIdentityByNameId($collabPersonId);
+        } catch (UserNotFoundException $e) {
+            $this->logger->notice(
+                $e->getMessage()
+            );
+            return;
+        }
         $command = new ForgetIdentityCommand();
         $command->UUID = (string)Uuid::uuid4();
         $command->nameId = $collabPersonId;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/DeprovisionServiceTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Service/DeprovisionServiceTest.php
@@ -75,15 +75,13 @@ class DeprovisionServiceTest extends TestCase
      */
     public function test_it_deals_with_non_exisiting_collab_user_id()
     {
-        $this->expectException(UserNotFoundException::class);
-        $this->expectExceptionMessage('User identified by: urn:collab:person:example.com:maynard_keenan was not found. Unable to provide deprovision data.');
-
         $this->apiRepo
             ->shouldReceive('findOneByNameId')
             ->with('urn:collab:person:example.com:maynard_keenan')
             ->once()
             ->andReturnNull();
-        $this->deprovisionService->readUserData('urn:collab:person:example.com:maynard_keenan');
+        $data = $this->deprovisionService->readUserData('urn:collab:person:example.com:maynard_keenan');
+        $this->assertEmpty($data);
     }
 
     /**
@@ -116,11 +114,10 @@ class DeprovisionServiceTest extends TestCase
             ->andReturnNull();
         $this->pipeline
             ->shouldNotHaveReceived('process');
-
-        $this->expectException(UserNotFoundException::class);
-        $this->expectExceptionMessage('User identified by: urn:collab:person:example.com:maynard_keenan was not found. Unable to provide deprovision data.');
-        $this->deprovisionService->deprovision('urn:collab:person:example.com:maynard_keenan');
+        $data = $this->deprovisionService->deprovision('urn:collab:person:example.com:maynard_keenan');
+        $this->assertNull($data);
     }
+
     public function test_deprovision_method_performs_the_right_to_be_forgotten_command()
     {
         $identity = m::mock(Identity::class);


### PR DESCRIPTION
Previously we returned a failed response when an identity is not found
in Middleware. This behavior changes as per [1]. We now return an
OK-with-an-empty-array response.

1: https://www.pivotaltracker.com/n/projects/1163646/stories/182988799