### PR TITLE
Refrain from injecting old Swift_Mailer

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Resources/config/processors.yml
@@ -38,7 +38,7 @@ services:
         public: false
         class: Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\EmailVerificationMailService
         arguments:
-            - "@mailer"
+            - "@mailer.mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
             - "" # Verification URL set in bundle extension
@@ -50,7 +50,7 @@ services:
         public: false
         class: Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\RegistrationMailService
         arguments:
-            - "@mailer"
+            - "@mailer.mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
             - "@surfnet_stepup_middleware_management.service.email_template"
@@ -61,7 +61,7 @@ services:
         public: false
         class: Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\SecondFactorRevocationMailService
         arguments:
-            - "@mailer"
+            - "@mailer.mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
             - "@surfnet_stepup_middleware_management.service.email_template"
@@ -73,7 +73,7 @@ services:
         public: false
         class: Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\RecoveryTokenMailService
         arguments:
-            - "@mailer"
+            - "@mailer.mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
             - "@surfnet_stepup_middleware_management.service.email_template"
@@ -85,7 +85,7 @@ services:
         public: false
         class: Surfnet\StepupMiddleware\CommandHandlingBundle\Identity\Service\SecondFactorVettedMailService
         arguments:
-            - "@mailer"
+            - "@mailer.mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
             - "@surfnet_stepup_middleware_management.service.email_template"

--- a/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddleware/MiddlewareBundle/Resources/config/services.yml
@@ -32,7 +32,7 @@ services:
     surfnet_stepup_middleware_middleware.verfied_second_factor_reminder_mailer:
         class: Surfnet\StepupMiddleware\MiddlewareBundle\Service\VerifiedSecondFactorReminderMailService
         arguments:
-            - "@mailer"
+            - "@mailer.mailer"
             - "@surfnet_stepup_middleware_command_handling.email_sender"
             - "@translator"
             - "@surfnet_stepup_middleware_management.service.email_template"


### PR DESCRIPTION
Some of our Composer dependencies still rely on Swiftmailer. And hence we have the mailer in the di container. On my previous (not to thorough, ahem) review I did not notice this discrepency. And the mailers would keep working as the interface change between the Swift_mailer and the SF Mailer is not changed on the methods we use.

Except for the ones where we passed the (email, name) construction without wrapping them in an Address (see previous PR#377).

Quite the pickle!

See: #377
See: https://www.pivotaltracker.com/n/projects/1163646/stories/183362518