### PR TITLE
Add input validation for Activation Code and Document Number

### DIFF
--- a/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
+++ b/src/Surfnet/Stepup/Identity/Entity/VerifiedSecondFactor.php
@@ -35,6 +35,8 @@ use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupBundle\Value\VettingType as StepupVettingType;
 
+use function preg_match;
+
 /**
  * A second factor whose possession has been proven by the registrant and the registrant's e-mail address has been
  * verified. The registrant must visit a registration authority next.
@@ -89,10 +91,10 @@ class VerifiedSecondFactor extends AbstractSecondFactor
         SecondFactorType $type,
         SecondFactorIdentifier $secondFactorIdentifier,
         DateTime $registrationRequestedAt,
-        $registrationCode
+        string $registrationCode
     ) {
-        if (!is_string($registrationCode)) {
-            throw InvalidArgumentException::invalidType('string', 'registrationCode', $registrationCode);
+        if (!preg_match('/^[A-Z0-9]{8}$/i', $registrationCode)) {
+            throw InvalidArgumentException::invalidType('valid characters', 'registrationCode', $registrationCode);
         }
 
         $secondFactor = new self;
@@ -123,7 +125,7 @@ class VerifiedSecondFactor extends AbstractSecondFactor
      * @param SecondFactorIdentifier $secondFactorIdentifier
      * @return bool
      */
-    public function hasRegistrationCodeAndIdentifier($registrationCode, SecondFactorIdentifier $secondFactorIdentifier)
+    public function hasRegistrationCodeAndIdentifier(string $registrationCode, SecondFactorIdentifier $secondFactorIdentifier)
     {
         return strcasecmp($registrationCode, $this->registrationCode) === 0
             && $secondFactorIdentifier->equals($this->secondFactorIdentifier);

--- a/src/Surfnet/Stepup/Identity/Value/DocumentNumber.php
+++ b/src/Surfnet/Stepup/Identity/Value/DocumentNumber.php
@@ -22,11 +22,12 @@ use JsonSerializable;
 use Surfnet\Stepup\Exception\InvalidArgumentException;
 
 use function preg_match;
+use function strval;
 
 final class DocumentNumber implements JsonSerializable
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $documentNumber;
 
@@ -35,15 +36,17 @@ final class DocumentNumber implements JsonSerializable
      */
     public static function unknown(): self
     {
-        return new self('–');
+        return new self(null);
     }
 
     /**
-     * @param string $documentNumber
+     * @param string|null $documentNumber
      */
-    public function __construct(string $documentNumber)
+    public function __construct(?string $documentNumber)
     {
-        if (empty($documentNumber)) {
+        if ($documentNumber === null) {
+            // Created using the static ::unknown method
+        } elseif (empty($documentNumber)) {
             throw InvalidArgumentException::invalidType('non-empty string', 'documentNumber', $documentNumber);
         } elseif (!preg_match('/^([-]|[A-Z0-9-]{6})$/i', $documentNumber)) {
             throw InvalidArgumentException::invalidType('valid characters', 'documentNumber', $documentNumber);
@@ -53,16 +56,16 @@ final class DocumentNumber implements JsonSerializable
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getDocumentNumber(): string
+    public function getDocumentNumber(): ?string
     {
         return $this->documentNumber;
     }
 
     public function __toString()
     {
-        return $this->documentNumber;
+        return strval($this->documentNumber);
     }
 
     public function equals(DocumentNumber $other): bool

--- a/src/Surfnet/Stepup/Identity/Value/DocumentNumber.php
+++ b/src/Surfnet/Stepup/Identity/Value/DocumentNumber.php
@@ -21,6 +21,8 @@ namespace Surfnet\Stepup\Identity\Value;
 use JsonSerializable;
 use Surfnet\Stepup\Exception\InvalidArgumentException;
 
+use function preg_match;
+
 final class DocumentNumber implements JsonSerializable
 {
     /**
@@ -31,18 +33,20 @@ final class DocumentNumber implements JsonSerializable
     /**
      * @return self
      */
-    public static function unknown()
+    public static function unknown(): self
     {
-        return new self('—');
+        return new self('–');
     }
 
     /**
      * @param string $documentNumber
      */
-    public function __construct($documentNumber)
+    public function __construct(string $documentNumber)
     {
-        if (!is_string($documentNumber) || empty($documentNumber)) {
+        if (empty($documentNumber)) {
             throw InvalidArgumentException::invalidType('non-empty string', 'documentNumber', $documentNumber);
+        } elseif (!preg_match('/^([-]|[A-Z0-9-]{6})$/i', $documentNumber)) {
+            throw InvalidArgumentException::invalidType('valid characters', 'documentNumber', $documentNumber);
         }
 
         $this->documentNumber = $documentNumber;
@@ -51,7 +55,7 @@ final class DocumentNumber implements JsonSerializable
     /**
      * @return string
      */
-    public function getDocumentNumber()
+    public function getDocumentNumber(): string
     {
         return $this->documentNumber;
     }
@@ -61,7 +65,7 @@ final class DocumentNumber implements JsonSerializable
         return $this->documentNumber;
     }
 
-    public function equals(DocumentNumber $other)
+    public function equals(DocumentNumber $other): bool
     {
         return $this->documentNumber === $other->documentNumber;
     }

--- a/src/Surfnet/Stepup/Tests/Identity/Event/EventSerializationAndDeserializationTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Event/EventSerializationAndDeserializationTest.php
@@ -551,7 +551,7 @@ class EventSerializationAndDeserializationTest extends UnitTest
             // Tests for changes in BC support for adding the VettingType in the SecondFactorVettedEvents in favour of the 'DocumentNumber'
             'SecondFactorVettedEvent:support-new-event-with-vetting-type' => [
                 '{"identity_id":"b260f10b-ce7c-4d09-b6a4-50a3923d637f","name_id":"urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1","identity_institution":"institution-d.example.com","second_factor_id":"512de1ff-0ae0-41b7-bb21-b71d77e570b8","second_factor_type":"yubikey","preferred_locale":"nl_NL"}',
-                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","vetting_type":{"type":"on-premise","document_number":"012345678"}}',
+                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","vetting_type":{"type":"on-premise","document_number":"AB-123"}}',
                 new SecondFactorVettedEvent(
                     new IdentityId('b260f10b-ce7c-4d09-b6a4-50a3923d637f'),
                     new NameId('urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1'),
@@ -562,12 +562,12 @@ class EventSerializationAndDeserializationTest extends UnitTest
                     new CommonName('jane-d1 Institution-D.EXAMPLE.COM'),
                     new Email('jane+jane-d1@stepup.example.com'),
                     new Locale('nl_NL'),
-                    new OnPremiseVettingType(new DocumentNumber('012345678'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 ),
             ],
             'SecondFactorVettedEvent:support-old-event-with-document-number' => [
                 '{"identity_id":"b260f10b-ce7c-4d09-b6a4-50a3923d637f","name_id":"urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1","identity_institution":"institution-d.example.com","second_factor_id":"512de1ff-0ae0-41b7-bb21-b71d77e570b8","second_factor_type":"yubikey","preferred_locale":"nl_NL"}',
-                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","document_number":"012345678"}',
+                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","document_number":"AB-123"}',
                 new SecondFactorVettedEvent(
                     new IdentityId('b260f10b-ce7c-4d09-b6a4-50a3923d637f'),
                     new NameId('urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1'),
@@ -578,12 +578,12 @@ class EventSerializationAndDeserializationTest extends UnitTest
                     new CommonName('jane-d1 Institution-D.EXAMPLE.COM'),
                     new Email('jane+jane-d1@stepup.example.com'),
                     new Locale('nl_NL'),
-                    new OnPremiseVettingType(new DocumentNumber('012345678'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 ),
             ],
             'SecondFactorVettedWithoutTokenProofOfPossession:support-new-event-with-vetting-type' => [
                 '{"identity_id":"b260f10b-ce7c-4d09-b6a4-50a3923d637f","name_id":"urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1","identity_institution":"institution-d.example.com","second_factor_id":"512de1ff-0ae0-41b7-bb21-b71d77e570b8","second_factor_type":"yubikey","preferred_locale":"nl_NL"}',
-                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","vetting_type":{"type":"on-premise","document_number":"012345678"}}',
+                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","vetting_type":{"type":"on-premise","document_number":"AB-123"}}',
                 new SecondFactorVettedWithoutTokenProofOfPossession(
                     new IdentityId('b260f10b-ce7c-4d09-b6a4-50a3923d637f'),
                     new NameId('urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1'),
@@ -594,12 +594,12 @@ class EventSerializationAndDeserializationTest extends UnitTest
                     new CommonName('jane-d1 Institution-D.EXAMPLE.COM'),
                     new Email('jane+jane-d1@stepup.example.com'),
                     new Locale('nl_NL'),
-                    new OnPremiseVettingType(new DocumentNumber('012345678'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 ),
             ],
             'SecondFactorVettedWithoutTokenProofOfPossession:support-old-event-with-document-number' => [
                 '{"identity_id":"b260f10b-ce7c-4d09-b6a4-50a3923d637f","name_id":"urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1","identity_institution":"institution-d.example.com","second_factor_id":"512de1ff-0ae0-41b7-bb21-b71d77e570b8","second_factor_type":"yubikey","preferred_locale":"nl_NL"}',
-                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","document_number":"012345678"}',
+                '{"common_name":"jane-d1 Institution-D.EXAMPLE.COM","email":"jane+jane-d1@stepup.example.com","second_factor_type":"yubikey","second_factor_identifier":"123465293846985","document_number":"AB-123"}',
                 new SecondFactorVettedWithoutTokenProofOfPossession(
                     new IdentityId('b260f10b-ce7c-4d09-b6a4-50a3923d637f'),
                     new NameId('urn:collab:person:Institution-D.EXAMPLE.COM:jane-d1'),
@@ -610,7 +610,7 @@ class EventSerializationAndDeserializationTest extends UnitTest
                     new CommonName('jane-d1 Institution-D.EXAMPLE.COM'),
                     new Email('jane+jane-d1@stepup.example.com'),
                     new Locale('nl_NL'),
-                    new OnPremiseVettingType(new DocumentNumber('012345678'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 ),
             ],
         ];

--- a/src/Surfnet/Stepup/Tests/Identity/Value/DocumentNumberTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Value/DocumentNumberTest.php
@@ -29,9 +29,9 @@ class DocumentNumberTest extends UnitTest
      * @group        domain
      * @dataProvider validDocumentNumberProvider
      *
-     * @param string $documentNumber
+     * @param string|null $documentNumber
      */
-    public function the_document_number_must_be_valid(string $documentNumber): void
+    public function the_document_number_must_be_valid(?string $documentNumber): void
     {
         $document = new DocumentNumber($documentNumber);
         $this->assertInstanceOf(DocumentNumber::class, $document);
@@ -102,7 +102,7 @@ class DocumentNumberTest extends UnitTest
         return [
             'Single hyphen'    => ['-'],
             'Contains hyphen'  => ['123-45'],
-            'Unknown document' => ['–'],
+            'Unknown document' => [null],
             'Uppercase'        => ['A1B2C3'],
             'Lowercase'        => ['a2b2c3'],
             'Mixed case'       => ['a2B2c3'],

--- a/src/Surfnet/Stepup/Tests/Identity/Value/DocumentNumberTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Value/DocumentNumberTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\Stepup\Tests\Identity\Value;
 
 use PHPUnit\Framework\TestCase as UnitTest;
+use Surfnet\Stepup\Exception\InvalidArgumentException;
 use Surfnet\Stepup\Identity\Value\DocumentNumber;
 
 class DocumentNumberTest extends UnitTest
@@ -26,25 +27,51 @@ class DocumentNumberTest extends UnitTest
     /**
      * @test
      * @group        domain
-     * @dataProvider invalidArgumentProvider
+     * @dataProvider validDocumentNumberProvider
      *
-     * @param mixed $invalidValue
+     * @param string $documentNumber
      */
-    public function the_document_number_must_be_a_non_empty_string($invalidValue)
+    public function the_document_number_must_be_valid(string $documentNumber): void
     {
-        $this->expectException(\Surfnet\Stepup\Exception\InvalidArgumentException::class);
+        $document = new DocumentNumber($documentNumber);
+        $this->assertInstanceOf(DocumentNumber::class, $document);
+    }
+
+
+    /**
+     * @test
+     * @group        domain
+     * @dataProvider invalidDocumentNumberProvider
+     *
+     * @param string $invalidValue
+     */
+    public function the_document_number_must_not_contain_illegal_characters(string $invalidValue): void
+    {
+        $this->expectException(InvalidArgumentException::class);
         new DocumentNumber($invalidValue);
     }
+
+
+    /**
+     * @test
+     * @group        domain
+     */
+    public function the_document_number_must_be_a_non_empty_string(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DocumentNumber('');
+    }
+
 
     /**
      * @test
      * @group domain
      */
-    public function two_document_numbers_with_the_same_value_are_equal()
+    public function two_document_numbers_with_the_same_value_are_equal(): void
     {
-        $commonName = new DocumentNumber('John Doe');
-        $theSame    = new DocumentNumber('John Doe');
-        $different  = new DocumentNumber('Jane Doe');
+        $commonName = new DocumentNumber('JHA1B4');
+        $theSame    = new DocumentNumber('JHA1B4');
+        $different  = new DocumentNumber('IGZ0A3');
         $unknown    = DocumentNumber::unknown();
 
         $this->assertTrue($commonName->equals($theSame));
@@ -52,17 +79,33 @@ class DocumentNumberTest extends UnitTest
         $this->assertFalse($commonName->equals($unknown));
     }
 
+
     /**
-     * provider for {@see the_document_number_address_must_be_a_non_empty_string()}
+     * provider for {@see the_document_number_address_must_not_contain_illegal_characters()}
      */
-    public function invalidArgumentProvider()
+    public function invalidDocumentNumberProvider(): array
     {
         return [
-            'empty string' => [''],
-            'array'        => [[]],
-            'integer'      => [1],
-            'float'        => [1.2],
-            'object'       => [new \StdClass()],
+            'Illegal character' => ['#12345'],
+            'Too long'          => ['TooLong'],
+            'Too short'         => ['Shor'], // Short
+            'Contains space'    => ['AB 123'],
+        ];
+    }
+
+
+    /**
+     * provider for {@see the_document_number_address_must_be_valid()}
+     */
+    public function validDocumentNumberProvider(): array
+    {
+        return [
+            'Single hyphen'    => ['-'],
+            'Contains hyphen'  => ['123-45'],
+            'Unknown document' => ['–'],
+            'Uppercase'        => ['A1B2C3'],
+            'Lowercase'        => ['a2b2c3'],
+            'Mixed case'       => ['a2B2c3'],
         ];
     }
 }

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/DocumentNumberTypeTest.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Tests/Doctrine/Type/DocumentNumberTypeTest.php
@@ -65,11 +65,11 @@ class DocumentNumberTypeTest extends UnitTest
     {
         $type = Type::getType(DocumentNumberType::NAME);
 
-        $input = new DocumentNumber('a');
+        $input = new DocumentNumber('A1B2C3');
         $output = $type->convertToDatabaseValue($input, $this->platform);
 
         $this->assertTrue(is_string($output));
-        $this->assertEquals('a', $output);
+        $this->assertEquals('A1B2C3', $output);
     }
 
     /**
@@ -108,7 +108,7 @@ class DocumentNumberTypeTest extends UnitTest
     {
         $type = Type::getType(DocumentNumberType::NAME);
 
-        $input = '12345';
+        $input = 'A12345';
         $output = $type->convertToPHPValue($input, $this->platform);
 
         $this->assertInstanceOf('Surfnet\Stepup\Identity\Value\DocumentNumber', $output);

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerMoveTokenTest.php
@@ -461,7 +461,7 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $targetYubikeySecFacId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $targetRegistrantCommonName,
                     $targetRegistrantEmail,
                     new Locale('en_GB')
@@ -569,7 +569,7 @@ class IdentityCommandHandlerMoveTokenTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $targetYubikeySecFacId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $targetRegistrantCommonName,
                     $targetRegistrantEmail,
                     new Locale('en_GB')

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerSelfAssertedTokensTest.php
@@ -561,7 +561,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $yubikeyPublicId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')
@@ -644,7 +644,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $yubikeyPublicId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')
@@ -721,7 +721,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
 
         $command = new SelfVetSecondFactorCommand();
         $command->secondFactorId = '+31 (0) 612345678';
-        $command->registrationCode = 'REGCODE';
+        $command->registrationCode = 'A1B2C3D4';
         $command->identityId = $this->id->getIdentityId();
         $command->authoringSecondFactorLoa = "loa-self-asserted";
         $command->secondFactorType = 'sms';
@@ -754,7 +754,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $yubikeyPublicId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')
@@ -803,7 +803,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('sms'),
                     $phoneIdentifier,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')
@@ -855,7 +855,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
 
         $command = new SelfVetSecondFactorCommand();
         $command->secondFactorId = 'identifier-for-a-gssp';
-        $command->registrationCode = 'REGCODE';
+        $command->registrationCode = 'A1B2C3D4';
         $command->identityId = $this->id->getIdentityId();
         $command->authoringSecondFactorLoa = "loa-self-asserted";
         $command->secondFactorType = 'tiqr';
@@ -905,7 +905,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $yubikeyPublicId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')
@@ -954,7 +954,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('sms'),
                     $phoneIdentifier,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')
@@ -995,7 +995,7 @@ class IdentityCommandHandlerSelfAssertedTokensTest extends CommandHandlerTest
                     new SecondFactorType('tiqr'),
                     $gsspIdentifier,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $this->commonName,
                     $this->email,
                     new Locale('en_GB')

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/IdentityCommandHandlerTest.php
@@ -262,7 +262,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
             ->shouldReceive('generateNonce')->once()->andReturn('nonce');
 
@@ -326,7 +326,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
             ->shouldReceive('generateNonce')->once()->andReturn('nonce');
 
@@ -435,7 +435,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
             ->shouldReceive('generateNonce')->once()->andReturn('nonce');
 
@@ -499,7 +499,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
             ->shouldReceive('generateNonce')->once()->andReturn('nonce');
 
@@ -548,7 +548,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
 
         $nonce = 'nonce';
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
@@ -626,7 +626,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
 
         $nonce = 'nonce';
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
@@ -679,7 +679,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
             ->shouldReceive('generateNonce')->once()->andReturn('nonce');
 
@@ -743,7 +743,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
         m::mock('alias:Surfnet\Stepup\Token\TokenGenerator')
             ->shouldReceive('generateNonce')->once()->andReturn('nonce');
 
@@ -911,7 +911,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         DateTimeHelper::setCurrentTime(new DateTime(new CoreDateTime('@12345')));
 
         m::mock('alias:Surfnet\StepupBundle\Security\OtpGenerator')
-            ->shouldReceive('generate')->once()->andReturn('regcode');
+            ->shouldReceive('generate')->once()->andReturn('A1B2C3D4');
 
         $id                     = new IdentityId(self::uuid());
         $institution            = new Institution('A Corp.');
@@ -962,7 +962,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $secondFactorIdentifier,
                     DateTime::now(),
-                    'regcode',
+                    'A1B2C3D4',
                     $commonName,
                     $email,
                     $preferredLocale
@@ -1025,7 +1025,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $secondFactorIdentifier,
                     DateTime::now(),
-                    'regcode',
+                    'A1B2C3D4',
                     $commonName,
                     $email,
                     $preferredLocale
@@ -1206,10 +1206,10 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $command->authorityId            = 'AID';
         $command->identityId             = 'IID';
         $command->secondFactorId         = 'ISFID';
-        $command->registrationCode       = 'REGCODE';
+        $command->registrationCode       = 'A1B2C3D4';
         $command->secondFactorType       = 'yubikey';
         $command->secondFactorIdentifier = '00028278';
-        $command->documentNumber         = 'NH9392';
+        $command->documentNumber         = 'ABC-12';
         $command->identityVerified       = true;
         $command->provePossessionSkipped = false;
 
@@ -1288,7 +1288,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $registrantSecFacIdentifier,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -1306,7 +1306,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('NH9392'))
+                    new OnPremiseVettingType(new DocumentNumber('ABC-12'))
                 ),
             ]);
     }
@@ -1324,10 +1324,10 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $command->authorityId            = 'AID';
         $command->identityId             = 'IID';
         $command->secondFactorId         = 'ISFID';
-        $command->registrationCode       = 'REGCODE';
+        $command->registrationCode       = 'A1B2C3D4';
         $command->secondFactorType       = 'yubikey';
         $command->secondFactorIdentifier = '00028278';
-        $command->documentNumber         = 'NH9392';
+        $command->documentNumber         = 'ABC-12';
         $command->identityVerified       = true;
 
         $authorityId                = new IdentityId($command->authorityId);
@@ -1381,7 +1381,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('sms'),
                     $authorityPhoneNo,
                     DateTime::now(),
-                    'regcode',
+                    'A1B2C3D4',
                     $authorityCommonName,
                     $authorityEmail,
                     new Locale('en_GB')
@@ -1396,7 +1396,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $authorityCommonName,
                     $authorityEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('NG-RB-81'))
+                    new OnPremiseVettingType(new DocumentNumber('ABC-12'))
                 )
             ])
             ->withAggregateId($registrantId)
@@ -1431,7 +1431,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $registrantPubId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -1449,7 +1449,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('NH9392'))
+                    new OnPremiseVettingType(new DocumentNumber('ABC-12'))
                 ),
             ]);
     }
@@ -1465,10 +1465,10 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $command->authorityId            = 'AID';
         $command->identityId             = 'IID';
         $command->secondFactorId         = 'ISFID';
-        $command->registrationCode       = 'REGCODE';
+        $command->registrationCode       = 'A1B2C3D4';
         $command->secondFactorType       = 'yubikey';
         $command->secondFactorIdentifier = '00028278';
-        $command->documentNumber         = 'NH9392';
+        $command->documentNumber         = 'ABC-12';
         $command->identityVerified       = true;
         $command->provePossessionSkipped = true;
 
@@ -1547,7 +1547,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $registrantSecFacIdentifier,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -1565,7 +1565,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('NH9392'))
+                    new OnPremiseVettingType(new DocumentNumber('ABC-12'))
                 ),
             ]);
     }
@@ -1583,10 +1583,10 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
         $command->authorityId            = 'AID';
         $command->identityId             = 'IID';
         $command->secondFactorId         = 'ISFID';
-        $command->registrationCode       = 'REGCODE';
+        $command->registrationCode       = 'A1B2C3D4';
         $command->secondFactorType       = 'yubikey';
         $command->secondFactorIdentifier = '00028278';
-        $command->documentNumber         = 'NH9392';
+        $command->documentNumber         = 'ABC-12';
         $command->identityVerified       = true;
         $command->provePossessionSkipped = true;
 
@@ -1646,7 +1646,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('sms'),
                     $authorityPhoneNo,
                     DateTime::now(),
-                    'regcode',
+                    'A1B2C3D4',
                     $authorityCommonName,
                     $authorityEmail,
                     new Locale('en_GB')
@@ -1661,7 +1661,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     $authorityCommonName,
                     $authorityEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('NG-RB-81'))
+                    new OnPremiseVettingType(new DocumentNumber('ABC-12'))
                 )
             ])
             ->withAggregateId($registrantId)
@@ -1696,7 +1696,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $registrantPubId,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -1860,7 +1860,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
     {
         $command = new SelfVetSecondFactorCommand();
         $command->secondFactorId = '+31 (0) 612345678';
-        $command->registrationCode = 'REGCODE';
+        $command->registrationCode = 'A1B2C3D4';
         $command->identityId = $this->uuid();
         $command->authoringSecondFactorLoa = "loa-3";
         $command->secondFactorType = 'sms';
@@ -1954,7 +1954,7 @@ class IdentityCommandHandlerTest extends CommandHandlerTest
                     new SecondFactorType('sms'),
                     $authorityPhoneNo,
                     DateTime::now(),
-                    'REGCODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/Identity/CommandHandler/SecondFactorRevocationTest.php
@@ -208,7 +208,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     new SecondFactorType('yubikey'),
                     $secondFactorIdentifier,
                     DateTime::now(),
-                    'SOMEREGISTRATIONCODE',
+                    'A1B2C3D4',
                     $commonName,
                     $email,
                     new Locale('en_GB')
@@ -278,7 +278,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $secondFactorType,
                     $secondFactorIdentifier,
                     DateTime::now(),
-                    'SOMEREGISTRATIONCODE',
+                    'A1B2C3D4',
                     $commonName,
                     $email,
                     new Locale('en_GB')
@@ -293,7 +293,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $commonName,
                     $email,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('DOCUMENT_42'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 )
             ])
             ->when($command)
@@ -478,7 +478,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantSecondFactorType,
                     $registrantSecondFactorIdentifier,
                     DateTime::now(),
-                    'REGISTRATION_CODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -577,7 +577,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantSecondFactorType,
                     $registrantSecondFactorIdentifier,
                     DateTime::now(),
-                    'REGISTRATION_CODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -592,7 +592,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('DOCUMENT_NUMBER'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 )
             ])
             ->when($command)
@@ -694,7 +694,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantSecondFactorType,
                     $registrantSecondFactorIdentifier,
                     DateTime::now(),
-                    'REGISTRATION_CODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -709,7 +709,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('DOCUMENT_NUMBER'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 )
             ])
             ->when($command)
@@ -816,7 +816,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantSecondFactorType,
                     $registrantSecondFactorIdentifier,
                     DateTime::now(),
-                    'REGISTRATION_CODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -831,7 +831,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('DOCUMENT_NUMBER'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 ),
                 // Second second factor
                 new U2fDevicePossessionProvenEvent(
@@ -856,7 +856,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantSecondFactorType2,
                     $registrantSecondFactorIdentifier2,
                     DateTime::now(),
-                    'REGISTRATION_CODE',
+                    'A1B2C3D4',
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB')
@@ -871,7 +871,7 @@ class SecondFactorRevocationTest extends CommandHandlerTest
                     $registrantCommonName,
                     $registrantEmail,
                     new Locale('en_GB'),
-                    new OnPremiseVettingType(new DocumentNumber('DOCUMENT_NUMBER'))
+                    new OnPremiseVettingType(new DocumentNumber('AB-123'))
                 ),
             ])
             ->when($command)

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/SensitiveData/SensitiveDataTest.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Tests/SensitiveData/SensitiveDataTest.php
@@ -87,8 +87,8 @@ class SensitiveDataTest extends TestCase
             ],
             'VettingType' => [
                 (new SensitiveData())
-                    ->withVettingType(new OnPremiseVettingType(new DocumentNumber("012345678"))),
-                ['VettingType' => new OnPremiseVettingType(new DocumentNumber("012345678"))],
+                    ->withVettingType(new OnPremiseVettingType(new DocumentNumber("AB-123"))),
+                ['VettingType' => new OnPremiseVettingType(new DocumentNumber("AB-123"))],
             ],
             'VettingType, forgotten' => [
                 (new SensitiveData())


### PR DESCRIPTION
This PR:

- Restricts document numbers to 6 characters, being A-Z, 0-9 or a hyphen
- Restricts activation codes to 8 characters, being A-Z or 0-9
- Replaces test-values with 'real-life' values instead of 'dumb' dummy-values like 'REGCODE'

Debatable:

- The value for an 'unknown' document was a non-default character (I think it's an 'En Dash' from Extended ASCII table No. 150), but I couldn't get the regexp to match it. Since it really doesn't seem to represent anything (seems to be stored as NULL in the database), I've changed the code to accept `null` for unknown documents.

Related: https://github.com/OpenConext/Stepup-RA/pull/310