### PR TITLE
Create Gateway Institution Configuration projection row if not exists

### DIFF
--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/InstitutionConfigurationProjector.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Projector/InstitutionConfigurationProjector.php
@@ -58,6 +58,16 @@ class InstitutionConfigurationProjector extends Projector
         if ($institutionConfiguration) {
             $institutionConfiguration->ssoOn2faEnabled = $event->ssoOn2faOption->isEnabled();
             $this->repository->save($institutionConfiguration);
+            return;
+        }
+        // It can happen that the event changed for an institution that already exists, but is not yet projected to
+        // this projection. In that case we can create it.
+        if (!$institutionConfiguration) {
+            $institutionConfiguration = new InstitutionConfiguration(
+                (string)$event->institution,
+                $event->ssoOn2faOption->isEnabled()
+            );
+            $this->repository->save($institutionConfiguration);
         }
     }
 

--- a/src/Surfnet/StepupMiddleware/GatewayBundle/Tests/Projector/InstitutionConfigurationProjectorTest.php
+++ b/src/Surfnet/StepupMiddleware/GatewayBundle/Tests/Projector/InstitutionConfigurationProjectorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddleware\GatewayBundle\Tests\Projector;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Rhumsaa\Uuid\Uuid;
+use Surfnet\Stepup\Configuration\Event\SsoOn2faOptionChangedEvent;
+use Surfnet\Stepup\Configuration\Value\Institution;
+use Surfnet\Stepup\Configuration\Value\InstitutionConfigurationId;
+use Surfnet\Stepup\Configuration\Value\SsoOn2faOption;
+use Surfnet\StepupMiddleware\GatewayBundle\Entity\InstitutionConfiguration;
+use Surfnet\StepupMiddleware\GatewayBundle\Projector\InstitutionConfigurationProjector;
+use Surfnet\StepupMiddleware\GatewayBundle\Repository\InstitutionConfigurationRepository;
+
+class InstitutionConfigurationProjectorTest extends TestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    private $projector;
+
+    private $repository;
+    protected function setUp(): void
+    {
+        $repository = m::mock(InstitutionConfigurationRepository::class);
+        $projector = new InstitutionConfigurationProjector($repository);
+        $this->repository = $repository;
+        $this->projector = $projector;
+    }
+
+    public function test_create_row_when_non_existent()
+    {
+        $event = new SsoOn2faOptionChangedEvent(
+            new InstitutionConfigurationId(Uuid::uuid4()->toString()),
+            new Institution('institution-a.nl'),
+            new SsoOn2faOption(true)
+        );
+        $this->repository->shouldReceive('findByInstitution')->with('institution-a.nl')->andReturn(null);
+        $this->repository->shouldReceive('save')->withArgs(function(InstitutionConfiguration $configuration){
+            return $configuration->institution === 'institution-a.nl' && $configuration->ssoOn2faEnabled === true;
+        });
+
+        $this->projector->applySsoOn2faOptionChangedEvent($event);
+    }
+    public function test_updates_existing_row()
+    {
+        $event = new SsoOn2faOptionChangedEvent(
+            new InstitutionConfigurationId(Uuid::uuid4()->toString()),
+            new Institution('institution-a.nl'),
+            new SsoOn2faOption(true)
+        );
+        $configuration = new InstitutionConfiguration('institution-a.nl', false);
+
+        $this->repository->shouldReceive('findByInstitution')->with('institution-a.nl')->andReturn($configuration);
+        $this->repository->shouldReceive('save')->withArgs(function(InstitutionConfiguration $configuration){
+            return $configuration->institution === 'institution-a.nl' && $configuration->ssoOn2faEnabled === true;
+        });
+
+        $this->projector->applySsoOn2faOptionChangedEvent($event);
+    }
+}


### PR DESCRIPTION
When the Gateway institution configuration is updated because the sso on 2fa config changed for that institution. The projection would only be updated if the institution already exists in the projection. If the projection did not yet have the institution, then the projection was not updated.

This fix now creates the row if the projection is not yet present. This only works now that we only track one single configuration value. 

Note that the real solution to this problem would be to do an event replay. But to prevent an event replay on `prod` we choose to add this construction.

https://www.pivotaltracker.com/story/show/185833305