### PR TITLE
Allow identity restoration

### DIFF
--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -1221,11 +1221,6 @@ parameters:
 			path: ../../src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
 
 		-
-			message: "#^Property Surfnet\\\\Stepup\\\\Identity\\\\Event\\\\SafeStoreSecretRecoveryTokenPossessionPromisedEvent\\:\\:\\$secret \\(Surfnet\\\\Stepup\\\\Identity\\\\Value\\\\RecoveryTokenIdentifier\\) does not accept Surfnet\\\\Stepup\\\\Identity\\\\Value\\\\RecoveryTokenIdentifier\\|null\\.$#"
-			count: 1
-			path: ../../src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
-
-		-
 			message: "#^Method Surfnet\\\\Stepup\\\\Identity\\\\Event\\\\SecondFactorMigratedEvent\\:\\:deserialize\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../src/Surfnet/Stepup/Identity/Event/SecondFactorMigratedEvent.php
@@ -1412,7 +1407,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method count\\(\\) on Surfnet\\\\Stepup\\\\Identity\\\\Entity\\\\SecondFactorCollection\\|null\\.$#"
-			count: 2
+			count: 5
 			path: ../../src/Surfnet/Stepup/Identity/Identity.php
 
 		-
@@ -1527,7 +1522,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, Surfnet\\\\Stepup\\\\Identity\\\\Entity\\\\SecondFactorCollection\\|null given\\.$#"
-			count: 4
+			count: 1
 			path: ../../src/Surfnet/Stepup/Identity/Identity.php
 
 		-
@@ -2572,12 +2567,12 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$commonName on Surfnet\\\\StepupMiddleware\\\\ApiBundle\\\\Identity\\\\Entity\\\\Identity\\|null\\.$#"
-			count: 1
+			count: 2
 			path: ../../src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
 
 		-
 			message: "#^Cannot access property \\$email on Surfnet\\\\StepupMiddleware\\\\ApiBundle\\\\Identity\\\\Entity\\\\Identity\\|null\\.$#"
-			count: 1
+			count: 2
 			path: ../../src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
 
 		-
@@ -2587,7 +2582,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$identity of method Surfnet\\\\StepupMiddleware\\\\ApiBundle\\\\Identity\\\\Repository\\\\IdentityRepository\\:\\:save\\(\\) expects Surfnet\\\\StepupMiddleware\\\\ApiBundle\\\\Identity\\\\Entity\\\\Identity, Surfnet\\\\StepupMiddleware\\\\ApiBundle\\\\Identity\\\\Entity\\\\Identity\\|null given\\.$#"
-			count: 3
+			count: 4
 			path: ../../src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
 
 		-

--- a/src/Surfnet/Stepup/Identity/Api/Identity.php
+++ b/src/Surfnet/Stepup/Identity/Api/Identity.php
@@ -232,6 +232,11 @@ interface Identity extends AggregateRoot
      */
     public function forget(): void;
 
+    public function restore(
+        CommonName $commonName,
+        Email $email,
+    ): void;
+
     /**
      * @return IdentityId
      */

--- a/src/Surfnet/Stepup/Identity/Event/IdentityRestoredEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/IdentityRestoredEvent.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Stepup\Identity\Event;
+
+use Surfnet\Stepup\Identity\AuditLog\Metadata;
+use Surfnet\Stepup\Identity\Value\CommonName;
+use Surfnet\Stepup\Identity\Value\Email;
+use Surfnet\Stepup\Identity\Value\IdentityId;
+use Surfnet\Stepup\Identity\Value\Institution;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\Forgettable;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\RightToObtainDataInterface;
+use Surfnet\StepupMiddleware\CommandHandlingBundle\SensitiveData\SensitiveData;
+
+class IdentityRestoredEvent extends IdentityEvent implements Forgettable, RightToObtainDataInterface
+{
+
+    /**
+     * @var string[]
+     */
+    private array $allowlist = [
+        'id',
+        'common_name',
+        'email',
+        'institution',
+    ];
+
+    public function __construct(
+        private readonly IdentityId $id,
+        private readonly Institution $institution,
+        public CommonName $commonName,
+        public Email $email,
+    ) {
+        parent::__construct($id, $institution);
+    }
+
+    public function getAuditLogMetadata(): Metadata
+    {
+        $metadata = new Metadata();
+        $metadata->identityId = $this->id;
+        $metadata->identityInstitution = $this->institution;
+
+        return $metadata;
+    }
+
+    /**
+     * @param array<string,string> $data
+     */
+    public static function deserialize(array $data): self
+    {
+        return new self(
+            new IdentityId($data['id']),
+            new Institution($data['institution']),
+            new CommonName($data['common_name']),
+            new Email($data['email']),
+        );
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function serialize(): array
+    {
+        return [
+            'id' => (string)$this->id,
+            'institution' => (string)$this->institution,
+            'common_name' => (string)$this->commonName,
+            'email' => (string)$this->email,
+        ];
+    }
+
+    public function getSensitiveData(): SensitiveData
+    {
+        return (new SensitiveData)
+            ->withCommonName($this->commonName)
+            ->withEmail($this->email);
+    }
+
+    public function setSensitiveData(SensitiveData $sensitiveData): void
+    {
+        $this->commonName = $sensitiveData->getCommonName();
+        $this->email = $sensitiveData->getEmail();
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function obtainUserData(): array
+    {
+        $serializedPublicUserData = $this->serialize();
+        $serializedSensitiveUserData = $this->getSensitiveData()->serialize();
+        return array_merge($serializedPublicUserData, $serializedSensitiveUserData);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowlist(): array
+    {
+        return $this->allowlist;
+    }
+}

--- a/src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
+++ b/src/Surfnet/Stepup/Identity/Event/SafeStoreSecretRecoveryTokenPossessionPromisedEvent.php
@@ -116,9 +116,14 @@ class SafeStoreSecretRecoveryTokenPossessionPromisedEvent extends IdentityEvent 
 
     public function setSensitiveData(SensitiveData $sensitiveData): void
     {
+        $secret = $sensitiveData->getRecoveryTokenIdentifier();
+        if ($secret === null) {
+            $secret = SafeStore::unknown();
+        }
+
         $this->email = $sensitiveData->getEmail();
         $this->commonName = $sensitiveData->getCommonName();
-        $this->secret = $sensitiveData->getRecoveryTokenIdentifier();
+        $this->secret = $secret;
     }
 
     public function obtainUserData(): array

--- a/src/Surfnet/Stepup/Identity/Value/SafeStore.php
+++ b/src/Surfnet/Stepup/Identity/Value/SafeStore.php
@@ -18,14 +18,20 @@
 
 namespace Surfnet\Stepup\Identity\Value;
 
+use Surfnet\Stepup\Exception\DomainException;
+use Surfnet\Stepup\Exception\RuntimeException;
+
 /**
  * Recovery token identifier for the SafeStore token type
  */
 class SafeStore implements RecoveryTokenIdentifier
 {
+    private ?Secret $secret = null;
+
     public function __construct(
-        private readonly Secret $secret,
+        Secret $secret,
     ) {
+        $this->secret = $secret;
     }
 
     public static function unknown(): self
@@ -40,6 +46,9 @@ class SafeStore implements RecoveryTokenIdentifier
 
     public function getValue(): string
     {
+        if ($this->secret === null) {
+            throw new RuntimeException("Secret should be set");
+        }
         return $this->secret->getSecret();
     }
 

--- a/src/Surfnet/Stepup/Tests/Identity/Event/EventSerializationAndDeserializationTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Event/EventSerializationAndDeserializationTest.php
@@ -40,6 +40,7 @@ use Surfnet\Stepup\Identity\Event\IdentityAccreditedAsRaForInstitutionEvent;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityRenamedEvent;
+use Surfnet\Stepup\Identity\Event\IdentityRestoredEvent;
 use Surfnet\Stepup\Identity\Event\LocalePreferenceExpressedEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\RegistrationAuthorityInformationAmendedEvent;
@@ -291,6 +292,14 @@ class EventSerializationAndDeserializationTest extends UnitTest
                     new CommonName('Henk Westbroek'),
                     new Email('info@example.invalid'),
                     new Locale('en_GB'),
+                ),
+            ],
+            'IdentityRestoredEvent' => [
+                new IdentityRestoredEvent(
+                    new IdentityId($this->UUID()),
+                    new Institution('BabelFish Inc'),
+                    new CommonName('Henk Westbroek'),
+                    new Email('info@example.invalid'),
                 ),
             ],
             'IdentityEmailChangedEvent' => [

--- a/src/Surfnet/Stepup/Tests/Identity/Event/ForgettableEventsTest.php
+++ b/src/Surfnet/Stepup/Tests/Identity/Event/ForgettableEventsTest.php
@@ -32,6 +32,7 @@ use Surfnet\Stepup\Identity\Event\GssfPossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityRenamedEvent;
+use Surfnet\Stepup\Identity\Event\IdentityRestoredEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenAndVerifiedEvent;
 use Surfnet\Stepup\Identity\Event\PhonePossessionProvenEvent;
 use Surfnet\Stepup\Identity\Event\PhoneRecoveryTokenPossessionProvenEvent;
@@ -93,6 +94,7 @@ final class ForgettableEventsTest extends TestCase
             YubikeyPossessionProvenAndVerifiedEvent::class,
             YubikeySecondFactorBootstrappedEvent::class,
             RegistrationAuthorityRetractedForInstitutionEvent::class,
+            IdentityRestoredEvent::class,
         ];
         $otherIdentityEventFqcns = array_diff($this->getConcreteIdentityEventFqcns(), $forgettableEventFqcns);
         $forgettableFqcn = Forgettable::class;

--- a/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
+++ b/src/Surfnet/StepupMiddleware/ApiBundle/Identity/Projector/IdentityProjector.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupMiddleware\ApiBundle\Identity\Projector;
 
+use Surfnet\Stepup\Identity\Event\IdentityRestoredEvent;
 use Surfnet\Stepup\Projector\Projector;
 use Surfnet\Stepup\Identity\Event\IdentityCreatedEvent;
 use Surfnet\Stepup\Identity\Event\IdentityEmailChangedEvent;
@@ -74,6 +75,16 @@ class IdentityProjector extends Projector
 
         $this->identityRepository->save($identity);
     }
+
+    public function applyIdentityRestoredEvent(IdentityRestoredEvent $event): void
+    {
+        $identity = $this->identityRepository->find((string)$event->identityId);
+        $identity->email = $event->email;
+        $identity->commonName = $event->commonName;
+
+        $this->identityRepository->save($identity);
+    }
+
 
     public function applySecondFactorVettedEvent(SecondFactorVettedEvent $event): void
     {

--- a/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
+++ b/src/Surfnet/StepupMiddleware/CommandHandlingBundle/Identity/CommandHandler/IdentityCommandHandler.php
@@ -122,6 +122,7 @@ class IdentityCommandHandler extends SimpleCommandHandler
         /** @var IdentityApi $identity */
         $identity = $this->eventSourcedRepository->load(new IdentityId($command->id));
 
+        $identity->restore(new CommonName($command->commonName), new Email($command->email));
         $identity->rename(new CommonName($command->commonName));
         $identity->changeEmail(new Email($command->email));
 


### PR DESCRIPTION
Earlier on it was not possible to restore identities after
they were forgotten. Now logic is added to restore and reset
the identity email, name and tokens in the identity aggregate
so the identity is reset.

https://github.com/OpenConext/Stepup-Middleware/issues/525