### PR TITLE
Fix token migration TypeError due to missing use statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+# 4.5.2
+- Fix type error during middleware:migrate:vetted-tokens console command #390
+
 # 4.5.1
 - Respond with OK when identity not found (deprovisioning) #375
 - Several minor security and other improvements 

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/SecondFactorProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/SecondFactorProjector.php
@@ -28,6 +28,7 @@ use Surfnet\Stepup\Identity\Event\GssfPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\IdentityForgottenEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent;
+use Surfnet\Stepup\Identity\Event\SecondFactorMigratedEvent;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedEvent;
 use Surfnet\Stepup\Identity\Event\SecondFactorVettedWithoutTokenProofOfPossession;
 use Surfnet\Stepup\Identity\Event\UnverifiedSecondFactorRevokedEvent;


### PR DESCRIPTION
Backport from https://github.com/OpenConext/Stepup-Middleware/commit/326cb0717297123c3be3f5eddb0c5188e44d66f0 

A missing `use Surfnet\Stepup\Identity\Event\SecondFactorMigratedEvent` causes an error during the middleware:migrate:vetted-tokens console command