### PR TITLE
Update documentation for recovery token API config

### DIFF
--- a/docs/MiddlewareConfiguration.md
+++ b/docs/MiddlewareConfiguration.md
@@ -82,6 +82,8 @@ Each property of this object denotes a specific type of email, the types availab
 * `second_factor_verification_reminder_with_ra_locations`: **(required)** the email sent when the registrant registered it's token 7 days ago and is invited to visit an RA for institutions using RA locations.
 * `vetted`: **(required)** the email sent when the Registrant has successfully vetted a Second Factor.
 * `second_factor_revoked` **(required)**: the email sent when a Second Factor has been revoked.
+* `recovery_token_created` **(required)**: the email sent when a recovery token was created.
+* `recovery_token_revoked` **(required)**: the email sent when a recovery token has been revoked.
 
 Each email contains an object, where each property corresponds with an IETF language tag (2 letter lower cased language code + underscore + 2 letter upper cased country code, i.e. nl_NL, nl_BE) that may be supported in the application.
 
@@ -160,6 +162,30 @@ Sent when the token of the user has been revoked by the user or by an RA.
 | email          | string  | jan@modaal.nl              |
 | tokenType      | string  | yubikey                    |
 | tokenId        | string  | 123923                     |
+| isRevokedByRa  | boolean | true                       |
+| selfServiceUrl | string  | http://selfservice.example |
+
+* `` **(required)**: 
+
+#### After vetting (recovery_token_created)
+
+Sent when an identity created a new recovery token.
+
+| name       | type   | example       |
+|------------|--------|---------------|
+| commonName | string | Jan Modaal    |
+| email      | string | jan@modaal.nl |
+
+#### Recovery token revocation (recovery_token_revoked)
+
+Sent when the token of the user has been revoked by the user or by an RA.
+
+| name           | type    | example                    |
+|----------------|---------|----------------------------|
+| commonName     | string  | Jan Modaal                 |
+| email          | string  | jan@modaal.nl              |
+| tokenType      | string  | sms                        |
+| tokenIdentifier| string  | +31612345678               |
 | isRevokedByRa  | boolean | true                       |
 | selfServiceUrl | string  | http://selfservice.example |
 

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RecoveryTokenMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RecoveryTokenMailService.php
@@ -31,6 +31,7 @@ use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Translation\TranslatorInterface;
+use function str_replace;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -123,13 +124,24 @@ final class RecoveryTokenMailService
             $this->fallbackLocale
         );
 
+        // In TemplatedEmail email is a reserved keyword, we also use it as a parameter that can be used in the mail
+        // message, to prevent having to update all templates, and prevent a 500 error from the mailer, we perform a
+        // search and replace of the {email} parameter in the template.
+        $emailTemplate->htmlContent = str_replace(
+            '{email}',
+            '{emailAddress}',
+            $emailTemplate->htmlContent
+        );
+
         $parameters = [
             'templateString' => $emailTemplate->htmlContent,
             'locale' => $locale->getLocale(),
             'isRevokedByRa' => $revokedByRa,
             'tokenType' => (string)$recoveryTokenType,
             'tokenIdentifier' => (string)$tokenId,
+            'selfServiceUrl' => $this->selfServiceUrl,
             'commonName' => $commonName->getCommonName(),
+            'emailAddress' => $email->getEmail(),
         ];
 
         $message = new TemplatedEmail();
@@ -165,10 +177,20 @@ final class RecoveryTokenMailService
             $this->fallbackLocale
         );
 
+        // In TemplatedEmail email is a reserved keyword, we also use it as a parameter that can be used in the mail
+        // message, to prevent having to update all templates, and prevent a 500 error from the mailer, we perform a
+        // search and replace of the {email} parameter in the template.
+        $emailTemplate->htmlContent = str_replace(
+            '{email}',
+            '{emailAddress}',
+            $emailTemplate->htmlContent
+        );
+
         $parameters = [
             'templateString' => $emailTemplate->htmlContent,
             'locale' => $locale->getLocale(),
             'commonName' => $commonName->getCommonName(),
+            'emailAddress' => $email->getEmail(),
         ];
 
         $message = (new TemplatedEmail())


### PR DESCRIPTION
The MiddlewareConfiguration allows setting mail templates. These templates have several purposes. Each of these are described in the MiddlewareConfiguration.md.

The new Recovery Token related mail templates where not yet represented in this readme.

In addition to documenting them. Some additional parameters have been made available. To align them more with the Second Factor counterparts.