### PR TITLE
Wrap address and name into an Address

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RecoveryTokenMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RecoveryTokenMailService.php
@@ -133,7 +133,7 @@ final class RecoveryTokenMailService
         ];
 
         $message = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
             ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/RecoveryTokenMailService/email.html.twig')

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
@@ -125,7 +125,7 @@ final class RegistrationMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
             ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
@@ -175,8 +175,8 @@ final class RegistrationMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email, $commonName)
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email, $commonName))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/SecondFactorRevocationMailService.php
@@ -186,8 +186,8 @@ final class SecondFactorRevocationMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email->getEmail(), $commonName->getCommonName())
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email->getEmail(), $commonName->getCommonName()))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Service/VerifiedSecondFactorReminderMailService.php
@@ -186,8 +186,8 @@ class VerifiedSecondFactorReminderMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email, $commonName)
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email, $commonName))
             ->subject($subject)
             ->htmlTemplate('@SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);
@@ -225,8 +225,8 @@ class VerifiedSecondFactorReminderMailService
         ];
 
         $email = (new TemplatedEmail())
-            ->from($this->sender->getEmail(), $this->sender->getName())
-            ->to($email, $commonName)
+            ->from(new Address($this->sender->getEmail(), $this->sender->getName()))
+            ->to(new Address($email, $commonName))
             ->subject($subject)
             ->htmlTemplate('SurfnetStepupMiddlewareCommandHandling/SecondFactorMailService/email.html.twig')
             ->context($parameters);


### PR DESCRIPTION
The to and from methods of the `TemplatedEmail` ask for addresses as its parameter. They are resolved quite magically. Setting a string with a plain mail address is possible, adding multiple parameters is cool too.

The issue we ran into was that the addres param was followed by a common name string. Both where resoved as being mail addresses. Causing the application to blow up on the common name. The solution is to provide Address objects. An address consists of an address and a name.

See: https://www.pivotaltracker.com/n/projects/1163646/stories/183362518
See: https://symfony.com/doc/4.4/mailer.html#email-addresses