### PR TITLE
Default for gateway vetting-type migration

### DIFF
--- a/src/Surfnet/Migrations/Version20220519134637.php
+++ b/src/Surfnet/Migrations/Version20220519134637.php
@@ -35,7 +35,8 @@ final class Version20220519134637 extends AbstractMigration implements Container
         $this->addSql('CREATE TABLE vetting_type_hint (institution VARCHAR(36) NOT NULL, hints LONGTEXT NOT NULL, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
 
         $gatewaySchema = $this->getGatewaySchema();
-        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD vetting_type VARCHAR(255) NOT NULL', $gatewaySchema));
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD vetting_type VARCHAR(255) NOT NULL DEFAULT \'unknown\'', $gatewaySchema));
+        $this->addSql(sprintf('update second_factor set vetting_type=\'on-premise\' where true', $gatewaySchema));
 
     }
 


### PR DESCRIPTION
To prevent having to do an event replay, we could set the default value for the vetting-type in the gateway table to 'on-premise'. For gateway, all previously vetted tokens are equal.