### PR TITLE
Make mail expiration date match selfservice

### DIFF
--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/Service/RegistrationMailService.php
@@ -227,6 +227,6 @@ class RegistrationMailService
     {
         return $date->add(
             new DateInterval('P14D'),
-        )->endOfDay();
+        );
     }
 }


### PR DESCRIPTION
The expiration dates displayed in selfservice web UI and the corresponding email you receive are not the same:

![Side by side view of Selfservice UI with date 18 maart 2024, and email with same registration code with date 19 maart 2024](https://github.com/OpenConext/Stepup-Middleware/assets/3808792/c6d67370-f9b8-4b97-a229-cac2294ede7e)

This PR changes that by making the algoritms the same (without endOfDay()) so they will be consistent. Further improvement of timezone handling is thinkable but in any case the algoritms should be the same.