### PR TITLE
Remove old swiftmailer config files

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5833,7 +5833,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v4.4.38"
+                "source": "https://github.com/symfony/mailer/tree/v4.4.41"
             },
             "funding": [
                 {

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -24,5 +24,4 @@ return [
     Surfnet\StepupMiddleware\ManagementBundle\SurfnetStepupMiddlewareManagementBundle::class => ['all' => true],
     Surfnet\StepupMiddleware\MiddlewareBundle\SurfnetStepupMiddlewareMiddlewareBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
-    Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
 ];

--- a/config/packages/dev/swiftmailer.yaml
+++ b/config/packages/dev/swiftmailer.yaml
@@ -1,4 +1,0 @@
-# See https://symfony.com/doc/current/email/dev_environment.html
-#swiftmailer:
-#    send all emails to a specific address
-#    delivery_addresses: ['me@example.com']

--- a/config/packages/swiftmailer.yaml
+++ b/config/packages/swiftmailer.yaml
@@ -1,3 +1,0 @@
-swiftmailer:
-    url: '%env(MAILER_URL)%'
-    spool: { type: 'memory' }

--- a/config/packages/test/mailer.yaml
+++ b/config/packages/test/mailer.yaml
@@ -1,3 +1,4 @@
 framework:
   mailer:
-    dsn: "%mailer_transport%://%mailer_user%:%mailer_password%@%mailer_host%"
+    dsn: 'null://null' # disable delivery
+

--- a/config/packages/test/swiftmailer.yaml
+++ b/config/packages/test/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    disable_delivery: true


### PR DESCRIPTION
They cause the application to try and load the Swiftmailer bundle. This was placed on the original PR, but was never reworked. And in the end, I just hit the merge button..

(╯°□°)╯︵ ┻━┻

I merged the old config with the new mailer config settings as good as possible. The one change required was to disable delivery in the test env. This was achieved by setting the DSN to null://null. As suggested in: https://symfony.com/doc/4.4/mailer.html#disabling-delivery

See: #352 #377 #378