### PR TITLE
Update SAT projection

### DIFF
--- a/src/Surfnet/Migrations/Version20220519134637.php
+++ b/src/Surfnet/Migrations/Version20220519134637.php
@@ -35,7 +35,12 @@ final class Version20220519134637 extends AbstractMigration implements Container
         $this->addSql('CREATE TABLE vetting_type_hint (institution VARCHAR(36) NOT NULL, hints LONGTEXT NOT NULL, PRIMARY KEY(institution)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
 
         $gatewaySchema = $this->getGatewaySchema();
-        $this->addSql(sprintf('ALTER TABLE %s.second_factor ADD vetting_type VARCHAR(255) NOT NULL', $gatewaySchema));
+        $this->addSql(
+            sprintf(
+                'ALTER TABLE %s.second_factor ADD identity_vetted TINYINT(1) DEFAULT \'1\'',
+                $gatewaySchema
+            )
+        );
 
     }
 
@@ -51,7 +56,7 @@ final class Version20220519134637 extends AbstractMigration implements Container
         $this->addSql('DROP TABLE vetting_type_hint');
 
         $gatewaySchema = $this->getGatewaySchema();
-        $this->addSql(sprintf('ALTER TABLE %s.second_factor DROP vetting_type', $gatewaySchema));
+        $this->addSql(sprintf('ALTER TABLE %s.second_factor DROP identity_vetted', $gatewaySchema));
     }
 
     private function getGatewaySchema()

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Entity/SecondFactor.php
@@ -96,11 +96,16 @@ class SecondFactor
     private $secondFactorIdentifier;
 
     /**
-     * @var string
+     * This boolean indicates if the second factor token was vetted
+     * using one of the vetting types that are considered 'identity-vetted'.
+     * That in turn means if the owner of the second factor token has its
+     * identity vetted (verified) by a RA(A) at the service desk. This trickles
+     * down to the self-vet vetting type. As the token used for self vetting
+     * was RA vetted.
      *
-     * @ORM\Column(length=255)
+     * @ORM\Column(type="boolean", options={"default":"1"})
      */
-    private $vettingType;
+    private $identityVetted;
 
     public function __construct(
         $identityId,
@@ -110,7 +115,7 @@ class SecondFactor
         $secondFactorId,
         $secondFactorIdentifier,
         $secondFactorType,
-        $vettingType
+        $identityVetted
     ) {
         $this->id                     = (string) Uuid::uuid4();
         $this->identityId             = $identityId;
@@ -119,7 +124,7 @@ class SecondFactor
         $this->displayLocale          = $displayLocale;
         $this->secondFactorId         = $secondFactorId;
         $this->secondFactorIdentifier = $secondFactorIdentifier;
-        $this->secondFactorType       = $secondFactorType;
-        $this->vettingType = $vettingType;
+        $this->secondFactorType = $secondFactorType;
+        $this->identityVetted = $identityVetted;
     }
 }


### PR DESCRIPTION
The final 4.5 release already added the second_factor.vetting_type column (later renamed to: `identity_vetted`). Adding it here is not possible. 

The Migration name (timestamp) was updated to be next in sequence to the 4.5 migration.

See task 3 of: https://www.pivotaltracker.com/story/show/184191063